### PR TITLE
rpc: connect to multiple endpoints concurrently, not serially

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -4,6 +4,7 @@
 #include "chat.h"
 #include "common.h"
 #include "download.h"
+#include "ggml-rpc.h"
 #include "json-schema-to-grammar.h"
 #include "llama.h"
 #include "log.h"
@@ -25,6 +26,7 @@
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <cinttypes>
 #include <climits>
 #include <cmath>
@@ -1121,7 +1123,36 @@ static void add_rpc_devices(const std::string & servers) {
     if (!ggml_backend_rpc_add_server_fn) {
         throw std::invalid_argument("failed to find RPC add server function");
     }
-    for (const auto & server : rpc_servers) {
+    typedef bool (*ggml_backend_rpc_prefetch_connection_t)(const char * endpoint);
+    ggml_backend_rpc_prefetch_connection_t ggml_backend_rpc_prefetch_connection_fn = (ggml_backend_rpc_prefetch_connection_t) ggml_backend_reg_get_proc_address(rpc_reg, "ggml_backend_rpc_prefetch_connection");
+    if (!ggml_backend_rpc_prefetch_connection_fn) {
+        throw std::invalid_argument("failed to find RPC prefetch connection function");
+    }
+    std::vector<uint8_t> prefetch_ok(rpc_servers.size(), false);
+    std::vector<std::thread> prefetch_threads;
+    std::atomic<size_t> next_server(0);
+    const size_t n_prefetch_threads = std::min(rpc_servers.size(), (size_t) GGML_RPC_MAX_SERVERS);
+    prefetch_threads.reserve(n_prefetch_threads);
+    for (size_t i = 0; i < n_prefetch_threads; i++) {
+        prefetch_threads.emplace_back([&]() {
+            while (true) {
+                size_t server = next_server++;
+                if (server >= rpc_servers.size()) {
+                    break;
+                }
+                prefetch_ok[server] = ggml_backend_rpc_prefetch_connection_fn(rpc_servers[server].c_str());
+            }
+        });
+    }
+    for (auto & thread : prefetch_threads) {
+        thread.join();
+    }
+    for (size_t i = 0; i < rpc_servers.size(); i++) {
+        if (!prefetch_ok[i]) {
+            LOG_WRN("failed to connect to RPC server %s\n", rpc_servers[i].c_str());
+            continue;
+        }
+        const auto & server = rpc_servers[i];
         auto reg = ggml_backend_rpc_add_server_fn(server.c_str());
         ggml_backend_register(reg);
     }

--- a/ggml/include/ggml-rpc.h
+++ b/ggml/include/ggml-rpc.h
@@ -30,6 +30,12 @@ GGML_BACKEND_API void ggml_backend_rpc_start_server(const char * endpoint, const
 GGML_BACKEND_API ggml_backend_reg_t ggml_backend_rpc_reg(void);
 GGML_BACKEND_API ggml_backend_reg_t ggml_backend_rpc_add_server(const char * endpoint);
 
+// Connects to `endpoint` and caches the connection without registering it as
+// a backend. Safe to call concurrently for different endpoints - see the
+// definition for why this exists and how it composes with
+// ggml_backend_rpc_add_server().
+GGML_BACKEND_API bool ggml_backend_rpc_prefetch_connection(const char * endpoint);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/ggml/include/ggml-rpc.h
+++ b/ggml/include/ggml-rpc.h
@@ -30,10 +30,8 @@ GGML_BACKEND_API void ggml_backend_rpc_start_server(const char * endpoint, const
 GGML_BACKEND_API ggml_backend_reg_t ggml_backend_rpc_reg(void);
 GGML_BACKEND_API ggml_backend_reg_t ggml_backend_rpc_add_server(const char * endpoint);
 
-// Connects to `endpoint` and caches the connection without registering it as
-// a backend. Safe to call concurrently for different endpoints - see the
-// definition for why this exists and how it composes with
-// ggml_backend_rpc_add_server().
+// Connects to `endpoint` and caches the connection without registering it as a backend.
+// Different endpoints can connect concurrently; same-endpoint callers share one attempt.
 GGML_BACKEND_API bool ggml_backend_rpc_prefetch_connection(const char * endpoint);
 
 #ifdef  __cplusplus

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -922,18 +922,45 @@ class rpc_command_queue {
 
 static std::shared_ptr<rpc_command_queue> get_command_queue(const std::string & endpoint) {
     static std::mutex                                                        mutex;
-    std::lock_guard<std::mutex>                                              lock(mutex);
     static std::unordered_map<std::string, std::weak_ptr<rpc_command_queue>> queues;
 
-    auto it = queues.find(endpoint);
-    if (it != queues.end()) {
-        if (auto queue = it->second.lock()) {
-            if (!queue->is_failed()) {
-                return queue;
+    auto cached = [&]() -> std::shared_ptr<rpc_command_queue> {
+        std::lock_guard<std::mutex> lock(mutex);
+        auto it = queues.find(endpoint);
+        if (it != queues.end()) {
+            if (auto queue = it->second.lock()) {
+                if (!queue->is_failed()) {
+                    return queue;
+                }
+            }
+        }
+        return nullptr;
+    };
+
+    if (auto queue = cached()) {
+        return queue;
+    }
+
+    // Connect without holding the lock: this is the part that can block for
+    // seconds (RPC_CLIENT_CONNECT_TIMEOUT_MS on an unreachable host), and
+    // different endpoints connecting concurrently are independent of each
+    // other. Holding the lock across it would serialize every endpoint a
+    // caller connects to in one call, one full connect-timeout at a time,
+    // regardless of how many callers or threads are involved.
+    auto queue = rpc_command_queue::create(endpoint);
+
+    std::lock_guard<std::mutex> lock(mutex);
+    // Re-check: a concurrent call for the same endpoint may have already
+    // connected and published its queue while this one was connecting.
+    // Prefer that one so this endpoint does not end up with two live
+    // command-queue threads racing on the same socket.
+    if (auto it = queues.find(endpoint); it != queues.end()) {
+        if (auto existing = it->second.lock()) {
+            if (!existing->is_failed()) {
+                return existing;
             }
         }
     }
-    auto queue = rpc_command_queue::create(endpoint);
     if (queue) {
         queues[endpoint] = queue;
     }
@@ -3584,6 +3611,9 @@ static void * ggml_backend_rpc_get_proc_address(ggml_backend_reg_t reg, const ch
     if (std::strcmp(name, "ggml_backend_rpc_add_server") == 0) {
         return (void *)ggml_backend_rpc_add_server;
     }
+    if (std::strcmp(name, "ggml_backend_rpc_prefetch_connection") == 0) {
+        return (void *)ggml_backend_rpc_prefetch_connection;
+    }
     if (std::strcmp(name, "ggml_backend_rpc_start_server") == 0) {
         return (void *)ggml_backend_rpc_start_server;
     }
@@ -3636,6 +3666,23 @@ static const ggml_backend_reg_i ggml_backend_rpc_reg_interface = {
     /* .get_device        = */ ggml_backend_rpc_reg_get_device,
     /* .get_proc_address  = */ ggml_backend_rpc_get_proc_address,
 };
+
+// Establishes (and caches) the connection to `endpoint` without registering
+// it as a backend. Safe to call from multiple threads for different
+// endpoints concurrently - unlike ggml_backend_rpc_add_server(), this does
+// not touch the reg_map/dev_id bookkeeping below, only get_command_queue()'s
+// own connection cache.
+//
+// Exists so a caller adding several RPC servers at once (e.g. every endpoint
+// in one --rpc list) can pay the connect latency for all of them in
+// parallel, then call ggml_backend_rpc_add_server() for each in the order it
+// wants device numbering assigned: that call's own connect becomes a cheap
+// cache hit on an already-open connection, so registration stays exactly as
+// fast and exactly as sequential/deterministic as it is today, while the
+// slow part - the network round trip - already happened concurrently.
+bool ggml_backend_rpc_prefetch_connection(const char * endpoint) {
+    return get_command_queue(endpoint) != nullptr;
+}
 
 ggml_backend_reg_t ggml_backend_rpc_add_server(const char * endpoint) {
     static std::unordered_map<std::string, ggml_backend_reg_t> reg_map;

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -920,66 +920,107 @@ class rpc_command_queue {
     std::unordered_map<std::string, uint64_t> alloc_cache;
 };
 
-static std::shared_ptr<rpc_command_queue> get_command_queue(const std::string & endpoint) {
-    struct connection_attempt {
-        std::condition_variable              cv;
-        std::shared_ptr<rpc_command_queue>   queue;
-        bool                                 done = false;
-    };
+struct rpc_connection_attempt {
+    std::condition_variable            cv;
+    std::shared_ptr<rpc_command_queue> queue;
+    bool                               keep_alive = false;
+    bool                               done       = false;
+};
 
-    static std::mutex                                                           mutex;
-    static std::unordered_map<std::string, std::weak_ptr<rpc_command_queue>>    queues;
-    static std::unordered_map<std::string, std::shared_ptr<connection_attempt>> connecting;
+struct rpc_connection_cache {
+    std::mutex                                                                  mutex;
+    std::unordered_map<std::string, std::weak_ptr<rpc_command_queue>>           queues;
+    std::unordered_map<std::string, std::shared_ptr<rpc_command_queue>>         prefetched;
+    std::unordered_map<std::string, std::shared_ptr<rpc_connection_attempt>>    connecting;
+};
 
-    auto cached = [&]() -> std::shared_ptr<rpc_command_queue> {
-        auto it = queues.find(endpoint);
-        if (it != queues.end()) {
-            if (auto queue = it->second.lock()) {
-                if (!queue->is_failed()) {
-                    return queue;
+static rpc_connection_cache & get_connection_cache() {
+    static rpc_connection_cache cache;
+    return cache;
+}
+
+static std::shared_ptr<rpc_command_queue> get_cached_command_queue_locked(rpc_connection_cache & cache, const std::string & endpoint, bool keep_alive) {
+    auto prefetch_it = cache.prefetched.find(endpoint);
+    if (prefetch_it != cache.prefetched.end()) {
+        if (!prefetch_it->second->is_failed()) {
+            auto queue = prefetch_it->second;
+            if (!keep_alive) {
+                cache.prefetched.erase(prefetch_it);
+            }
+            return queue;
+        }
+        cache.prefetched.erase(prefetch_it);
+    }
+
+    auto it = cache.queues.find(endpoint);
+    if (it != cache.queues.end()) {
+        if (auto queue = it->second.lock()) {
+            if (!queue->is_failed()) {
+                if (keep_alive) {
+                    cache.prefetched[endpoint] = queue;
                 }
+                return queue;
             }
         }
-        return nullptr;
-    };
+    }
+    return nullptr;
+}
 
-    std::shared_ptr<connection_attempt> attempt;
-    bool                                is_connector = false;
+static std::shared_ptr<rpc_command_queue> get_command_queue(const std::string & endpoint, bool keep_alive = false) {
+    auto & cache = get_connection_cache();
+
+    std::shared_ptr<rpc_connection_attempt> attempt;
+    bool                                    is_connector = false;
     {
-        std::unique_lock<std::mutex> lock(mutex);
-        if (auto queue = cached()) {
+        std::unique_lock<std::mutex> lock(cache.mutex);
+        if (auto queue = get_cached_command_queue_locked(cache, endpoint, keep_alive)) {
             return queue;
         }
 
-        auto it = connecting.find(endpoint);
-        if (it == connecting.end()) {
-            attempt = std::make_shared<connection_attempt>();
-            connecting.emplace(endpoint, attempt);
+        auto it = cache.connecting.find(endpoint);
+        if (it == cache.connecting.end()) {
+            attempt = std::make_shared<rpc_connection_attempt>();
+            attempt->keep_alive = keep_alive;
+            cache.connecting.emplace(endpoint, attempt);
             is_connector = true;
         } else {
             attempt = it->second;
+            attempt->keep_alive = attempt->keep_alive || keep_alive;
         }
     }
 
     if (!is_connector) {
-        std::unique_lock<std::mutex> lock(mutex);
+        std::unique_lock<std::mutex> lock(cache.mutex);
         attempt->cv.wait(lock, [&] { return attempt->done; });
-        return attempt->queue;
+        auto queue = attempt->queue;
+        if (queue && !keep_alive) {
+            cache.prefetched.erase(endpoint);
+        }
+        return queue;
     }
 
     auto queue = rpc_command_queue::create(endpoint);
 
     {
-        std::lock_guard<std::mutex> lock(mutex);
+        std::lock_guard<std::mutex> lock(cache.mutex);
         if (queue) {
-            queues[endpoint] = queue;
+            cache.queues[endpoint] = queue;
+            if (attempt->keep_alive) {
+                cache.prefetched[endpoint] = queue;
+            }
         }
         attempt->queue = queue;
         attempt->done  = true;
-        connecting.erase(endpoint);
+        cache.connecting.erase(endpoint);
     }
     attempt->cv.notify_all();
     return queue;
+}
+
+static void release_prefetched_command_queue(const std::string & endpoint) {
+    auto & cache = get_connection_cache();
+    std::lock_guard<std::mutex> lock(cache.mutex);
+    cache.prefetched.erase(endpoint);
 }
 
 static void normalize_alloc_cache_tensor(rpc_tensor & tensor) {
@@ -3685,7 +3726,7 @@ static const ggml_backend_reg_i ggml_backend_rpc_reg_interface = {
 // Establishes the connection without registering a backend. This lets callers
 // warm many endpoints in parallel, then register them in deterministic order.
 bool ggml_backend_rpc_prefetch_connection(const char * endpoint) {
-    return get_command_queue(endpoint) != nullptr;
+    return get_command_queue(endpoint, true) != nullptr;
 }
 
 ggml_backend_reg_t ggml_backend_rpc_add_server(const char * endpoint) {
@@ -3694,6 +3735,7 @@ ggml_backend_reg_t ggml_backend_rpc_add_server(const char * endpoint) {
     static uint32_t dev_id = 0;
     std::lock_guard<std::mutex> lock(mutex);
     if (reg_map.find(endpoint) != reg_map.end()) {
+        release_prefetched_command_queue(endpoint);
         return reg_map[endpoint];
     }
     uint32_t dev_count = ggml_backend_rpc_get_device_count(endpoint);

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -921,11 +921,17 @@ class rpc_command_queue {
 };
 
 static std::shared_ptr<rpc_command_queue> get_command_queue(const std::string & endpoint) {
-    static std::mutex                                                        mutex;
-    static std::unordered_map<std::string, std::weak_ptr<rpc_command_queue>> queues;
+    struct connection_attempt {
+        std::condition_variable              cv;
+        std::shared_ptr<rpc_command_queue>   queue;
+        bool                                 done = false;
+    };
+
+    static std::mutex                                                           mutex;
+    static std::unordered_map<std::string, std::weak_ptr<rpc_command_queue>>    queues;
+    static std::unordered_map<std::string, std::shared_ptr<connection_attempt>> connecting;
 
     auto cached = [&]() -> std::shared_ptr<rpc_command_queue> {
-        std::lock_guard<std::mutex> lock(mutex);
         auto it = queues.find(endpoint);
         if (it != queues.end()) {
             if (auto queue = it->second.lock()) {
@@ -937,33 +943,42 @@ static std::shared_ptr<rpc_command_queue> get_command_queue(const std::string & 
         return nullptr;
     };
 
-    if (auto queue = cached()) {
-        return queue;
-    }
+    std::shared_ptr<connection_attempt> attempt;
+    bool                                is_connector = false;
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        if (auto queue = cached()) {
+            return queue;
+        }
 
-    // Connect without holding the lock: this is the part that can block for
-    // seconds (RPC_CLIENT_CONNECT_TIMEOUT_MS on an unreachable host), and
-    // different endpoints connecting concurrently are independent of each
-    // other. Holding the lock across it would serialize every endpoint a
-    // caller connects to in one call, one full connect-timeout at a time,
-    // regardless of how many callers or threads are involved.
-    auto queue = rpc_command_queue::create(endpoint);
-
-    std::lock_guard<std::mutex> lock(mutex);
-    // Re-check: a concurrent call for the same endpoint may have already
-    // connected and published its queue while this one was connecting.
-    // Prefer that one so this endpoint does not end up with two live
-    // command-queue threads racing on the same socket.
-    if (auto it = queues.find(endpoint); it != queues.end()) {
-        if (auto existing = it->second.lock()) {
-            if (!existing->is_failed()) {
-                return existing;
-            }
+        auto it = connecting.find(endpoint);
+        if (it == connecting.end()) {
+            attempt = std::make_shared<connection_attempt>();
+            connecting.emplace(endpoint, attempt);
+            is_connector = true;
+        } else {
+            attempt = it->second;
         }
     }
-    if (queue) {
-        queues[endpoint] = queue;
+
+    if (!is_connector) {
+        std::unique_lock<std::mutex> lock(mutex);
+        attempt->cv.wait(lock, [&] { return attempt->done; });
+        return attempt->queue;
     }
+
+    auto queue = rpc_command_queue::create(endpoint);
+
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (queue) {
+            queues[endpoint] = queue;
+        }
+        attempt->queue = queue;
+        attempt->done  = true;
+        connecting.erase(endpoint);
+    }
+    attempt->cv.notify_all();
     return queue;
 }
 
@@ -3667,19 +3682,8 @@ static const ggml_backend_reg_i ggml_backend_rpc_reg_interface = {
     /* .get_proc_address  = */ ggml_backend_rpc_get_proc_address,
 };
 
-// Establishes (and caches) the connection to `endpoint` without registering
-// it as a backend. Safe to call from multiple threads for different
-// endpoints concurrently - unlike ggml_backend_rpc_add_server(), this does
-// not touch the reg_map/dev_id bookkeeping below, only get_command_queue()'s
-// own connection cache.
-//
-// Exists so a caller adding several RPC servers at once (e.g. every endpoint
-// in one --rpc list) can pay the connect latency for all of them in
-// parallel, then call ggml_backend_rpc_add_server() for each in the order it
-// wants device numbering assigned: that call's own connect becomes a cheap
-// cache hit on an already-open connection, so registration stays exactly as
-// fast and exactly as sequential/deterministic as it is today, while the
-// slow part - the network round trip - already happened concurrently.
+// Establishes the connection without registering a backend. This lets callers
+// warm many endpoints in parallel, then register them in deterministic order.
 bool ggml_backend_rpc_prefetch_connection(const char * endpoint) {
     return get_command_queue(endpoint) != nullptr;
 }

--- a/tests/test-rpc.cpp
+++ b/tests/test-rpc.cpp
@@ -3,11 +3,13 @@
 #include "ggml.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <thread>
 #include <vector>
 
 static bool check_values(const std::vector<float> & values, float expected) {
@@ -17,6 +19,101 @@ static bool check_values(const std::vector<float> & values, float expected) {
             return false;
         }
     }
+    return true;
+}
+
+using prefetch_connection_fn = bool (*)(const char *);
+
+static prefetch_connection_fn get_prefetch_connection() {
+    ggml_backend_reg_t rpc_reg = ggml_backend_reg_by_name("RPC");
+    if (rpc_reg == nullptr) {
+        return nullptr;
+    }
+    return (prefetch_connection_fn) ggml_backend_reg_get_proc_address(rpc_reg, "ggml_backend_rpc_prefetch_connection");
+}
+
+static std::vector<std::string> split_endpoints(const std::string & endpoints) {
+    std::vector<std::string> result;
+    size_t start = 0;
+    while (true) {
+        size_t separator = endpoints.find(',', start);
+        result.push_back(endpoints.substr(start, separator - start));
+        if (separator == std::string::npos) {
+            break;
+        }
+        start = separator + 1;
+    }
+    return result;
+}
+
+static int64_t now_ms() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+static bool check_concurrent_prefetch(prefetch_connection_fn prefetch_connection, const std::string & endpoint) {
+    static constexpr size_t n_threads = 8;
+    std::vector<uint8_t> ok(n_threads, false);
+    std::vector<std::thread> threads;
+    threads.reserve(n_threads);
+    for (size_t i = 0; i < n_threads; i++) {
+        threads.emplace_back([&, i]() {
+            ok[i] = prefetch_connection(endpoint.c_str());
+        });
+    }
+    for (auto & thread : threads) {
+        thread.join();
+    }
+    for (uint8_t result : ok) {
+        if (!result) {
+            fprintf(stderr, "concurrent RPC prefetch failed for %s\n", endpoint.c_str());
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool check_unreachable_prefetch_timing(prefetch_connection_fn prefetch_connection, const std::string & endpoints) {
+    std::vector<std::string> rpc_servers = split_endpoints(endpoints);
+    if (rpc_servers.size() < 2) {
+        fprintf(stderr, "GGML_RPC_TEST_UNREACHABLE_ENDPOINTS must contain at least two comma-separated endpoints\n");
+        return false;
+    }
+
+    int64_t start = now_ms();
+    if (prefetch_connection(rpc_servers[0].c_str())) {
+        fprintf(stderr, "expected unreachable RPC endpoint: %s\n", rpc_servers[0].c_str());
+        return false;
+    }
+    int64_t single_ms = now_ms() - start;
+
+    std::vector<uint8_t> ok(rpc_servers.size(), false);
+    std::vector<std::thread> threads;
+    threads.reserve(rpc_servers.size());
+    start = now_ms();
+    for (size_t i = 0; i < rpc_servers.size(); i++) {
+        threads.emplace_back([&, i]() {
+            ok[i] = prefetch_connection(rpc_servers[i].c_str());
+        });
+    }
+    for (auto & thread : threads) {
+        thread.join();
+    }
+    int64_t parallel_ms = now_ms() - start;
+
+    for (size_t i = 0; i < ok.size(); i++) {
+        if (ok[i]) {
+            fprintf(stderr, "expected unreachable RPC endpoint: %s\n", rpc_servers[i].c_str());
+            return false;
+        }
+    }
+    if (parallel_ms > single_ms * 3 / 2 + 1000) {
+        fprintf(stderr, "parallel unreachable RPC prefetch took too long: single=%lld ms parallel=%lld ms\n",
+                (long long) single_ms, (long long) parallel_ms);
+        return false;
+    }
+    printf("unreachable RPC prefetch timing: single=%lld ms parallel=%lld ms\n",
+           (long long) single_ms, (long long) parallel_ms);
     return true;
 }
 
@@ -39,10 +136,26 @@ static ggml_backend_ptr init_backend(const std::string & endpoint, ggml_backend_
 }
 
 int main() {
+    ggml_backend_load_all();
+
+    auto prefetch_connection = get_prefetch_connection();
+    if (prefetch_connection == nullptr) {
+        fprintf(stderr, "RPC prefetch connection function is unavailable\n");
+        return 1;
+    }
+
+    const char * unreachable_endpoints_env = std::getenv("GGML_RPC_TEST_UNREACHABLE_ENDPOINTS");
+    bool ran_unreachable_test = unreachable_endpoints_env != nullptr;
+    if (ran_unreachable_test) {
+        if (!check_unreachable_prefetch_timing(prefetch_connection, unreachable_endpoints_env)) {
+            return 1;
+        }
+    }
+
     const char * endpoints_env = std::getenv("GGML_RPC_TEST_ENDPOINTS");
     if (endpoints_env == nullptr) {
-        printf("GGML_RPC_TEST_ENDPOINTS is not set, skipping RPC integration test\n");
-        return 77;
+        printf("GGML_RPC_TEST_ENDPOINTS is not set, skipping live RPC integration test\n");
+        return ran_unreachable_test ? 0 : 77;
     }
 
     std::string endpoints(endpoints_env);
@@ -54,7 +167,9 @@ int main() {
     std::string endpoint_a = endpoints.substr(0, separator);
     std::string endpoint_b = endpoints.substr(separator + 1);
 
-    ggml_backend_load_all();
+    if (!check_concurrent_prefetch(prefetch_connection, endpoint_a)) {
+        return 1;
+    }
 
     ggml_backend_dev_t device_a  = nullptr;
     ggml_backend_dev_t device_b  = nullptr;

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <atomic>
 #include <chrono>
 #include <cinttypes>
 #include <clocale>
@@ -25,6 +26,7 @@
 #include "download.h"
 #include "fit.h"
 #include "ggml.h"
+#include "ggml-rpc.h"
 #include "llama.h"
 #include "log.h"
 
@@ -189,7 +191,38 @@ static void register_rpc_server_list(const std::string & servers) {
     if (!ggml_backend_rpc_add_server_fn) {
         throw std::invalid_argument("failed to find RPC add server function");
     }
-    for (const auto & server : rpc_servers) {
+    using prefetch_rpc_connection_fn = bool (*)(const char * endpoint);
+    auto * ggml_backend_rpc_prefetch_connection_fn = (prefetch_rpc_connection_fn) ggml_backend_reg_get_proc_address(rpc_reg, "ggml_backend_rpc_prefetch_connection");
+    if (!ggml_backend_rpc_prefetch_connection_fn) {
+        throw std::invalid_argument("failed to find RPC prefetch connection function");
+    }
+
+    std::vector<uint8_t> prefetch_ok(rpc_servers.size(), false);
+    std::vector<std::thread> prefetch_threads;
+    std::atomic<size_t> next_server(0);
+    const size_t n_prefetch_threads = std::min(rpc_servers.size(), (size_t) GGML_RPC_MAX_SERVERS);
+    prefetch_threads.reserve(n_prefetch_threads);
+    for (size_t i = 0; i < n_prefetch_threads; i++) {
+        prefetch_threads.emplace_back([&]() {
+            while (true) {
+                size_t server = next_server++;
+                if (server >= rpc_servers.size()) {
+                    break;
+                }
+                prefetch_ok[server] = ggml_backend_rpc_prefetch_connection_fn(rpc_servers[server].c_str());
+            }
+        });
+    }
+    for (auto & thread : prefetch_threads) {
+        thread.join();
+    }
+
+    for (size_t i = 0; i < rpc_servers.size(); i++) {
+        if (!prefetch_ok[i]) {
+            LOG_WRN("failed to connect to RPC server %s\n", rpc_servers[i].c_str());
+            continue;
+        }
+        const auto & server = rpc_servers[i];
         auto reg = ggml_backend_rpc_add_server_fn(server.c_str());
         ggml_backend_register(reg);
     }


### PR DESCRIPTION
## Overview

### Problem

`get_command_queue()` held one mutex across its entire body, including the
blocking `rpc_command_queue::create(endpoint)` call — the TCP connect and
protocol hello, up to `RPC_CLIENT_CONNECT_TIMEOUT_MS` on an unreachable
host. Registering N independent `--rpc` endpoints therefore cost N times one
endpoint's connect time, even though the endpoints are independent of each
other. In practice this means any single node that's down, still booting, or
slow to answer serially delays every other endpoint queued behind it in the
list — and it's paid on every `load()`/`reload()` that specifies multiple
`rpc-servers`, not just once at process startup.

### Fix

Narrow the lock to the connection-cache bookkeeping only; do the actual
connect outside the lock; re-check the cache afterward in case a concurrent
call for the same endpoint already published a connection, so two live
command-queue threads never end up racing on the same socket.

Also exports `ggml_backend_rpc_prefetch_connection()`: connects to an
endpoint and caches it without registering it as a backend, so a caller
adding several servers at once can warm all of their connections in
parallel, then call `ggml_backend_rpc_add_server()` for each in the order it
wants device numbering assigned. `add_server()` keeps its own existing lock
(protects `dev_id`/`reg_map` bookkeeping, unchanged here) and stays exactly
as sequential and deterministic as it always was — by the time it runs per
endpoint, the connect is already a cache hit instead of a fresh one, so it's
the network wait that moves off the critical path, not the registration
order.

## Testing

Three targeted timing tests, all using distinct unreachable hosts (not just
different ports on one host — same-host repeat connects can have their
unreachability cached by the OS, which produces a false-flat result
independent of any code change):

- **Concurrent `prefetch_connection()` alone:** n=1 and n=3 endpoints both
  ~5s (flat) — this is the actual mechanism this patch fixes.
- **`add_server()` alone, sequential** (today's only path without
  prefetching): n=1 ~5s, n=3 ~15s — confirms this really is the pre-fix
  cost, and that it's unaffected by this patch by design (see note below).
- **Full prefetch-then-add_server flow** (what a caller actually does): n=1
  and n=3 both ~5s (flat).

## Scope / impact

Not a correctness fix — a latency issue. Zero effect with a single RPC
endpoint. Impact scales with (a) how many endpoints are registered together
and (b) how slow any one of them is to respond; the worst case is a handful
of endpoints where one is unreachable, which pays the full connect timeout
serially today. Reasonable to land alongside or after the pipeline-parallel
ACCEL fix in a follow-up, since it's independent and lower urgency.

## Note for review

`ggml_backend_rpc_add_server()` intentionally keeps its own separate mutex
around its whole body — untouched here — so calling it concurrently still
serializes today, by design, to preserve deterministic `RPC0`/`RPC1`/...
numbering. The fix works because callers are expected to call the new
`prefetch_connection()` concurrently *first*. Flagging this explicitly since
testing `add_server()` concurrency directly (the more obvious thing to test)
would look like the patch does nothing.

This is a concurrency change (double-checked locking, shared cache map) —
would appreciate a second pair of eyes on the thread-safety reasoning
specifically; only exercised up to 3 concurrent endpoints, not stress-tested
at higher concurrency.