### PR TITLE
fix: surface a failed K-shift instead of decoding over stale K

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -785,6 +785,8 @@ llama_context::memory_update_status llama_context::memory_update(bool optimize) 
         return memory_update_status::no_update;
     }
 
+    memory_update_result = GGML_STATUS_SUCCESS;
+
     {
         const auto mctx = memory->init_update(this, optimize);
         switch (mctx->get_status()) {
@@ -813,10 +815,18 @@ llama_context::memory_update_status llama_context::memory_update(bool optimize) 
         if (!mctx->apply()) {
             LLAMA_LOG_ERROR("%s: failed to apply memory update\n", __func__);
 
-            // A failed K-shift leaves the cells carrying shifted positions that
-            // K was never rotated to match. Report it rather than reserving a
-            // graph and letting the caller decode against a cache it cannot
-            // trust.
+            // the update did not complete, so the memory cannot be trusted for
+            // decode - report it rather than reserving a graph and letting the
+            // caller carry on
+            //
+            // the memory module reset the scheduler to build its own graph, and
+            // the reserve below that would have restored the worst-case
+            // reservation is now skipped, so drain whatever it dispatched before
+            // failing and ask for a fresh reserve on the next call
+            ggml_backend_sched_synchronize(sched.get());
+
+            sched_need_reserve = true;
+
             return memory_update_status::failed;
         }
     }
@@ -840,6 +850,24 @@ llama_context::memory_update_status llama_context::memory_update(bool optimize) 
     }
 
     return memory_update_status::updated;
