### PR TITLE
QVAC-24112 fit: budget against real memory availability

### DIFF
--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -175,6 +175,45 @@ common_device_memory_data_vec common_get_device_memory_data(
     return ret;
 }
 
+int64_t common_fit_shared_pool_deficit(
+        const std::vector<int64_t> & dev_projected,
+        const std::vector<bool>    & shares_host,
+                           int64_t   host_free,
+                           int64_t   host_projected_resident,
+                           int64_t   host_margin) {
+    GGML_ASSERT(dev_projected.size() == shares_host.size());
+    int64_t shared_projected = 0;
+    for (size_t id = 0; id < dev_projected.size(); id++) {
+        if (shares_host[id]) {
+            shared_projected += dev_projected[id];
+        }
+    }
+    const int64_t host_free_after = host_free - host_projected_resident - shared_projected;
+    return host_free_after < host_margin ? host_margin - host_free_after : 0;
+}
+
+uint32_t common_fit_reduced_n_ctx(
+        int64_t  sum_used_target,
+        int64_t  sum_projected_used,
+        int64_t  sum_projected_used_min_ctx,
+        uint32_t hp_nct,
+        uint32_t n_ctx_min) {
+    // A context-independent memory profile (e.g. n_gpu_layers == 0 keeps the
+    // whole KV cache host-side, so the device rows do not vary with context)
+    // makes this delta exactly 0; an unguarded division faults on x86-64 and
+    // silently returns 0 on AArch64.
+    const int64_t used_delta = sum_projected_used - sum_projected_used_min_ctx;
+    if (sum_used_target <= sum_projected_used_min_ctx || used_delta <= 0) {
+        return 0;
+    }
+    uint32_t n_ctx = n_ctx_min + (hp_nct - n_ctx_min) * (sum_used_target - sum_projected_used_min_ctx) / used_delta;
+    // No correct input yields a context above the training context, but the
+    // interpolation can once the target exceeds the max-context sample.
+    n_ctx = std::min(n_ctx, hp_nct);
+    n_ctx = std::max(n_ctx - n_ctx % 256, n_ctx_min); // round down context for CUDA backend
+    return n_ctx;
+}
+
 // Whether allocations on this device draw from the same physical pool as
 // host memory. For such devices the per-device budget alone under-counts:
 // their wired buffers, the host-assigned layers, and every other process all
@@ -220,6 +259,13 @@ static void common_params_fit_impl(
         for (size_t id = 0; id < nd; id++) {
             margins.push_back(margins_s[id]);
         }
+    }
+
+    // Single registry touchpoint: the decision arithmetic below is pure over
+    // these flags (and unit-testable without live devices, see fit.h).
+    std::vector<bool> shares_host(nd);
+    for (size_t id = 0; id < nd; id++) {
+        shares_host[id] = ggml_dev_shares_host_memory(devs[id]);
     }
 
     std::vector<std::string> dev_names;
