### PR TITLE
ggml-cuda: make GGML_CUDA_RESTRICT architecture independent

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1640,11 +1640,19 @@ static bool ggml_cuda_kernel_can_use_pdl(const void * kernel) {
 #endif //defined(GGML_CUDA_USE_PDL)
 
 // PDL and __restrict__ need to be mutually exclusive, see https://github.com/ggml-org/llama.cpp/pull/24030
-# if (defined(GGML_CUDA_USE_PDL) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= GGML_CUDA_CC_HOPPER)
+//
+// Must NOT depend on __CUDA_ARCH__: this appears in __global__ template
+// signatures, and nvcc builds the host launch stub for those from the device
+// pass, so an arch-dependent expansion makes the stub stop matching its own
+// declaration. It only breaks when the arch list spans generations, which
+// ggml's own default list does. GGML_CUDA_USE_PDL is already per-build, so
+// keying off it alone keeps the two exclusive with one uniform expansion. Cost
+// is losing __restrict__ on pre-Hopper in a PDL build, a hint, not correctness.
+# if defined(GGML_CUDA_USE_PDL)
 # define GGML_CUDA_RESTRICT
 # else
 # define GGML_CUDA_RESTRICT __restrict__
-# endif // defined(GGML_CUDA_USE_PDL) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= GGML_CUDA_CC_HOPPER
+# endif // defined(GGML_CUDA_USE_PDL)
 
 template<typename Kernel, typename... Args>
 static __inline__ void ggml_cuda_kernel_launch(Kernel kernel, const ggml_cuda_kernel_launch_params & launch_params, Args&&... args) {


### PR DESCRIPTION
## What

```diff
-# if (defined(GGML_CUDA_USE_PDL) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= GGML_CUDA_CC_HOPPER)
+# if defined(GGML_CUDA_USE_PDL)
```

`GGML_CUDA_RESTRICT` must not depend on `__CUDA_ARCH__`. Today the CUDA backend fails to compile whenever the architecture list spans more than one GPU generation.

## Why

The macro appears in `__global__` template signatures, and nvcc emits the host-side launch stub for those from the device-pass parse. The host pass has no `__CUDA_ARCH__` and always sees `__restrict__`, while a device pass at Hopper or newer sees nothing, so the stub stops matching the visible declaration:

```
error: template-id '__wrapper__device_stub_sigmoid_back_cuda<__half>'
  does not match any template declaration
note: candidate is: template<class T> void
  __wrapper__device_stub_sigmoid_back_cuda(const T* __restrict__&, ...)
```

A build whose device passes are all pre-Hopper agrees with the host pass by accident, which is why this has gone unnoticed. ggml's own default architecture list spans generations, so the CUDA backend does not build there at all. Measured on CUDA 13.3:

```
86 alone   ok      86 + 89     ok      (both pre-Hopper)
86 + 90    fails   86 + 120a   fails   (crosses into Hopper/Blackwell)
```

Identical on CUDA 12.8 and 13.3, and with both g++ and clang++ as host, with no GPU involved, so it is not machine, toolkit or host-compiler specific. Several files are affected, `sigmoid-back.cu` and `gated_delta_net_back.cu` among them, so excluding individual sources is not a workaround.

`GGML_CUDA_USE_PDL` is a per-build decision and already architecture independent, so keying off it alone keeps PDL and `__restrict__` mutually exclusive as ggml-org/llama.cpp#24030 requires, with one uniform expansion. The cost is losing `__restrict__` on pre-Hopper architectures inside a PDL-enabled build, an optimisation hint rather than a correctness property.

## How was it tested

Against `v10297.0.0` with CUDA 13.3, compiling sm_86 and sm_120a together. No GPU needed, this is a pure compile failure.

```
nvcc -Iggml/src/ggml-cuda/.. -Iggml/src/../include -Iggml/include -Iggml/src \
  -O3 -std=c++17 --generate-code=arch=compute_86,code=[sm_86] \
  --generate-code=arch=compute_120a,code=[sm_120a] -use_fast_math \
  -extended-lambda -c ggml/src/ggml-cuda/gated_delta_net_back.cu
```

| | before | after |
|---|---|---|
| `gated_delta_net_back.cu` | 8 errors | exit 0, object written |
| `sigmoid-back.cu` | fails | exit 0, object written |

No GPU run. The change cannot alter emitted device code beyond dropping a `__restrict__` hint on pre-Hopper.

## Context

Found while adding CUDA to the NLP addons under QVAC-23763, which ships sm_86, sm_87 and sm_120 and so necessarily spans generations. Based on `temp-10297` so it can go into the next tag from that line.
