### PR TITLE
llama-context: exclude ACCEL backends from the pipeline-parallel gate

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -436,9 +436,16 @@ llama_context::llama_context(
         if (pipeline_parallel) {
             for (auto & backend : backends) {
                 auto dev_type = ggml_backend_dev_type(ggml_backend_get_device(backend.get()));
-                if (dev_type == GGML_BACKEND_DEVICE_TYPE_CPU) {
-                    // ignore CPU backend
-                    // TODO: should we ignore ACCEL types too?
+                if (dev_type == GGML_BACKEND_DEVICE_TYPE_CPU || dev_type == GGML_BACKEND_DEVICE_TYPE_ACCEL) {
+                    // ignore CPU and ACCEL backends: they are helper backends that never
+                    // form a pipeline stage, so their lack of async/events must not veto
+                    // pipelining for the compute devices that do.
+                    //
+                    // ACCEL devices are added unconditionally above, so leaving them in
+                    // this check disabled pipeline parallelism outright on any build with
+                    // one present - e.g. Accelerate on macOS, which reports
+                    // caps.async = caps.events = false. That happened silently: only the
+                    // enabled path logs.
                     continue;
                 }
                 auto * dev = ggml_backend_get_device(backend.get());


### PR DESCRIPTION
## Problem

The pipeline-parallelism caps check in `llama_context`'s constructor only
skips `CPU`-type backends before requiring every remaining device to report
`caps.async`/`caps.events`:

```cpp
if (dev_type == GGML_BACKEND_DEVICE_TYPE_CPU) {
    // ignore CPU backend
    // TODO: should we ignore ACCEL types too?
    continue;
}
```

Any `ACCEL`-type backend present — e.g. Accelerate on macOS, which is added
unconditionally elsewhere — fails that caps check and silently disables
pipeline parallelism for *every* device in the context, including GPUs that
do support it. There's no error and no log for the failure path; only the
success path logs `pipeline parallelism enabled`, so this degrades silently.

## Fix

Skip `ACCEL` alongside `CPU` in the same check. ACCEL backends are helper
backends that never form a pipeline stage themselves, so their lack of
async/events support must not veto pipelining for the compute devices that
do. This resolves the TODO already left on this line.

## Testing

Reproduced and verified on macOS with a controlled before/after rebuild —
same machine, same model, same layer-split RPC config, same backend set
(`backend_ptrs.size() = 4`: two RPC devices + CPU + the local Accelerate
device macOS registers), only this patch toggled:

- **Without the fix:** `pipeline parallelism enabled` never fires. The model
  still loads and runs correctly — it's a silent degrade to sequential
  layer-split, not a crash.
- **With the fix:** `pipeline parallelism enabled` fires every run.

Also checked three ways for causality specifically: stock build (Accelerate
present) never engages pipelining; Accelerate forcibly disabled engages it;
this patch with Accelerate back on also engages it — isolating the ACCEL
device, not something else, as the cause.

**Caveat:** our reproduction is macOS-specific, since Accelerate was the only
ACCEL-type backend available to trigger it. The fix itself is generic (any
`ACCEL`-type device), and the mechanism is unambiguous from the code, but we
haven't reproduced against a different ACCEL backend on another platform.