@@ -318,19 +364,16 @@ static void common_params_fit_impl(
     int64_t host_shared_deficit = 0;
     bool    device_rows_ok      = true;
     if (nd > 0) {
-        int64_t shared_projected = 0;
+        std::vector<int64_t> dev_projected(nd);
         for (size_t id = 0; id < nd; id++) {
-            if (ggml_dev_shares_host_memory(devs[id])) {
-                shared_projected += dmds_full[id].mb.total();
-            }
+            dev_projected[id] = dmds_full[id].mb.total();
             if (projected_free_per_device[id] < margins[id]) {
                 device_rows_ok = false;
             }
         }
-        const int64_t host_projected  = host_resident(dmds_full.back());
-        const int64_t host_free_after = dmds_full.back().free - host_projected - shared_projected;
-        if (host_free_after < margins[0]) {
-            host_shared_deficit = margins[0] - host_free_after;
+        host_shared_deficit = common_fit_shared_pool_deficit(
+            dev_projected, shares_host, dmds_full.back().free, host_resident(dmds_full.back()), margins[0]);
+        if (host_shared_deficit > 0) {
             LOG_TRC("%s: host + shared-memory devices projected to overshoot available host memory by %" PRId64 " MiB\n",
                 __func__, host_shared_deficit/MiB);
         }
@@ -420,23 +463,12 @@ static void common_params_fit_impl(
                             sum_projected_used_min_ctx += dmds_min_ctx[id].mb.total();
                         }
                     }
-                    // With a host-forced descent the device rows can be
-                    // context-independent (n_gpu_layers == 0 keeps the whole
-                    // KV cache host-side), making this delta exactly 0; an
-                    // unguarded division faults on x86-64 and silently
-                    // returns 0 on AArch64.
-                    const int64_t used_delta = sum_projected_used - sum_projected_used_min_ctx;
-                    if (sum_used_target > sum_projected_used_min_ctx && used_delta > 0) {
-                        // linear interpolation between minimum and maximum context size:
-                        cparams->n_ctx += (hp_nct - n_ctx_min) * (sum_used_target - sum_projected_used_min_ctx)
-                            / used_delta;
-                        // No correct input yields a context above the training
-                        // context, but the interpolation can once the target
-                        // exceeds the max-context sample.
-                        cparams->n_ctx = std::min(cparams->n_ctx, hp_nct);
-                        cparams->n_ctx = std::max(cparams->n_ctx - cparams->n_ctx % 256, n_ctx_min); // round down context for CUDA backend
+                    const uint32_t n_ctx_reduced = common_fit_reduced_n_ctx(
+                        sum_used_target, sum_projected_used, sum_projected_used_min_ctx, hp_nct, n_ctx_min);
+                    if (n_ctx_reduced > 0) {
+                        cparams->n_ctx = n_ctx_reduced;
 
-                        const int64_t bytes_per_ctx = used_delta / (hp_nct - n_ctx_min);
+                        const int64_t bytes_per_ctx = (sum_projected_used - sum_projected_used_min_ctx) / (hp_nct - n_ctx_min);
                         const int64_t memory_reduction = ((int64_t) hp_nct - (int64_t) cparams->n_ctx) * bytes_per_ctx;
                         LOG_TRC("%s: context size reduced from %" PRIu32 " to %" PRIu32 " -> need %" PRId64 " MiB less memory in total\n",
                             __func__, hp_nct, cparams->n_ctx, memory_reduction/MiB);
@@ -671,7 +703,7 @@ static void common_params_fit_impl(
     const int64_t host_resident_full = host_resident(dmds_full.back());
     for (size_t id = 0; id < nd; id++) {
         int64_t target = dmds_full[id].free - margins[id];
-        if (ggml_dev_shares_host_memory(devs[id])) {
+        if (shares_host[id]) {
             // The device's "free" is the same physical pool the host row
             // draws from; leave room for the host's own demand and margin or
             // step 3 fills the pool and starves the host.

--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -192,6 +192,21 @@ int64_t common_fit_shared_pool_deficit(
     return host_free_after < host_margin ? host_margin - host_free_after : 0;
 }
 
+int64_t common_fit_shared_pool_target(
+                           int64_t   host_free,
+                           int64_t   host_projected_resident,
+                           int64_t   host_margin,
+                            size_t   n_shares_host) {
+    GGML_ASSERT(n_shares_host > 0);
+    const int64_t budget = host_free - host_projected_resident - host_margin;
+    // keep a negative budget whole: the descent reads it as "must reduce",
+    // and a division would only make it look less short than it is
+    if (budget <= 0) {
+        return budget;
+    }
+    return budget / (int64_t) n_shares_host;
+}
+
 uint32_t common_fit_reduced_n_ctx(
         int64_t  sum_used_target,
         int64_t  sum_projected_used,
@@ -701,13 +716,19 @@ static void common_params_fit_impl(
     // resident host demand (context/compute shifts remain a known
     // imprecision).
     const int64_t host_resident_full = host_resident(dmds_full.back());
+    size_t n_shares_host = 0;
+    for (size_t id = 0; id < nd; id++) {
+        n_shares_host += shares_host[id] ? 1 : 0;
+    }
     for (size_t id = 0; id < nd; id++) {
         int64_t target = dmds_full[id].free - margins[id];
         if (shares_host[id]) {
             // The device's "free" is the same physical pool the host row
             // draws from; leave room for the host's own demand and margin or
-            // step 3 fills the pool and starves the host.
-            const int64_t pool_target = dmds_full.back().free - margins[0] - host_resident_full;
+            // step 3 fills the pool and starves the host. The budget is split
+            // between the shared devices so they cannot each claim all of it.
+            const int64_t pool_target = common_fit_shared_pool_target(
+                dmds_full.back().free, host_resident_full, margins[0], n_shares_host);
             target = std::min(target, pool_target);
         }
         targets.push_back(target);

--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <stdexcept>
 #include <cinttypes>
+#include <cstring>
 #include <set>
 #include <string>
 #include <vector>
@@ -175,6 +176,25 @@ common_device_memory_data_vec common_get_device_memory_data(
     return ret;
 }
 
+// Whether allocations on this device draw from the same physical pool as
+// host memory. For such devices the per-device budget alone under-counts:
+// their wired buffers, the host-assigned layers, and every other process all
+// share one pool.
+static bool ggml_dev_shares_host_memory(ggml_backend_dev_t dev) {
+    if (ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_IGPU) {
+        return true;
+    }
+#if defined(__APPLE__) && defined(__aarch64__)
+    // Apple silicon: every Metal device is unified with system memory.
+    ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
+    const char * reg_name = reg == nullptr ? nullptr : ggml_backend_reg_name(reg);
+    if (reg_name != nullptr && strcmp(reg_name, "Metal") == 0) {
+        return true;
+    }
+#endif
+    return false;
+}
+
 static void common_params_fit_impl(
         const char * path_model, struct llama_model_params * mparams, struct llama_context_params * cparams,
         float * tensor_split, struct llama_model_tensor_buft_override * tensor_buft_overrides,
@@ -233,9 +253,12 @@ static void common_params_fit_impl(
 
     if (nd == 0) {
         sum_projected_used = dmds_full.back().mb.total();
-        sum_free           = dmds_full.back().total;
+        // Budget against what the host can actually still hand out. Using
+        // total physical memory here meant a CPU-only fit always succeeded,
+        // no matter the model size or what else was running.
+        sum_free           = dmds_full.back().free;
         sum_projected_free = sum_free - sum_projected_used;
-        LOG_TRC("%s: projected to use %" PRId64 " MiB of host memory vs. %" PRId64 " MiB of total host memory\n",
+        LOG_TRC("%s: projected to use %" PRId64 " MiB of host memory vs. %" PRId64 " MiB of available host memory\n",
             __func__, sum_projected_used/MiB, sum_free/MiB);
         if (sum_projected_free >= margins[0]) {
             LOG_TRC("%s: will leave %" PRId64 " >= %" PRId64 " MiB of system memory, no changes needed\n",
@@ -266,24 +289,48 @@ static void common_params_fit_impl(
         assert(sum_free >= 0 && sum_projected_used >= 0);
         LOG_TRC("%s: projected to use %" PRId64 " MiB of device memory vs. %" PRId64 " MiB of free device memory\n",
             __func__, sum_projected_used/MiB, sum_free/MiB);
-        if (nd == 1) {
-            if (projected_free_per_device[0] >= margins[0]) {
-                LOG_TRC("%s: will leave %" PRId64 " >= %" PRId64 " MiB of free device memory, no changes needed\n",
-                    __func__, projected_free_per_device[0]/MiB, margins[0]/MiB);
-                return;
+    }
+
+    // Combined budget for the host row plus every device that shares physical
+    // memory with the host. The per-device rows cannot see this sum: on
+    // Apple silicon, a model with most layers on the GPU and the rest on the
+    // CPU can pass both individual rows, load, and then fail every decode
+    // because the two allocations plus the rest of the system exceed physical
+    // memory. Uses the first margin as the host margin.
+    int64_t host_shared_deficit = 0;
+    if (nd > 0) {
+        int64_t shared_projected = 0;
+        for (size_t id = 0; id < nd; id++) {
+            if (ggml_dev_shares_host_memory(devs[id])) {
+                shared_projected += dmds_full[id].mb.total();
             }
-        } else {
-            bool changes_needed = false;
-            for (size_t id = 0; id < nd; id++) {
-                if (projected_free_per_device[id] < margins[id]) {
-                    changes_needed = true;
-                    break;
-                }
+        }
+        const int64_t host_projected  = dmds_full.back().mb.total();
+        const int64_t host_free_after = dmds_full.back().free - host_projected - shared_projected;
+        if (host_free_after < margins[0]) {
+            host_shared_deficit = margins[0] - host_free_after;
+            LOG_TRC("%s: host + shared-memory devices projected to overshoot available host memory by %" PRId64 " MiB\n",
+                __func__, host_shared_deficit/MiB);
+        }
+    }
+
+    if (nd == 1) {
+        if (projected_free_per_device[0] >= margins[0] && host_shared_deficit == 0) {
+            LOG_TRC("%s: will leave %" PRId64 " >= %" PRId64 " MiB of free device memory, no changes needed\n",
+                __func__, projected_free_per_device[0]/MiB, margins[0]/MiB);
+            return;
+        }
+    } else if (nd > 1) {
+        bool changes_needed = host_shared_deficit > 0;
+        for (size_t id = 0; id < nd; id++) {
+            if (projected_free_per_device[id] < margins[id]) {
+                changes_needed = true;
+                break;
             }
-            if (!changes_needed) {
-                LOG_TRC("%s: targets for free memory can be met on all devices, no changes needed\n", __func__);
-                return;
-            }
+        }
+        if (!changes_needed) {
+            LOG_TRC("%s: targets for free memory can be met on all devices, no changes needed\n", __func__);
+            return;
         }
     }
 
@@ -297,6 +344,9 @@ static void common_params_fit_impl(
             for (size_t id = 0; id < nd; id++) {
                 global_surplus -= margins[id];
             }
+            // A host-side deficit must force a reduction even when the device
+            // rows individually have surplus.
+            global_surplus -= host_shared_deficit;
         }
         if (global_surplus < 0) {
             if (nd <= 1) {

--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -8,7 +8,6 @@
 #include <cassert>
 #include <stdexcept>
 #include <cinttypes>
-#include <cstring>
 #include <set>
 #include <string>
 #include <vector>
@@ -179,20 +178,16 @@ common_device_memory_data_vec common_get_device_memory_data(
 // Whether allocations on this device draw from the same physical pool as
 // host memory. For such devices the per-device budget alone under-counts:
 // their wired buffers, the host-assigned layers, and every other process all
-// share one pool.
+// share one pool. The backend itself is the authority (ggml_backend_dev_props
+// is memset by ggml_backend_dev_get_props, so backends that do not know
+// report false); integrated GPUs share by definition.
 static bool ggml_dev_shares_host_memory(ggml_backend_dev_t dev) {
     if (ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_IGPU) {
         return true;
     }
-#if defined(__APPLE__) && defined(__aarch64__)
-    // Apple silicon: every Metal device is unified with system memory.
-    ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
-    const char * reg_name = reg == nullptr ? nullptr : ggml_backend_reg_name(reg);
-    if (reg_name != nullptr && strcmp(reg_name, "Metal") == 0) {
-        return true;
-    }
-#endif
-    return false;
+    ggml_backend_dev_props props;
+    ggml_backend_dev_get_props(dev, &props);
+    return props.memory_unified;
 }
 
 static void common_params_fit_impl(
@@ -252,10 +247,15 @@ static void common_params_fit_impl(
     projected_free_per_device.reserve(nd);
 
     if (nd == 0) {
+        // Budget against what the host can actually still hand out, in
+        // resident terms: with the caller on mmap the weight pages are
+        // file-backed and evictable, so they are not demand against an
+        // availability metric that counts them as free (see host_resident
+        // below — duplicated here because this branch runs before it).
         sum_projected_used = dmds_full.back().mb.total();
-        // Budget against what the host can actually still hand out. Using
-        // total physical memory here meant a CPU-only fit always succeeded,
-        // no matter the model size or what else was running.
+        if (mparams->load_mode == LLAMA_LOAD_MODE_MMAP) {
+            sum_projected_used -= dmds_full.back().mb.model;
+        }
         sum_free           = dmds_full.back().free;
         sum_projected_free = sum_free - sum_projected_used;
         LOG_TRC("%s: projected to use %" PRId64 " MiB of host memory vs. %" PRId64 " MiB of available host memory\n",
@@ -291,21 +291,43 @@ static void common_params_fit_impl(
             __func__, sum_projected_used/MiB, sum_free/MiB);
     }
 
+    // Host demand must be measured in the same currency as host availability.
+    // The probe loads with LLAMA_LOAD_MODE_NONE, so mb.model counts the full
+    // weight bytes as resident buffers — but under the caller's real
+    // LLAMA_LOAD_MODE_MMAP those pages are file-backed and evictable, i.e.
+    // exactly the pages the availability metric deliberately leaves in the
+    // pool. Charging them as resident would inflate demand by the size of
+    // pages supply has already declared available.
+    const bool host_model_evictable = mparams->load_mode == LLAMA_LOAD_MODE_MMAP;
+    auto host_resident = [&](const llama_device_memory_data & host_row) -> int64_t {
+        int64_t projected = host_row.mb.total();
+        if (host_model_evictable) {
+            projected -= host_row.mb.model;
+        }
+        return projected;
+    };
+
     // Combined budget for the host row plus every device that shares physical
     // memory with the host. The per-device rows cannot see this sum: on
     // Apple silicon, a model with most layers on the GPU and the rest on the
     // CPU can pass both individual rows, load, and then fail every decode
     // because the two allocations plus the rest of the system exceed physical
-    // memory. Uses the first margin as the host margin.
+    // memory. Uses the first margin as the host margin (callers size the
+    // margins buffer per device with one policy value; the host has no
+    // dedicated slot).
     int64_t host_shared_deficit = 0;
+    bool    device_rows_ok      = true;
     if (nd > 0) {
         int64_t shared_projected = 0;
         for (size_t id = 0; id < nd; id++) {
             if (ggml_dev_shares_host_memory(devs[id])) {
                 shared_projected += dmds_full[id].mb.total();
             }
+            if (projected_free_per_device[id] < margins[id]) {
+                device_rows_ok = false;
+            }
         }
-        const int64_t host_projected  = dmds_full.back().mb.total();
+        const int64_t host_projected  = host_resident(dmds_full.back());
         const int64_t host_free_after = dmds_full.back().free - host_projected - shared_projected;
         if (host_free_after < margins[0]) {
             host_shared_deficit = margins[0] - host_free_after;
@@ -366,6 +388,11 @@ static void common_params_fit_impl(
                         for (size_t id = 0; id < nd; id++) {
                             sum_used_target -= margins[id];
                         }
+                        // The deficit forced entry into this reduction; both
+                        // sides of the comparison below must be measured against
+                        // the same budget or the interpolation ratio exceeds 1
+                        // and inflates the context instead of reducing it.
+                        sum_used_target -= host_shared_deficit;
                     }
                     if (nd > 1) {
                         // for multiple devices we need to be more conservative in terms of how much context we think can fit:
@@ -373,7 +400,10 @@ static void common_params_fit_impl(
                         //   - for MoE models only whole tensors can be assigned to devices, which we estimate to be <= 1/3 of a layer
                         //   - on average we expect a waste of 0.5 layers/tensors per device
                         //   - use slightly more than the expected average for nd devices to be safe
-                        const int64_t model_per_layer = sum_projected_model / std::min(uint32_t(mparams->n_gpu_layers), hp_ngl);
+                        // n_gpu_layers can legitimately be 0 here (host-forced descent);
+                        // an unguarded division faults on x86-64 and silently returns 0
+                        // on AArch64.
+                        const int64_t model_per_layer = sum_projected_model / std::max(1U, std::min(uint32_t(mparams->n_gpu_layers), hp_ngl));
                         sum_used_target -= (nd + 1) * model_per_layer / (hp_nex == 0 ? 2 : 6);
                     }
 
@@ -382,19 +412,32 @@ static void common_params_fit_impl(
                     const dmds_t dmds_min_ctx = common_get_device_memory_data_impl(path_model, mparams, cparams, devs, hp_ngl, hp_nct, hp_nex, log_level);
                     if (nd == 0) {
                         sum_projected_used_min_ctx = dmds_min_ctx.back().mb.total();
+                        if (mparams->load_mode == LLAMA_LOAD_MODE_MMAP) {
+                            sum_projected_used_min_ctx -= dmds_min_ctx.back().mb.model;
+                        }
                     } else {
                         for (size_t id = 0; id < nd; id++) {
                             sum_projected_used_min_ctx += dmds_min_ctx[id].mb.total();
                         }
                     }
-                    if (sum_used_target > sum_projected_used_min_ctx) {
+                    // With a host-forced descent the device rows can be
+                    // context-independent (n_gpu_layers == 0 keeps the whole
+                    // KV cache host-side), making this delta exactly 0; an
+                    // unguarded division faults on x86-64 and silently
+                    // returns 0 on AArch64.
+                    const int64_t used_delta = sum_projected_used - sum_projected_used_min_ctx;
+                    if (sum_used_target > sum_projected_used_min_ctx && used_delta > 0) {
                         // linear interpolation between minimum and maximum context size:
                         cparams->n_ctx += (hp_nct - n_ctx_min) * (sum_used_target - sum_projected_used_min_ctx)
-                            / (sum_projected_used - sum_projected_used_min_ctx);
+                            / used_delta;
+                        // No correct input yields a context above the training
+                        // context, but the interpolation can once the target
+                        // exceeds the max-context sample.
+                        cparams->n_ctx = std::min(cparams->n_ctx, hp_nct);
                         cparams->n_ctx = std::max(cparams->n_ctx - cparams->n_ctx % 256, n_ctx_min); // round down context for CUDA backend
 
-                        const int64_t bytes_per_ctx = (sum_projected_used - sum_projected_used_min_ctx) / (hp_nct - n_ctx_min);
-                        const int64_t memory_reduction = (hp_nct - cparams->n_ctx) * bytes_per_ctx;
+                        const int64_t bytes_per_ctx = used_delta / (hp_nct - n_ctx_min);
+                        const int64_t memory_reduction = ((int64_t) hp_nct - (int64_t) cparams->n_ctx) * bytes_per_ctx;
                         LOG_TRC("%s: context size reduced from %" PRIu32 " to %" PRIu32 " -> need %" PRId64 " MiB less memory in total\n",
                             __func__, hp_nct, cparams->n_ctx, memory_reduction/MiB);
                         if (nd <= 1) {
@@ -422,6 +465,17 @@ static void common_params_fit_impl(
     }
     if (nd == 0) {
         throw common_params_fit_exception("was unable to fit model into system memory by reducing context, abort");
+    }
+
+    // When only the combined host+shared budget was short (every device row
+    // met its own margin), falling through to the generic pinned-parameter
+    // throws below would blame n_gpu_layers for a host-memory shortfall.
+    // Name the actual cause instead.
+    if (host_shared_deficit > 0 && device_rows_ok &&
+        mparams->n_gpu_layers != default_mparams.n_gpu_layers) {
+        throw common_params_fit_exception(
+            "available host memory is short by " + std::to_string(host_shared_deficit/MiB) +
+            " MiB for the combined host + unified-device demand, and n_gpu_layers is pinned by the user, abort");
     }
 
     if (mparams->n_gpu_layers != default_mparams.n_gpu_layers) {
@@ -608,8 +662,23 @@ static void common_params_fit_impl(
 
     std::vector<int64_t> targets; // maximum acceptable memory use per device
     targets.reserve(nd);
+    // Resident host demand at the full-parameter probe, used to cap the
+    // budget of devices that draw from the host pool. Static across the
+    // descent: with mmap the host-side weights are excluded above, so
+    // moving layers between a unified device and the host barely moves the
+    // resident host demand (context/compute shifts remain a known
+    // imprecision).
+    const int64_t host_resident_full = host_resident(dmds_full.back());
     for (size_t id = 0; id < nd; id++) {
-        targets.push_back(dmds_full[id].free - margins[id]);
+        int64_t target = dmds_full[id].free - margins[id];
+        if (ggml_dev_shares_host_memory(devs[id])) {
+            // The device's "free" is the same physical pool the host row
+            // draws from; leave room for the host's own demand and margin or
+            // step 3 fills the pool and starves the host.
+            const int64_t pool_target = dmds_full.back().free - margins[0] - host_resident_full;
+            target = std::min(target, pool_target);
+        }
+        targets.push_back(target);
         LOG_TRC("%s: id=%zu, target=%" PRId64 " MiB\n", __func__, id, targets[id]/MiB);
     }
 
@@ -849,6 +918,12 @@ enum common_params_fit_status common_fit_params(
         ggml_log_level log_level) {
     const int64_t t0_us = llama_time_us();
     common_params_fit_status status = COMMON_PARAMS_FIT_STATUS_SUCCESS;
+    // The impl mutates the params while it works (e.g. n_ctx during the
+    // context-reduction probe). Callers that ignore the status — including
+    // common_init_from_params — would otherwise load with a half-mutated
+    // configuration after a FAILURE, silently clamping the context.
+    const llama_model_params   mparams_original = *mparams;
+    const llama_context_params cparams_original = *cparams;
     try {
         common_params_fit_impl(path_model, mparams, cparams, tensor_split, tensor_buft_overrides, margins, n_ctx_min, log_level);
         LOG_TRC("%s: successfully fit params to free device memory\n", __func__);
@@ -858,6 +933,14 @@ enum common_params_fit_status common_fit_params(
     } catch (const std::runtime_error & e) {
         LOG_ERR("%s: encountered an error while trying to fit params to free device memory: %s\n", __func__, e.what());
         status = COMMON_PARAMS_FIT_STATUS_ERROR;
+    } catch (const std::exception & e) {
+        // A preflight gate must never take the caller down.
+        LOG_ERR("%s: unexpected error while trying to fit params: %s\n", __func__, e.what());
+        status = COMMON_PARAMS_FIT_STATUS_ERROR;
+    }
+    if (status != COMMON_PARAMS_FIT_STATUS_SUCCESS) {
+        *mparams = mparams_original;
+        *cparams = cparams_original;
     }
     const int64_t t1_us = llama_time_us();
     LOG_TRC("%s: fitting params to free memory took %.2f seconds\n", __func__, (t1_us - t0_us) * 1e-6);

--- a/common/fit.h
+++ b/common/fit.h
@@ -26,6 +26,29 @@ common_params_fit_status common_fit_params(
                            uint32_t   n_ctx_min,             // minimum context size to set when trying to reduce memory use
                      ggml_log_level   log_level);            // minimum log level to print during fitting, lower levels go to debug log
 
+// Pure decision arithmetic, exposed for tests (tests/test-fit-params.cpp).
+// The projected figures are resident demand per row; "shares_host" marks
+// devices whose memory is the same physical pool as the host's.
+
+// Deficit (in bytes, >= 0) of the combined host + shared-memory-device budget
+// against available host memory. 0 means the combined budget is met.
+int64_t common_fit_shared_pool_deficit(
+        const std::vector<int64_t> & dev_projected,
+        const std::vector<bool>    & shares_host,
+                           int64_t   host_free,
+                           int64_t   host_projected_resident,
+                           int64_t   host_margin);
+
+// Context size after the step-2 linear interpolation, guarded against a
+// context-independent memory delta (returns n_ctx_min) and clamped to the
+// training context. Returns 0 when no reduction can meet the target.
+uint32_t common_fit_reduced_n_ctx(
+        int64_t  sum_used_target,
+        int64_t  sum_projected_used,
+        int64_t  sum_projected_used_min_ctx,
+        uint32_t hp_nct,
+        uint32_t n_ctx_min);
+
 // print estimated memory to stdout
 void common_fit_print(
                          const char * path_model,

--- a/common/fit.h
+++ b/common/fit.h
@@ -39,6 +39,15 @@ int64_t common_fit_shared_pool_deficit(
                            int64_t   host_projected_resident,
                            int64_t   host_margin);
 
+// Per-device cap for a device that draws from the host pool. The pool budget
+// is what stays free after the host's own demand and margin, split evenly
+// between the devices that share it. A negative budget is returned unsplit.
+int64_t common_fit_shared_pool_target(
+                           int64_t   host_free,
+                           int64_t   host_projected_resident,
+                           int64_t   host_margin,
+                            size_t   n_shares_host);
+
 // Context size after the step-2 linear interpolation, guarded against a
 // context-independent memory delta (returns n_ctx_min) and clamped to the
 // training context. Returns 0 when no reduction can meet the target.

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -168,6 +168,10 @@ extern "C" {
         size_t memory_total;
         // device type
         enum ggml_backend_dev_type type;
+        // whether device memory is the same physical pool as host memory
+        // (e.g. Apple silicon unified memory); such devices must be budgeted
+        // together with the host rather than as an independent pool
+        bool memory_unified;
         // device id
         //   for PCI devices, this should be the lower-case PCI bus id formatted as "domain:bus:device.function" (e.g. "0000:c1:00.0")
         //   if the id is unknown, this should be NULL

--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -1,6 +1,10 @@
 #include "ggml-backend.h"
 #include "ggml-backend-impl.h"
 #include "ggml-cpu.h"
+
+#if defined(__APPLE__) && !defined(_WIN32)
+#include <mach/mach.h>
+#endif
 #include "repack.h"
 #include "traits.h"
 #include "ggml-impl.h"
@@ -369,6 +373,43 @@ static void ggml_backend_cpu_device_get_memory(ggml_backend_dev_t dev, size_t * 
     GlobalMemoryStatusEx(&status);
     *total = status.ullTotalPhys;
     *free = status.ullAvailPhys;
+#elif defined(__APPLE__)
+    long pages = sysconf(_SC_PHYS_PAGES);
+    long page_size = sysconf(_SC_PAGE_SIZE);
+    *total = pages * page_size;
+
+    // Physical memory minus what cannot be evicted: wired pages and the
+    // compressor's footprint. Anonymous and file-backed pages are not
+    // subtracted — the kernel compresses or evicts them under pressure.
+    // Reporting total here made every host-memory fit trivially pass: an
+    // 18 GiB model on a 24 GiB machine "fit" regardless of what was running.
+    vm_statistics64_data_t vm_stats;
+    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+    if (host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t) &vm_stats, &count) == KERN_SUCCESS) {
+        const size_t unavailable = ((size_t) vm_stats.wire_count + (size_t) vm_stats.compressor_page_count) * (size_t) page_size;
+        *free = *total > unavailable ? *total - unavailable : 0;
+    } else {
+        *free = *total;
+    }
+#elif defined(__linux__)
+    long pages = sysconf(_SC_PHYS_PAGES);
+    long page_size = sysconf(_SC_PAGE_SIZE);
+    *total = pages * page_size;
+
+    // MemAvailable is the kernel's own estimate of allocatable memory without
+    // swapping; fall back to total when /proc/meminfo is unavailable.
+    *free = *total;
+    if (FILE * f = fopen("/proc/meminfo", "r")) {
+        char line[128];
+        while (fgets(line, sizeof(line), f)) {
+            unsigned long long kib = 0;
+            if (sscanf(line, "MemAvailable: %llu kB", &kib) == 1) {
+                *free = (size_t) kib * 1024;
+                break;
+            }
+        }
+        fclose(f);
+    }
 #else
     long pages = sysconf(_SC_PHYS_PAGES);
     long page_size = sysconf(_SC_PAGE_SIZE);

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -6,6 +6,9 @@
 
 #include <Foundation/Foundation.h>
 
+#include <mach/mach.h>
+#include <sys/sysctl.h>
+
 #include <Metal/Metal.h>
 
 #include <stdatomic.h>
@@ -1167,6 +1170,33 @@ void ggml_metal_device_get_memory(ggml_metal_device_t dev, size_t * free, size_t
     if (@available(macOS 10.12, iOS 16.0, *)) {
         *total = dev->mtl_device.recommendedMaxWorkingSetSize;
         *free  = *total - dev->mtl_device.currentAllocatedSize;
+
+        // currentAllocatedSize only counts this process. On unified memory the
+        // device budget is the same physical RAM every other process is using,
+        // so clamp by what the host can still make available — otherwise a
+        // fresh process (e.g. a fit/preflight subprocess) sees an idle device
+        // no matter how much is already wired system-wide.
+        //
+        // "Available" here is physical memory minus what cannot be evicted:
+        // wired pages (other processes' GPU buffers included) and the
+        // compressor's own footprint. Anonymous and file-backed pages are NOT
+        // subtracted — the kernel compresses or evicts them under pressure, and
+        // an estimate like free+inactive that ignores this rejects loads that
+        // demonstrably run.
+        if (dev->mtl_device.hasUnifiedMemory) {
+            vm_statistics64_data_t vm_stats;
+            mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+            int64_t total_mem = 0;
+            size_t total_len = sizeof(total_mem);
+            if (host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t) &vm_stats, &count) == KERN_SUCCESS &&
+                sysctlbyname("hw.memsize", &total_mem, &total_len, NULL, 0) == 0) {
+                const size_t unavailable = ((size_t) vm_stats.wire_count + (size_t) vm_stats.compressor_page_count) * (size_t) vm_kernel_page_size;
+                const size_t host_available = (size_t) total_mem > unavailable ? (size_t) total_mem - unavailable : 0;
+                if (host_available < *free) {
+                    *free = host_available;
+                }
+            }
+        }
     } else {
         *free = 0;
         *total = 0;

--- a/ggml/src/ggml-metal/ggml-metal.cpp
+++ b/ggml/src/ggml-metal/ggml-metal.cpp
@@ -688,9 +688,13 @@ static enum ggml_backend_dev_type ggml_backend_metal_device_get_type(ggml_backen
 }
 
 static void ggml_backend_metal_device_get_props(ggml_backend_dev_t dev, ggml_backend_dev_props * props) {
+    ggml_metal_device_t ctx_dev = (ggml_metal_device_t)dev->context;
+
     props->name        = ggml_backend_metal_device_get_name(dev);
     props->description = ggml_backend_metal_device_get_description(dev);
     props->type        = ggml_backend_metal_device_get_type(dev);
+
+    props->memory_unified = ggml_metal_device_get_props(ctx_dev)->has_unified_memory;
 
     ggml_backend_metal_device_get_memory(dev, &props->memory_free, &props->memory_total);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -311,6 +311,7 @@ if (GGML_RPC)
     llama_build_and_test(test-rpc.cpp)
     set_tests_properties(test-rpc PROPERTIES SKIP_RETURN_CODE 77 TIMEOUT 120)
 endif()
+llama_build_and_test(test-unified-memory-props.cpp)
 
 # Vulkan TBQ/PQ copy-to-quant subgroup-size sweep. Spawns itself with different
 # GGML_VK_TBQ_COPY_SG_SIZE values to exercise the shader's cross-subgroup stitch

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -312,6 +312,7 @@ if (GGML_RPC)
     set_tests_properties(test-rpc PROPERTIES SKIP_RETURN_CODE 77 TIMEOUT 120)
 endif()
 llama_build_and_test(test-unified-memory-props.cpp)
+llama_build_and_test(test-fit-params.cpp)
 
 # Vulkan TBQ/PQ copy-to-quant subgroup-size sweep. Spawns itself with different
 # GGML_VK_TBQ_COPY_SG_SIZE values to exercise the shader's cross-subgroup stitch

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -307,12 +307,16 @@ if (NOT LLAMA_SANITIZE_ADDRESS AND NOT GGML_SCHED_NO_REALLOC)
   llama_build_and_test(test-opt.cpp)
 endif()
 llama_build_and_test(test-backend-ops.cpp)
+llama_build_and_test(test-unified-memory-props.cpp)
+if (GGML_METAL)
+    # only a Metal build can enumerate a Metal device
+    target_compile_definitions(test-unified-memory-props PRIVATE LLAMA_TEST_EXPECT_METAL)
+endif()
+llama_build_and_test(test-fit-params.cpp)
 if (GGML_RPC)
     llama_build_and_test(test-rpc.cpp)
     set_tests_properties(test-rpc PROPERTIES SKIP_RETURN_CODE 77 TIMEOUT 120)
 endif()
-llama_build_and_test(test-unified-memory-props.cpp)
-llama_build_and_test(test-fit-params.cpp)
 
 # Vulkan TBQ/PQ copy-to-quant subgroup-size sweep. Spawns itself with different
 # GGML_VK_TBQ_COPY_SG_SIZE values to exercise the shader's cross-subgroup stitch

--- a/tests/test-fit-params.cpp
+++ b/tests/test-fit-params.cpp
@@ -53,6 +53,24 @@ int main() {
         common_fit_shared_pool_deficit({10 * GiB, 30 * GiB}, {true, false}, 18 * GiB, 5 * GiB, 1 * GiB),
         0);
 
+    // --- common_fit_shared_pool_target ---
+
+    // One shared device takes the whole pool budget: 18 - 5 - 1 = 12.
+    expect_i64("single shared device takes the whole budget",
+        common_fit_shared_pool_target(18 * GiB, 5 * GiB, 1 * GiB, 1),
+        12 * GiB);
+
+    // Two shared devices split it, so they cannot each claim all of it.
+    // Without the split both would cap at 12 GiB and together overrun the pool.
+    expect_i64("two shared devices split the budget",
+        common_fit_shared_pool_target(18 * GiB, 5 * GiB, 1 * GiB, 2),
+        6 * GiB);
+
+    // A negative budget stays whole: splitting would understate the shortfall.
+    expect_i64("negative budget is not split",
+        common_fit_shared_pool_target(6 * GiB, 8 * GiB, 1 * GiB, 2),
+        -3 * GiB);
+
     // --- common_fit_reduced_n_ctx ---
 
     // Reviewer-traced inflation shape: deficit-forced entry where the target

--- a/tests/test-fit-params.cpp
+++ b/tests/test-fit-params.cpp
@@ -1,0 +1,110 @@
+// Table-driven tests for the pure fit decision arithmetic in common/fit.cpp.
+// These are the sites of the review findings on qvac-fabric-llm.cpp#214: the
+// shared-pool fold and the step-2 context interpolation. Everything here is
+// provable from the algebra with no hardware, which is the point — the
+// context-inflation bug would have failed these fixtures on their first run.
+
+#include "../common/fit.h"
+
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+constexpr int64_t GiB = 1024LL * 1024 * 1024;
+
+static int failures = 0;
+
+static void expect_i64(const char * label, int64_t got, int64_t want) {
+    if (got != want) {
+        fprintf(stderr, "FAIL %s: got %lld, want %lld\n", label, (long long) got, (long long) want);
+        failures++;
+    }
+}
+
+static void expect_u32(const char * label, uint32_t got, uint32_t want) {
+    if (got != want) {
+        fprintf(stderr, "FAIL %s: got %u, want %u\n", label, got, want);
+        failures++;
+    }
+}
+
+int main() {
+    // --- common_fit_shared_pool_deficit ---
+
+    // nd == 1, discrete GPU: device demand never counts against the host pool.
+    expect_i64("discrete GPU never folds",
+        common_fit_shared_pool_deficit({14 * GiB}, {false}, 8 * GiB, 11 * GiB, 1 * GiB),
+        4 * GiB); // host row alone: 8 - 11 = -3 free, short of the 1 GiB margin by 4
+
+    // nd == 1, shared device, device surplus but combined deficit — the
+    // measured Gemma ngl=48 shape: device row passes on its own, the pool sum
+    // does not.
+    expect_i64("shared device folds into the pool",
+        common_fit_shared_pool_deficit({14 * GiB}, {true}, 18 * GiB, 5 * GiB, 1 * GiB),
+        2 * GiB); // 18 - 5 - 14 = -1 free, short of the 1 GiB margin by 2
+
+    // Same shape with room to spare: no deficit.
+    expect_i64("combined budget met",
+        common_fit_shared_pool_deficit({10 * GiB}, {true}, 18 * GiB, 5 * GiB, 1 * GiB),
+        0);
+
+    // nd == 2, mixed shared/discrete: only the shared device is folded.
+    expect_i64("mixed devices fold only the shared one",
+        common_fit_shared_pool_deficit({10 * GiB, 30 * GiB}, {true, false}, 18 * GiB, 5 * GiB, 1 * GiB),
+        0);
+
+    // --- common_fit_reduced_n_ctx ---
+
+    // Reviewer-traced inflation shape: deficit-forced entry where the target
+    // still exceeds the max-context sample. Pre-fix this interpolated
+    // 32768 -> 47104; the result must never exceed the training context.
+    {
+        const uint32_t n_ctx = common_fit_reduced_n_ctx(
+            /*sum_used_target        =*/ 17 * GiB,
+            /*sum_projected_used     =*/ 14 * GiB,
+            /*sum_projected_used_min =*/ 13 * GiB,
+            /*hp_nct                 =*/ 131072,
+            /*n_ctx_min              =*/ 4096);
+        if (n_ctx > 131072) {
+            fprintf(stderr, "FAIL inflation clamp: n_ctx %u exceeds training context\n", n_ctx);
+            failures++;
+        }
+        expect_u32("target beyond max sample clamps to hp_nct", n_ctx, 131072);
+    }
+
+    // Context-independent rows (n_gpu_layers == 0 keeps KV host-side):
+    // used_delta == 0 exactly. Pre-fix this divided by zero — SIGFPE on
+    // x86-64, silent 0 on AArch64. Must report "no reduction possible".
+    expect_u32("zero delta reports no reduction, not a fault",
+        common_fit_reduced_n_ctx(12 * GiB, 14 * GiB, 14 * GiB, 131072, 4096),
+        0);
+
+    // Ordinary interior reduction: target halfway between the samples lands
+    // halfway between the context bounds (rounded down to a 256 multiple).
+    expect_u32("interior interpolation",
+        common_fit_reduced_n_ctx(13 * GiB, 14 * GiB, 12 * GiB, 65536, 4096),
+        // 4096 + (65536-4096) * 1/2 = 34816, already a 256 multiple
+        34816);
+
+    // Target below the min-context sample: no context can meet it.
+    expect_u32("target below min sample",
+        common_fit_reduced_n_ctx(11 * GiB, 14 * GiB, 12 * GiB, 65536, 4096),
+        0);
+
+    // Result never drops below n_ctx_min.
+    {
+        const uint32_t n_ctx = common_fit_reduced_n_ctx(
+            12 * GiB + 1, 14 * GiB, 12 * GiB, 65536, 4096);
+        if (n_ctx != 0 && n_ctx < 4096) {
+            fprintf(stderr, "FAIL floor: n_ctx %u below n_ctx_min\n", n_ctx);
+            failures++;
+        }
+    }
+
+    if (failures > 0) {
+        fprintf(stderr, "%d failure(s)\n", failures);
+        return 1;
+    }
+    printf("OK\n");
+    return 0;
+}

--- a/tests/test-unified-memory-props.cpp
+++ b/tests/test-unified-memory-props.cpp
@@ -1,0 +1,63 @@
+// Asserts that backends whose device memory shares the host's physical pool
+// report it through ggml_backend_dev_props.memory_unified, and that the
+// public wrapper zero-initializes the field for backends that do not set it.
+//
+// Regression fixture for the fit host+shared-memory fold: a name-based check
+// in common/fit.cpp once matched a registry name that did not exist, so the
+// fold was dead code and no fixture could tell "fold works" from "fold never
+// runs" (qvac-fabric-llm.cpp#214 review).
+
+#include "ggml-backend.h"
+
+#include <cstdio>
+#include <cstring>
+
+int main() {
+    ggml_backend_load_all();
+
+    const size_t n_dev = ggml_backend_dev_count();
+    bool saw_metal = false;
+
+    for (size_t i = 0; i < n_dev; i++) {
+        ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+
+        ggml_backend_dev_props props;
+        ggml_backend_dev_get_props(dev, &props);
+
+        ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
+        const char * reg_name = reg ? ggml_backend_reg_name(reg) : "";
+
+        printf("device %zu: reg=%s name=%s type=%d memory_unified=%d\n",
+            i, reg_name, props.name, (int) props.type, (int) props.memory_unified);
+
+        if (strcmp(reg_name, "MTL") == 0) {
+            saw_metal = true;
+#if defined(__APPLE__) && defined(__aarch64__)
+            // Every Apple silicon Metal device is unified with system memory.
+            if (!props.memory_unified) {
+                fprintf(stderr, "FAIL: Metal device does not report memory_unified on Apple silicon\n");
+                return 1;
+            }
+#endif
+        }
+
+        // The CPU device is host memory by definition but is not a shared
+        // *device* pool; it must not claim the flag.
+        if (props.type == GGML_BACKEND_DEVICE_TYPE_CPU && props.memory_unified) {
+            fprintf(stderr, "FAIL: CPU device claims memory_unified\n");
+            return 1;
+        }
+    }
+
+#if defined(__APPLE__) && defined(__aarch64__)
+    if (!saw_metal) {
+        fprintf(stderr, "FAIL: no Metal device enumerated on Apple silicon\n");
+        return 1;
+    }
+#else
+    (void) saw_metal;
+#endif
+
+    printf("OK\n");
+    return 0;
+}

--- a/tests/test-unified-memory-props.cpp
+++ b/tests/test-unified-memory-props.cpp
@@ -49,7 +49,9 @@ int main() {
         }
     }
 
-#if defined(__APPLE__) && defined(__aarch64__)
+    // LLAMA_TEST_EXPECT_METAL is set only when GGML_METAL is ON. Apple silicon
+    // CI also builds Vulkan/WebGPU with Metal off, where no Metal device exists.
+#if defined(__APPLE__) && defined(__aarch64__) && defined(LLAMA_TEST_EXPECT_METAL)
     if (!saw_metal) {
         fprintf(stderr, "FAIL: no Metal device enumerated on Apple silicon\n");
         return 1;


### PR DESCRIPTION
> Draft — needs a decision on which release train carries it (base is `temp-10297`).

## Problem

QVAC-24112. Hardware evidence from the QVAC-22629 advisory-fit work (24 GiB Apple M4 Pro, full write-up in the tether workspace under `tasks/task-qvac-9515-sdk-device-resource-monitoring/qvac-22629-local-hardware-evidence.md`) showed `common_fit_params` verdicts wrong in both directions, traced to its memory premises:

1. **Host "free" ≡ total RAM.** `ggml_backend_cpu_device_get_memory` reports `*free = *total` on non-Windows, and the `nd == 0` arm budgets against `.total` anyway. An 18 GiB model on a 24 GiB machine "fits" on CPU no matter what is running.
2. **The host row is never consulted for `nd ≥ 1`.** `common_get_device_memory_data` computes it, the decision loop ignores it. A partial offload (48/61 layers on GPU) passed while its host+device sum exceeded what the machine could serve — it loads, then every decode fails.
3. **Metal free is per-process.** `recommendedMaxWorkingSetSize − currentAllocatedSize` sees nothing other processes have wired. Measured: an 11 GiB model resident in another process did not move the verdict at all — a fit/preflight subprocess always sees an idle device.

## Fix

- **ggml-cpu**: report available memory — macOS: physical − (wired + compressor) pages; Linux: `MemAvailable`; Windows already used `ullAvailPhys`.
- **ggml-metal**: on `hasUnifiedMemory` devices, clamp free by the same system-wide availability, so cross-process wiring finally registers.
- **common/fit**: `nd == 0` budgets against `.free`; for `nd ≥ 1`, devices sharing physical memory with the host (Apple silicon Metal, `GGML_BACKEND_DEVICE_TYPE_IGPU`) are folded with the host row into one combined budget. A host-side deficit forces context reduction, and for pinned parameters surfaces as FAILURE through the existing throws.

Availability is deliberately **physical − non-evictable** (wired + compressor), *not* free+inactive: the kernel compresses/evicts anonymous and file-backed pages under pressure, and a free+inactive budget rejects loads that demonstrably run (verified: a 10.8 GiB model at 32k ran at 69 tok/s while free+inactive said no).

## Validation (M4 Pro 24 GiB, `llama-fit-params`, margin 1024)

Re-run after the review fixes, with the fold **provably engaged**
(`tests/test-unified-memory-props.cpp` asserts Metal reports `memory_unified`;
the first version of this table ran against a dead fold — see review).

| Fixture | Verdict | Real outcome |
|---|---|---|
| Gemma 4 31B `-ngl 99 -c 1024` | does-not-fit | loads, cannot decode → **correct** |
| Gemma 4 31B `-ngl 48 -c 1024` | **does-not-fit** (was the false positive) | loads, cannot decode → **correct** |
| gpt-oss-20B `-ngl 99 -c 32768` | fits | runs → correct |
| Qwen3.5 9B Q6 `-c 131072` | fits | runs → correct |
| Gemma 4 31B CPU `-c 32768` (mmap) | fits | decodes (0.1 tok/s) → correct on feasibility |
| Gemma 4 31B CPU, auto ctx | reduces context sanely | no silent 4096 clamp |
| `-ngl 0` with a device present | structured FAILURE naming the host shortfall | previously SIGFPE on x86-64 |
| 11 GiB resident in another process | reduces the budget | matches reality |

Plus two device-free ctests: `test-fit-params` (table-driven decision
arithmetic — the traced context-inflation case fails against the pre-fix
algebra) and `test-unified-memory-props`.

## Known limits (declared, follow-up material)

- For `nd ≥ 1` the step-2 reduction sums remain device-side: a host-only
  deficit with an auto context fails conservatively instead of reducing the
  host-side KV.
- The step-3 pool cap for shared-memory devices is static across the descent
  rather than re-derived per assignment; the MoE surplus and margin reporting
  paths still sum device rows only.
- The fitter's own projection runs a few hundred MiB high near the boundary
  (gpt-oss @128k f32 KV: real 17.7 GiB, projected past the margin) — accuracy,
  not budget premise.
- macOS memory pressure is bistable near the ceiling, so projection alone can
  never be denial-grade on this platform; the companion llm-llamacpp probe
  decode (QVAC-24114, tetherto/qvac#4039) verifies at load.

## Testing

- `cmake --build build --target llama-fit-params` clean on macOS arm64 (Metal).
- Fixture matrix above, plus healthy controls unchanged.
- Not covered here: Linux `MemAvailable` path built but not exercised on real Linux; Windows path untouched.