+}
+
+void llama_context::set_memory_update_result(ggml_status status) {
+    memory_update_result = status;
+}
+
+int llama_context::memory_update_ret() const {
+    // mirror the mapping decode() uses for the ubatch compute status, so the
+    // caller sees the same code for the same failure wherever it happened. an
+    // abort in particular is not a fatal error
+    switch (memory_update_result) {
+        case GGML_STATUS_ABORTED:      return  2;
+        case GGML_STATUS_FAILED:       return -3;
+        case GGML_STATUS_ALLOC_FAILED: return -2;
+        case GGML_STATUS_SUCCESS:      break; // failed before computing a graph
+    }
+
+    return -2;
 }
 
 enum llama_pooling_type llama_context::pooling_type() const {
@@ -1801,9 +1829,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
     // handle any pending shifts/copies
     if (memory_update(false) == memory_update_status::failed) {
-        LLAMA_LOG_ERROR("%s: failed to apply pending memory updates\n", __func__);
-
-        return -2;
+        return memory_update_ret();
     }
 
     llama_memory_context_ptr mctx;
@@ -1829,7 +1855,15 @@ int llama_context::decode(const llama_batch & batch_inp) {
                     if (!did_optimize) {
                         did_optimize = true;
 
-                        if (memory_update(true) == memory_update_status::updated) {
+                        const auto status = memory_update(true);
+
+                        // a failed update means the memory cannot be trusted, so
+                        // it must not be reported as the retryable "no slot"
+                        if (status == memory_update_status::failed) {
+                            return memory_update_ret();
+                        }
+
+                        if (status == memory_update_status::updated) {
                             LLAMA_LOG_DEBUG("%s: retrying batch size %d after cache optimization\n", __func__, balloc->get_n_tokens());
 
                             continue;

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -822,7 +822,11 @@ llama_context::memory_update_status llama_context::memory_update(bool optimize) 
             // the memory module reset the scheduler to build its own graph, and
             // the reserve below that would have restored the worst-case
             // reservation is now skipped, so drain whatever it dispatched before
-            // failing and ask for a fresh reserve on the next call
+            // failing and leave the rebuild to the next call
+            //
+            // sched_need_reserve makes sched_reserve() build a whole new scheduler
+            // rather than only re-reserve, which is what an allocation failure wants:
+            // the current one is freed before the next attempt asks for memory
             ggml_backend_sched_synchronize(sched.get());
 
             sched_need_reserve = true;
@@ -853,7 +857,23 @@ llama_context::memory_update_status llama_context::memory_update(bool optimize) 
 }
 
 void llama_context::set_memory_update_result(ggml_status status) {
-    memory_update_result = status;
+    // an iswa or hybrid apply() runs every sub-context even after one of them has
+    // failed, so more than one can report here. keep the most severe: an abort is the
+    // caller cancelling and must never mask a real failure from another sub-context
+    const auto severity = [](ggml_status s) {
+        switch (s) {
+            case GGML_STATUS_SUCCESS:      return 0;
+            case GGML_STATUS_ABORTED:      return 1;
+            case GGML_STATUS_ALLOC_FAILED: return 2;
+            case GGML_STATUS_FAILED:       return 3;
+        }
+
+        return 3;
+    };
+
+    if (severity(status) > severity(memory_update_result)) {
+        memory_update_result = status;
+    }
 }
 
 int llama_context::memory_update_ret() const {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -780,9 +780,9 @@ llama_memory_t llama_context::get_memory() const {
     return memory.get();
 }
 
-bool llama_context::memory_update(bool optimize) {
+llama_context::memory_update_status llama_context::memory_update(bool optimize) {
     if (!memory) {
-        return false;
+        return memory_update_status::no_update;
     }
 
     {
@@ -795,13 +795,13 @@ bool llama_context::memory_update(bool optimize) {
             case LLAMA_MEMORY_STATUS_NO_UPDATE:
                 {
                     // no updates need to be performed
-                    return false;
+                    return memory_update_status::no_update;
                 }
             case LLAMA_MEMORY_STATUS_FAILED_PREPARE:
             case LLAMA_MEMORY_STATUS_FAILED_COMPUTE:
                 {
                     LLAMA_LOG_ERROR("%s: failed to prepare memory update\n", __func__);
-                    return false;
+                    return memory_update_status::failed;
                 }
         }
 
@@ -812,6 +812,12 @@ bool llama_context::memory_update(bool optimize) {
 
         if (!mctx->apply()) {
             LLAMA_LOG_ERROR("%s: failed to apply memory update\n", __func__);
+
+            // A failed K-shift leaves the cells carrying shifted positions that
+            // K was never rotated to match. Report it rather than reserving a
+            // graph and letting the caller decode against a cache it cannot
+            // trust.
+            return memory_update_status::failed;
         }
     }
 
@@ -833,7 +839,7 @@ bool llama_context::memory_update(bool optimize) {
         }
     }
 
-    return true;
+    return memory_update_status::updated;
 }
 
 enum llama_pooling_type llama_context::pooling_type() const {
@@ -1794,7 +1800,11 @@ int llama_context::decode(const llama_batch & batch_inp) {
     bool did_optimize = false;
 
     // handle any pending shifts/copies
-    memory_update(false);
+    if (memory_update(false) == memory_update_status::failed) {
+        LLAMA_LOG_ERROR("%s: failed to apply pending memory updates\n", __func__);
+
+        return -2;
+    }
 
     llama_memory_context_ptr mctx;
 
@@ -1819,7 +1829,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
                     if (!did_optimize) {
                         did_optimize = true;
 
-                        if (memory_update(true)) {
+                        if (memory_update(true) == memory_update_status::updated) {
                             LLAMA_LOG_DEBUG("%s: retrying batch size %d after cache optimization\n", __func__, balloc->get_n_tokens());
 
                             continue;

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1836,11 +1836,6 @@ int llama_context::decode(const llama_batch & batch_inp) {
     }
     embd_seq.clear();
 
-    if (t_compute_start_us == 0) {
-        t_compute_start_us = ggml_time_us();
-    }
-    n_queued_tokens += n_tokens_all;
-
     output_swaps.clear();
 
     sched_reserve();
@@ -1851,6 +1846,14 @@ int llama_context::decode(const llama_batch & batch_inp) {
     if (memory_update(false) == memory_update_status::failed) {
         return memory_update_ret();
     }
+
+    // count the batch only once it is going to be evaluated: the memory update above
+    // can fail and return, and synchronize() attributes everything queued to the next
+    // decode that completes
+    if (t_compute_start_us == 0) {
+        t_compute_start_us = ggml_time_us();
+    }
+    n_queued_tokens += n_tokens_all;
 
     llama_memory_context_ptr mctx;
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -74,7 +74,6 @@ struct llama_context {
 
     llama_memory_t get_memory() const;
 
-    // return true if the memory was updated
     // Result of applying pending memory updates. A bool cannot express this:
     // "nothing was pending" and "the update failed" are both not-updated, but
     // only one of them means the caller must stop.
@@ -85,6 +84,12 @@ struct llama_context {
     };
 
     memory_update_status memory_update(bool optimize);
+
+    // The memory module computes through llama_memory_context_i::apply(), which
+    // returns bool, so a failed update's ggml_status would be lost on the way
+    // out. The module records it here instead, and memory_update_ret() maps it
+    // onto the same llama_decode codes the ubatch compute path uses.
+    void set_memory_update_result(ggml_status status);
 
     enum llama_pooling_type pooling_type() const;
 
@@ -246,6 +251,13 @@ struct llama_context {
 
 private:
     //
+    // memory
+    //
+
+    // llama_decode return code for a memory update that reported failed
+    int memory_update_ret() const;
+
+    //
     // output
     //
 
@@ -372,6 +384,9 @@ private:
     ggml_backend_sched_ptr sched;
 
     bool sched_need_reserve = true;
+
+    // ggml_status of the last memory update, see set_memory_update_result()
+    ggml_status memory_update_result = GGML_STATUS_SUCCESS;
 
     ggml_backend_t backend_cpu = nullptr;
     std::vector<ggml_backend_ptr> backends;

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -75,7 +75,16 @@ struct llama_context {
     llama_memory_t get_memory() const;
 
     // return true if the memory was updated
-    bool memory_update(bool optimize);
+    // Result of applying pending memory updates. A bool cannot express this:
+    // "nothing was pending" and "the update failed" are both not-updated, but
+    // only one of them means the caller must stop.
+    enum class memory_update_status {
+        no_update, // nothing was pending
+        updated,   // pending work was applied successfully
+        failed,    // an update was attempted and did not complete
+    };
+
+    memory_update_status memory_update(bool optimize);
 
     enum llama_pooling_type pooling_type() const;
 

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -996,17 +996,24 @@ bool llama_kv_cache::update(llama_context * lctx, bool do_shift, const stream_co
             auto * gf = build_graph_shift(res, lctx);
             if (!ggml_backend_sched_alloc_graph(sched, gf)) {
                 LLAMA_LOG_ERROR("%s: failed to allocate compute graph for K-shift\n", __func__);
-                // The cells already carry their shifted positions but K was never
-                // rotated to match, so the cache is inconsistent. has_shift stays
-                // set because the shift is still owed; report the failure so the
-                // caller stops rather than attending over stale K.
+
+                // has_shift stays set, the shift is still owed
+                lctx->set_memory_update_result(GGML_STATUS_ALLOC_FAILED);
+
                 return false;
             }
 
             res->set_inputs(nullptr);
 
-            if (lctx->graph_compute(gf, false) != GGML_STATUS_SUCCESS) {
+            const auto status = lctx->graph_compute(gf, false);
+            if (status != GGML_STATUS_SUCCESS) {
                 LLAMA_LOG_ERROR("%s: failed to compute K-shift\n", __func__);
+
+                // keep the status rather than flattening it: stopping is right
+                // either way since K is left half-rotated, but an abort is the
+                // caller cancelling and must not reach it as a fatal error
+                lctx->set_memory_update_result(status);
+
                 return false;
             }
         }

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -513,6 +513,13 @@ bool llama_kv_cache::seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos p1) {
         if (new_head != cells.size() && new_head < head) {
             head = new_head;
         }
+
+        // An empty stream owes no shift. Without this, a K-shift that failed
+        // leaves has_shift set with no way for a caller to clear it short of
+        // llama_memory_clear(), so every later decode retries the same shift.
+        if (cells.get_used() == 0) {
+            cells.reset_shift();
+        }
     } else {
         // match any sequence
         for (uint32_t s = 0; s < n_stream; ++s) {
@@ -536,6 +543,11 @@ bool llama_kv_cache::seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos p1) {
             // If we freed up a slot, set head to it so searching can start there.
             if (new_head != cells.size() && new_head < head) {
                 head = new_head;
+            }
+
+            // see the note on the seq_id >= 0 branch above
+            if (cells.get_used() == 0) {
+                cells.reset_shift();
             }
         }
     }

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -934,8 +934,6 @@ bool llama_kv_cache::update(llama_context * lctx, bool do_shift, const stream_co
         return true;
     }
 
-    bool updated = false;
-
     auto * sched = lctx->get_sched();
 
     if (!sc_info.empty()) {
@@ -986,17 +984,19 @@ bool llama_kv_cache::update(llama_context * lctx, bool do_shift, const stream_co
             auto * gf = build_graph_shift(res, lctx);
             if (!ggml_backend_sched_alloc_graph(sched, gf)) {
                 LLAMA_LOG_ERROR("%s: failed to allocate compute graph for K-shift\n", __func__);
-                return updated;
+                // The cells already carry their shifted positions but K was never
+                // rotated to match, so the cache is inconsistent. has_shift stays
+                // set because the shift is still owed; report the failure so the
+                // caller stops rather than attending over stale K.
+                return false;
             }
 
             res->set_inputs(nullptr);
 
             if (lctx->graph_compute(gf, false) != GGML_STATUS_SUCCESS) {
                 LLAMA_LOG_ERROR("%s: failed to compute K-shift\n", __func__);
-                return updated;
+                return false;
             }
-
-            updated = true;
         }
 
         for (uint32_t s = 0; s < n_stream; ++s) {
@@ -1006,7 +1006,7 @@ bool llama_kv_cache::update(llama_context * lctx, bool do_shift, const stream_co
         }
     }
 
-    return updated;
+    return true;
 }
 
 llama_kv_cache::slot_info llama_kv_cache::find_slot(const llama_ubatch & ubatch, bool cont) const {
@@ -2750,9 +2750,7 @@ bool llama_kv_cache_context::apply() {
 
     // no ubatches -> this is a KV cache update
     if (ubatches.empty()) {
-        kv->update(lctx, do_shift, sc_info);
-
-        return true;
+        return kv->update(lctx, do_shift, sc_info);
     }
 
     kv->apply_ubatch(sinfos[i_cur], ubatches[i_cur]);

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -196,6 +196,10 @@ public:
     // return empty vector on failure
     slot_info_vec_t prepare(const std::vector<llama_ubatch> & ubatches);
 
+    // Applies pending shifts and stream copies. Returns whether the update
+    // SUCCEEDED, not whether it did any work: a no-op update is a success.
+    // A failed K-shift leaves the cells carrying shifted positions that K was
+    // never rotated to match, so the caller must not keep decoding.
     bool update(llama_context * lctx, bool do_shift, const stream_copy_info & sc_info);
 
     // find a slot of kv cells that can hold the ubatch

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -199,7 +199,13 @@ public:
     // Applies pending shifts and stream copies. Returns whether the update
     // SUCCEEDED, not whether it did any work: a no-op update is a success.
     // A failed K-shift leaves the cells carrying shifted positions that K was
-    // never rotated to match, so the caller must not keep decoding.
+    // never rotated to match, so the caller must not keep decoding. has_shift
+    // stays set on that path because the shift is still owed; a caller that
+    // empties the stream via seq_rm clears it.
+    //
+    // NOTE: the meaning diverges from upstream, which returns whether any work
+    // was done. The signature is unchanged, so a rebase that restores upstream's
+    // body will compile and silently revert this. See tetherto PR #213.
     bool update(llama_context * lctx, bool do_shift, const stream_copy_info & sc_info);
 
     // find a slot of kv cells that can hold the ubatch

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1466,7 +1466,17 @@ private:
             process_single_task(std::move(task));
         });
         queue_tasks.on_update_slots([this]() {
-            update_slots();
+            try {
+                update_slots();
+            } catch (const std::exception & e) {
+                // update_slots() throws to abandon a batch it cannot finish. some throw
+                // sites release the affected slots first and some do not, and a slot left
+                // in processing state is picked up again on the next wake-up and throws
+                // again, so the request would hang forever. make sure none survive
+                SRV_ERR("update slots failed: %s\n", e.what());
+
+                release_processing_slots(std::string("Internal server error: ") + e.what());
+            }
         });
         queue_tasks.on_sleeping_state([this](bool sleeping) {
             handle_sleeping_state(sleeping);
@@ -3634,6 +3644,22 @@ private:
         }
     }
 
+    // fail every slot that is still mid-batch and put it back in the pool. the batch is
+    // being abandoned and there is no way to tell how much of it was consumed, so the
+    // whole context goes with it
+    void release_processing_slots(const std::string & err) {
+        for (auto & slot : slots) {
+            if (slot.is_processing()) {
+                send_error(slot, err);
+                slot.release();
+
+                // note: it's complicated to keep track of how much of the current batch has been
+                //       processed before the error occurred, so we simply clear the entire context
+                slot.prompt_clear();
+            }
+        }
+    }
+
     // returns true = success ; false = retry with smaller batch size
     // throw std::runtime_error on fatal error
     bool decode(int32_t & n_batch, int32_t off, llama_batch & batch_view) {
@@ -3693,16 +3719,7 @@ private:
                 if (!err.empty()) {
                     SRV_ERR("%s off = %d, n_batch = %d, ret = %d\n", err.c_str(), off, n_batch, ret);
 
-                    for (auto & slot : slots) {
-                        if (slot.is_processing()) {
-                            send_error(slot, err);
-                            slot.release();
-
-                            // note: it's complicated to keep track of how much of the current batch has been
-                            //       processed before the error occurred, so we simply clear the entire context
-                            slot.prompt_clear();
-                        }
-                    }
+                    release_processing_slots(err);
 
                     // stop, do not retry with smaller batch size
                     throw std::runtime_error(err);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3683,7 +3683,12 @@ private:
                     err = "Compute error.";
                 }
 
-                // TODO: handle ret == 2 (abort) when we start aborting
+                if (ret == 2) {
+                    // aborted through the abort callback. a smaller batch cannot help, and
+                    // when the abort hit a pending K-shift the shift is still owed, so the
+                    // retry aborts again and halves n_batch until it reaches zero
+                    err = "Operation aborted.";
+                }
 
                 if (!err.empty()) {
                     SRV_ERR("%s off = %d, n_batch = %d, ret = %d\n", err.c_str(), off, n_batch, ret);

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -4,6 +4,7 @@
 #include "log.h"
 
 #include <chrono>
+#include <exception>
 
 #define QUE_INF(fmt, ...) LOG_INF("que  %12.*s: " fmt, 12, __func__, __VA_ARGS__)
 #define QUE_WRN(fmt, ...) LOG_WRN("que  %12.*s: " fmt, 12, __func__, __VA_ARGS__)
@@ -160,7 +161,15 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
         QUE_DBG("%s", "update slots\n");
 
         // this will run the main inference process for all slots
-        callback_update_slots();
+        // update_slots() throws to abandon a batch it cannot finish, for example a
+        // decode that failed on a memory update. it has already errored and released
+        // the affected slots by then, so keep serving instead of taking the process
+        // down with the batch
+        try {
+            callback_update_slots();
+        } catch (const std::exception & e) {
+            QUE_ERR("update slots failed: %s\n", e.what());
+        }
         {
             // update_slots() may take a while to finish, we need to make sure it's not counted as idle
             std::unique_lock<std::mutex> lock(mutex_tasks);

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -161,10 +161,11 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
         QUE_DBG("%s", "update slots\n");
 
         // this will run the main inference process for all slots
-        // update_slots() throws to abandon a batch it cannot finish, for example a
-        // decode that failed on a memory update. it has already errored and released
-        // the affected slots by then, so keep serving instead of taking the process
-        // down with the batch
+        //
+        // update_slots() throws to abandon a batch it cannot finish, for example a decode
+        // that failed on a memory update. the callback releases the affected slots itself
+        // and this is only the backstop that keeps the process up if that teardown throws
+        // too, since start_loop() runs outside any try and the exception would reach main
         try {
             callback_update_slots();
         } catch (const std::exception & e) {


### PR DESCRIPTION
## What this fixes

When the K-shift graph fails to allocate or compute, `llama_decode` still returns 0 and the decode carries on. By that point the cells already hold their shifted positions but K was never rotated to match, so attention runs against stale K. The result is wrong and nothing reports it.

Two layers were swallowing the failure, and both had the same shape: a `bool` that could not distinguish "nothing to do" from "it failed". A third `bool` then flattened the failure itself, so the caller could not tell an abort from a real error.

## Layer 1: `apply()` discarded the result

```cpp
if (ubatches.empty()) {
    kv->update(lctx, do_shift, sc_info);

    return true;
}
```

`llama_kv_cache::update()` could not simply be forwarded, because it reported whether it had done any *work*, not whether it *succeeded*. `updated` starts false and is only set once a shift actually runs, so a no-op update returned false. It now reports success instead. Nothing consumed the old meaning: `update()` is declared on `llama_kv_cache` rather than the `llama_memory_i` interface, and `apply()` is its only caller.

## Layer 2: `memory_update()` logged it and returned true

```cpp
if (!mctx->apply()) {
    LLAMA_LOG_ERROR("%s: failed to apply memory update\n", __func__);
}
```

and `llama_context::decode` calls it for exactly this purpose, discarding the return:

```cpp
// handle any pending shifts/copies
memory_update(false);
```

`memory_update`'s `bool` had the same problem one level up: `LLAMA_MEMORY_STATUS_NO_UPDATE` returns false, so forwarding it would have failed every decode that had nothing pending. It now returns a three-state result:

```cpp
enum class memory_update_status { no_update, updated, failed };
```

`decode()` stops on `failed`, and so does the cache-optimization retry, which used to fall through to `return 1` and tell the caller to try a smaller batch.

Returning early there also skips the worst-case graph reserve below it. That reserve was what restored the reservation after the memory module reset the scheduler to build its own graph, and it was the only synchronize on the path, since `graph_compute` dispatches async and `ggml_backend_sched_reset` does not drain. The failure path drains and asks for a fresh reserve on the next call instead.

## Layer 3: the status was flattened into one return code

A `false` out of the K-shift said nothing about what went wrong. `graph_compute() != GGML_STATUS_SUCCESS` is true for `ALLOC_FAILED`, `FAILED` and `ABORTED` alike, so all three reached the caller as one `-2`. `decode()` does not flatten them for its own ubatch compute:

```cpp
case GGML_STATUS_ABORTED:      return  2;
case GGML_STATUS_ALLOC_FAILED: return -2;
case GGML_STATUS_FAILED:       return -3;
```

The abort callback is installed on every backend from the constructor and nothing suspends it for the shift, so a caller cancelling mid-shift got a fatal `-2` instead of the non-fatal `2`. Stopping is right either way, since K is left half-rotated, but the caller has to be able to tell the two apart. `llama_memory_context_i::apply()` returns `bool` and cannot carry the status out, so `llama_context` records it on the way through and maps it in one place.

## Deliberate non-change

`has_shift` is left set on the failure path. The shift is still owed, and clearing it would silently discard a pending correction rather than let the caller decide. A caller that ignores the decode error will retry the same failing shift, which is preferable to it silently attending over stale K.

There was no way out of it, though. `seq_rm` resets each cell's own shift but never the cells-level flag, and retrying does not converge because the shift graph is sized off the cache capacity rather than its occupancy, so `llama_memory_clear` was the only escape and llama-server never calls it. An empty stream owes no shift, so `seq_rm` clears the flag there.

## Context

Found while removing context shifting from reasoning-block compaction in the llm-addon, tetherto/qvac#3938. That change removes the addon's only path into this code, so the addon no longer depends on this fix. It is still reachable by any other caller that shifts, including `tools/completion` (both the context-shift loop and the self-extend path), `examples/passkey`, and anything else calling `llama_memory_seq_add`.

## The server side

Two changes are outside `src`, both pre-existing and both made easier to hit by this one.

`update_slots()` throws on `ret < -1` and nothing catches it, so llama-server goes down with the batch. The other `-2` returns in `decode()` already reach it. It is caught in the callback now, where the slots are, because not every throw site releases them first: `common_speculative_process` failing, the unsupported `has_embd` + spec case and an out-of-range speculative batch index all throw mid-batch. A slot left processing is picked up on the next wake-up and throws again, so the request would hang rather than error. The queue loop keeps its own catch as the backstop for a teardown that throws too, since `start_loop` runs outside any try.

`decode()` left `err` empty for `ret == 2`, so an abort fell through to the "no free space in the KV cache" path and halved `n_batch`. Retrying cannot help: the abort came from outside, and when it hit a pending K-shift the shift is still owed, so the retry aborts in the same place while `n_batch` walks down to zero. It stops like the other fatal returns now.

## Testing

Full build clean with server on, ctest 67/68 locally on `temp-10297`. The one failure is `test-jinja-py`, missing jinja2 in my env. The failure paths are allocation and compute failures inside the K-shift graph, which the test suite cannot synthesize without a memory-constrained backend, so the propagation itself is reviewed by inspection of the call sites above.


