### PR TITLE
xdna : selective hybrid CPU/NPU execution for Qwen3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ Enhanced GPU support with targeted optimizations for Qualcomm Adreno GPUs.
 - Adreno-specific Vulkan shader variants for improved throughput.
 - Vulkan Memory Allocator (VMA) integration for efficient GPU memory management.
 
+### AMD XDNA (NPU) Backend *(exclusive)*
+
+Offloads weight `MUL_MAT` to the AMD XDNA2 NPU (Strix Halo / Ryzen AI MAX). Prefill GEMM runs on the NPU; decode stays on nested CPU. Device name for `--device` is `XDNA`.
+
+Build and run instructions, IRON 1.3.4 install, and `--device` semantics: [docs/backend/XDNA.md](docs/backend/XDNA.md).
+
+```bash
+source /opt/xilinx/xrt/setup.sh
+cmake -B build -DGGML_XDNA=ON \
+    -DGGML_XDNA_IRON_PYTHON=$HOME/ironenv/bin/python3
+cmake --build build -j --target llama-completion llama-server
+./build/bin/llama-completion --list-devices
+./build/bin/llama-completion -m model.gguf --device XDNA -ngl 99 -p "Hello" -n 32
+```
+
 
 ## Quick Start
 
@@ -112,6 +127,13 @@ cmake --build build --config Release
 # With Metal support (macOS, iOS)
 cmake -B build -DGGML_METAL=ON
 cmake --build build --config Release
+
+# With AMD XDNA NPU support (Linux, Strix Halo). Needs XRT + mlir-aie 1.3.4.
+# See docs/backend/XDNA.md.
+source /opt/xilinx/xrt/setup.sh
+cmake -B build -DGGML_XDNA=ON \
+    -DGGML_XDNA_IRON_PYTHON=$HOME/ironenv/bin/python3
+cmake --build build --config Release
 ```
 
 For more detailed build instructions, see [docs/build.md](docs/build.md).
@@ -128,7 +150,7 @@ For more detailed build instructions, see [docs/build.md](docs/build.md).
 
 | Platform | Backend | Status |
 |----------|---------|--------|
-| Linux (x86_64, ARM64) | CPU, Vulkan, CUDA | ✅ Full support |
+| Linux (x86_64, ARM64) | CPU, Vulkan, CUDA, XDNA (NPU, x86_64 Strix Halo) | ✅ Full support |
 | macOS (Intel, Apple Silicon) | CPU, Metal | ✅ Full support |
 | Windows (x86_64) | CPU, Vulkan, CUDA | ✅ Full support |
 | Android (ARM64) | CPU, Vulkan, OpenCL | ✅ Full support |
@@ -152,6 +174,7 @@ The following features are developed in qvac-fabric-llm.cpp and are not availabl
 | BitNet inference and training | TQ2_0 quantization on Vulkan, Metal, and CPU for inference and LoRA fine-tuning; extends [microsoft/BitNet](https://github.com/microsoft/BitNet) beyond its CUDA-only GPU support |
 | Memory-based model loading | Load models from in-memory buffers with split-model and async fulfillment support |
 | Mobile GPU optimization | Adreno 800+ quantized inference (Q4_0, Q8), Adreno-specific Vulkan shader variants, VMA integration |
+| AMD XDNA NPU backend | Weight GEMM offload to XDNA2 (`--device XDNA`); see [docs/backend/XDNA.md](docs/backend/XDNA.md) |
 
 ### Upstream Compatibility
 

--- a/docs/backend/XDNA.md
+++ b/docs/backend/XDNA.md
@@ -1,0 +1,482 @@
+# AMD XDNA backend
+
+The XDNA backend offloads weight `MUL_MAT` operations to the AMD XDNA2 NPU.
+All other operations use the standard GGML CPU backend. The production build
+contains two BF16 GEMM artifacts and no model-specific fused kernels.
+
+## Validated environment
+
+The backend targets the XDNA2 (`aie2p`) NPU on Linux. Everything in this
+document was built and measured on one machine:
+
+| | Value |
+| --- | --- |
+| Host | ASUS ProArt PX13 HN7306EA, AMD Ryzen AI MAX+ 395 w/ Radeon 8060S (Strix Halo), 27 GiB RAM |
+| NPU | `NPU Strix Halo`, `aie2p`, 6x8 topology, BDF `0000:c5:00.1` |
+| OS | Ubuntu 24.04.4 LTS, kernel 7.0.0-28-generic, Python 3.12 |
+| XRT | 2.25.37 under `/opt/xilinx/xrt` |
+| `amdxdna` driver | 2.25.260102.56.release_20260630 (DKMS) |
+| NPU firmware | 1.1.2.65 |
+| IRON | mlir-aie **1.3.4** + llvm-aie 21 (`~/ironenv`) |
+| Models | Qwen3.5-0.8B Q4_K_M and BF16, Qwen3.5-9B Q4_K_M |
+
+`xrt-smi examine` reports the XRT, driver, firmware and device rows. The NPU
+has to appear there before `--device XDNA` can do anything.
+
+mlir-aie **1.4.1 is not compatible** with this branch. The production GEMM
+design constructs `Runtime()` with no arguments; 1.4.1 requires `seq_fn` and
+fails at compile time with `TypeError: Runtime.__init__() missing 1 required
+positional argument: 'seq_fn'`. Use 1.3.4.
+
+## Dependencies
+
+Install these **before** running CMake. Kernel compilation needs all three;
+the C++ binary needs XRT at runtime even if the `.xclbin` files are copied in.
+
+### 1. XRT and the `amdxdna` driver
+
+XRT 2.25.x must live under `/opt/xilinx/xrt` (or `$XILINX_XRT`) and the
+`amdxdna` DKMS module must match that XRT. After install:
+
+```sh
+source /opt/xilinx/xrt/setup.sh
+xrt-smi examine
+```
+
+The table must list an `aie2p` device (on the validated box: `NPU Strix Halo`).
+`xclbinutil` has to be on `PATH` (it comes with XRT) or kernel compilation
+fails. `pyxrt` is imported from `/opt/xilinx/xrt/python`, which `setup.sh`
+puts on `PYTHONPATH`.
+
+Optional, before a timed run:
+
+```sh
+xrt-smi configure --pmode performance
+```
+
+### 2. IRON toolchain (mlir-aie 1.3.4)
+
+Wheels are not on PyPI. Install them from the Xilinx GitHub release indexes
+into a dedicated venv. Do **not** point CMake at a 1.4.1 environment.
+
+```sh
+python3 -m venv "$HOME/ironenv"
+"$HOME/ironenv/bin/pip" install -U pip
+"$HOME/ironenv/bin/pip" install mlir-aie==1.3.4 \
+    -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.3.4
+"$HOME/ironenv/bin/pip" install 'llvm-aie==21.0.0.2026073101+cfd8aae2' \
+    -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/latest-wheels
+
+source /opt/xilinx/xrt/setup.sh
+"$HOME/ironenv/bin/python3" -c "import mlir_aie, aie.iron, pyxrt; print('ok')"
+```
+
+The llvm-aie pin is the version used with mlir-aie 1.3.4 on the validated
+box. A later `llvm-aie` 22 wheel (the current `latest-wheels` default) belongs
+with mlir-aie 1.4.1 and is not the toolchain for this branch.
+
+CMake looks for `$HOME/ironenv/bin/python3` by default
+(`-DGGML_XDNA_IRON_PYTHON`). Override that if the venv lives elsewhere.
+
+For interactive kernel work, `source ggml/src/ggml-xdna/iron/env_setup.sh`
+after activating the venv; CMake already does the equivalent through
+`build-kernels.sh`.
+
+## Build
+
+XRT must be sourced in the CMake shell so the backend can link
+`libxrt_coreutil.so`. `-DGGML_OPENMP=ON` is the default and is required for
+the host pack/scatter path used at runtime.
+
+```sh
+source /opt/xilinx/xrt/setup.sh
+cmake -B build -DGGML_XDNA=ON -DGGML_OPENMP=ON \
+    -DGGML_XDNA_IRON_PYTHON="$HOME/ironenv/bin/python3"
+cmake --build build -j --target llama-completion llama-server
+```
+
+`GGML_XDNA_BUILD_KERNELS` defaults to `ON`. The production build generates
+two GEMM artifact pairs next to the binaries:
+
+```text
+build/bin/ggml-xdna-gemm-npu2-bf16-16-16.{xclbin,insts.bin}   # MB=16, M block 2048
+build/bin/ggml-xdna-gemm-npu2-bf16-16-32.{xclbin,insts.bin}   # MB=32, M block 4096
+```
+
+Kernel compilation takes several minutes and needs `xclbinutil`. Set
+`GGML_XDNA_BUILD_KERNELS=OFF` only when those four files are already in
+`build/bin/` (or `$GGML_XDNA_KERNELS_DIR`). The runtime searches
+`GGML_XDNA_KERNELS_DIR`, `GGML_BACKEND_DIR`, the executable directory, and
+the current directory.
+
+The artifacts are build products. They are not stored in git.
+
+Without XRT headers the C++ backend still compiles, but
+`ggml_backend_xdna_reg_get_device_count` returns 0 and `--list-devices`
+will not show `XDNA`.
+
+### Dynamic backend library
+
+`ggml-xdna` uses the same `ggml_add_backend_library` path as other ggml
+backends, including `GGML_BACKEND_DL_IMPL`. To build it as a loadable module:
+
+```sh
+cmake -B build-dl -DGGML_XDNA=ON -DGGML_BACKEND_DL=ON -DBUILD_SHARED_LIBS=ON \
+    -DGGML_XDNA_IRON_PYTHON="$HOME/ironenv/bin/python3"
+cmake --build build-dl -j --target llama-completion ggml-xdna
+```
+
+That writes `build-dl/bin/libqvac-ggml-xdna.so` next to `llama-completion`.
+Keep the GEMM artifacts in the same directory, or set `GGML_XDNA_KERNELS_DIR`.
+
+## `--device` / `-dev`
+
+This backend registers a ggml device whose **name is always `XDNA`**. That is
+the string `--device` / `-dev` must be given. XRT's PCI name (`NPU Strix Halo`
+on the validated box) is only the description; it is not accepted by
+`--device`.
+
+`--device` is parsed by `parse_device_list`: a comma-separated list of ggml
+device names, looked up with `ggml_backend_dev_by_name`. The special value
+`none` disables offload. The same list is accepted via `LLAMA_ARG_DEVICE`.
+`XDNA` has no spaces, so it does not need quoting. `--list-devices` prints
+every non-CPU device and exits.
+
+| Flag | Effect on this backend |
+| --- | --- |
+| `--device XDNA` | Use the XDNA ACCEL device for offload. Required for the NPU GEMM path. |
+| `-dev XDNA` | Same as `--device XDNA`. |
+| `--device none` | Do not put XDNA on the llama.cpp offload device list. Weight repack can still happen: `XDNA_REPACK` is an extra ACCEL buffer type on the CPU list. For a CPU-only run also set `GGML_XDNA_NPU=0`. |
+| (omit `--device`) | llama.cpp may still pick XDNA as an ACCEL device. Pass `--device XDNA` explicitly. |
+| `-ngl 99` | Standard llama.cpp offload count. Use this with `--device XDNA`. |
+| `-ngl 0` | Layers stay on the CPU device, but `XDNA_REPACK` extra bufts are still considered unless `GGML_XDNA_NPU=0`. |
+
+`GGML_XDNA_NPU` is independent of `--device`:
+
+- `GGML_XDNA_NPU=1` (default): if the NPU is present and both GEMM artifacts
+  are found, `XDNA_REPACK` is offered and prefill `MUL_MAT` with `M >= 128`
+  runs on the NPU.
+- `GGML_XDNA_NPU=0`: the device can still appear in `--list-devices` (XRT
+  probe succeeded), but extra bufts are not offered and nothing is submitted
+  to the NPU.
+
+`--list-devices` shows `XDNA` only when XRT actually found an NPU
+(`npu_present`). It still shows `XDNA` when artifacts are missing or
+`GGML_XDNA_NPU=0`; the description then says `(no NPU kernels)` or the
+init log lists `kernels=none`. If `XDNA` is absent entirely: XRT is not
+sourced, `libxrt_coreutil` was not linked, or no NPU is visible to
+`xrt-smi examine`.
+
+On a healthy production build the line looks like:
+
+```text
+  XDNA: AMD XDNA NPU Strix Halo (NPU GEMM_MB16, GEMM_MB32) [own-graph] (0 MiB, 0 MiB free)
+```
+
+The memory fields are always 0; this backend does not report device DRAM.
+
+## E2E CLI
+
+XRT must be sourced in the **same shell** that runs the binary. The
+implementation check is `llama-completion`; `llama-server` is the same
+backend with an HTTP front-end. `llama-cli` accepts the same `--device`
+flag.
+
+### 1. Confirm the device
+
+```sh
+source /opt/xilinx/xrt/setup.sh
+./build/bin/llama-completion --list-devices
+```
+
+### 2. One-shot completion (implementation check)
+
+```sh
+GGML_XDNA_NPU=1 OMP_WAIT_POLICY=PASSIVE \
+    ./build/bin/llama-completion \
+    -m Qwen3.5-0.8B-Q4_K_M.gguf \
+    --device XDNA -ngl 99 \
+    -p "The capital of France is" -n 32 \
+    --top-k 1 --temp 0 -s 42 \
+    -t 16 --poll 0 --flash-attn off -c 2048
+```
+
+The init log must contain:
+
+```text
+ggml_backend_xdna_init: XDNA backend init: device=NPU Strix Halo, kernels=GEMM_MB16, GEMM_MB32, own_graph=on
+```
+
+`device=` is the XRT name of this machine's NPU. `kernels=` must list
+`GEMM_MB16, GEMM_MB32` and must not list ADD, MUL, RMS_NORM, or GDN.
+
+Greedy CPU reference (same binary, NPU disabled):
+
+```sh
+GGML_XDNA_NPU=0 OMP_WAIT_POLICY=PASSIVE \
+    ./build/bin/llama-completion \
+    -m Qwen3.5-0.8B-Q4_K_M.gguf \
+    --device none -ngl 0 \
+    -p "The capital of France is" -n 32 \
+    --top-k 1 --temp 0 -s 42 \
+    -t 16 --poll 0 --flash-attn off -c 2048
+```
+
+The first greedy answer should match. Token equality after that is not a
+numerical correctness test; use `test-xdna-production micro` for NMSE against
+a CPU reference.
+
+`GGML_XDNA_DEBUG=1` reports which ops the backend accepted, per-artifact NPU
+run counts and submit time, host pack/scatter time, and nested CPU totals.
+Output text alone cannot tell the two paths apart.
+
+### 3. Server (the Qwen3.5-0.8B measurement configuration)
+
+```sh
+GGML_XDNA_NPU=1 OMP_WAIT_POLICY=PASSIVE \
+    ./build/bin/llama-server -m Qwen3.5-0.8B-Q4_K_M.gguf \
+    --host 127.0.0.1 --port 8080 \
+    -c 147456 -np 4 -b 4096 -ub 4096 --flash-attn off \
+    -t 16 --poll 0 --device XDNA -ngl 99
+```
+
+CPU baseline for a fair comparison. Keep `OMP_WAIT_POLICY` identical: the NPU
+path blocks on XRT completions, and an active OpenMP spin loop burns CPU that
+the baseline never spends. `GGML_XDNA_NPU=0` is required; `--device none`
+alone is not enough (see `--device` above).
+
+```sh
+GGML_XDNA_NPU=0 OMP_WAIT_POLICY=PASSIVE \
+    ./build/bin/llama-server -m Qwen3.5-0.8B-Q4_K_M.gguf \
+    --host 127.0.0.1 --port 8080 \
+    -c 147456 -np 4 -b 4096 -ub 4096 --flash-attn off \
+    -t 16 --poll 0 --device none -ngl 0
+```
+
+### 4. 9B memlock
+
+Qwen3.5-9B packs about 13 GiB into `XDNA_REPACK` (`MAP_LOCKED`). If
+`RLIMIT_MEMLOCK` is the usual 1/8 of RAM, raise it for that session:
+
+```sh
+sudo prlimit --pid $$ --memlock=unlimited:unlimited
+```
+
+## Execution contract
+
+The backend's default `own_graph` mode claims the graph so model weights can be
+placed in `XDNA_REPACK`. Within that graph:
+
+- supported weight `MUL_MAT` operations with sufficiently large M run on the
+  NPU;
+- decode-sized weight `MUL_MAT` operations use the original quantized weights
+  through a nested instance of the standard GGML CPU backend;
+- every other operation uses that same standard CPU backend unchanged.
+
+The XDNA backend does not contain private CPU implementations of model
+operations. Host work in the NPU path is limited to weight conversion at model
+load and activation packing/result scattering for each GEMM.
+
+`GGML_XDNA_NPU=0`, a missing NPU, or failure to initialize both GEMM artifacts
+prevents XDNA weight placement and leaves execution on the regular CPU path.
+A failure after an NPU submission has started is reported as a compute error;
+it is not silently recomputed on the CPU.
+
+## Supported MUL_MAT
+
+For `dst = src0 * src1`:
+
+- `src0` is a two-dimensional weight tensor stored in `XDNA_REPACK`;
+- `src1` is a contiguous F32 activation matrix;
+- `dst` is contiguous F32;
+- K is a positive multiple of 64;
+- N is a positive multiple of 512 and no greater than 16384;
+- M is unrestricted for placement, but only M greater than or equal to
+  `GGML_XDNA_GEMM_M_MIN` runs on the NPU by default;
+- batched dimensions `ne[2]` and `ne[3]` must both be one.
+
+GGUF weights with a `to_float` trait (quantized, BF16, F16) are converted row
+by row. The NPU therefore reads a swizzled BF16 copy rather than the source
+layout. F32 activations are not placed in `XDNA_REPACK`.
+With `GGML_XDNA_KEEP_SRC=1` (the default), the original GGUF bytes live in a
+regular host allocation so nested CPU decode uses the same kernels and the
+same DRAM as `-ngl 0`. The XRT buffer holds only the swizzled BF16 copy the
+NPU reads.
+
+## GEMM layout
+
+The production geometry is:
+
+```text
+TILE_M = 32
+TILE_K = 64
+TILE_N = 64
+grid   = 4 x 8
+KT     = 16
+K per submit = 1024
+N per submit = 512
+```
+
+Two artifacts differ only in the number of M blocks:
+
+```text
+MB=16: M block = 16 * 4 * 32 = 2048
+MB=32: M block = 32 * 4 * 32 = 4096
+```
+
+M greater than `GGML_XDNA_GEMM_MB32_MIN` selects MB=32. K values larger than
+1024 are split and accumulated. M and partial K blocks are zero-padded by the
+host. N is not padded in the production weight path.
+
+Weights are laid out as:
+
+```text
+[n_block][k_block][grid_column][k_tile][8x8-swizzled tile]
+```
+
+Activations and results use the corresponding 8x8 MMUL micro-tile order.
+Weights and activations are converted to BF16; each NPU K-slice produces F32,
+and the host accumulates K-slices into the final F32 tensor.
+
+## Buffer and kernel lifetime
+
+`XDNA_REPACK` allocations are XRT host-only buffer objects mapped into the
+process and visible to the NPU. They hold the swizzled BF16 copy. With
+`KEEP_SRC=1`, original GGUF bytes are a separate host allocation used by nested
+CPU decode. Weights are packed and synchronized once when the model is loaded.
+
+Each GEMM artifact owns one `xrt::hw_context` and one persistent kernel handle.
+Contexts are initialized lazily, shared by backend instances, and remain alive
+until process exit. Per-submit A and C buffers are also persistent. Two banks
+allow the host to pack the next M block while the previous run completes.
+Multiple K-slices are submitted through one `xrt::runlist`.
+
+The production build therefore uses at most two of the 16 hardware contexts
+available on the validated XDNA2 device.
+
+## Runtime settings
+
+A first run needs only `--device XDNA`, `-ngl 99`, and a sourced XRT
+environment. Defaults already enable the NPU (`GGML_XDNA_NPU=1`,
+`GGML_XDNA_GEMM=1`, `GGML_XDNA_OWN_GRAPH=1`). For any timed comparison against
+CPU, also set `OMP_WAIT_POLICY=PASSIVE` on **both** sides, and set
+`GGML_XDNA_NPU=0` on the CPU side.
+
+| Variable | Default | Purpose |
+| --- | ---: | --- |
+| `GGML_XDNA_NPU` | `1` | Enable XDNA device execution |
+| `GGML_XDNA_GEMM` | `1` | Enable production weight GEMM |
+| `GGML_XDNA_GEMM_MB` | `16` | MB used by the first artifact |
+| `GGML_XDNA_GEMM_MB16` | `1` | Enable the MB=16 slot |
+| `GGML_XDNA_GEMM_MB32` | `1` | Enable the MB=32 slot |
+| `GGML_XDNA_GEMM_MB32_MIN` | `2048` | Select MB=32 when M is greater than this |
+| `GGML_XDNA_GEMM_M_MIN` | `128` | Minimum M submitted to the NPU |
+| `GGML_XDNA_GEMM_KB_MAX` | `16` | Maximum K-slices in one runlist |
+| `GGML_XDNA_GEMM_BANKS` | `2` | Number of A/C ping-pong banks |
+| `GGML_XDNA_KEEP_SRC` | `1` | Keep original GGUF bytes in host DRAM |
+| `GGML_XDNA_OWN_GRAPH` | `1` | Use nested standard CPU fallback |
+| `GGML_XDNA_HOST_THREADS` | `8` | Threads used for GEMM pack/scatter |
+| `GGML_XDNA_KERNELS_DIR` | unset | Additional artifact directory |
+| `GGML_XDNA_WARMUP` | `4` | Warm-up submissions after context creation |
+| `GGML_XDNA_CLFLUSH` | `1` | Invalidate mapped result cache lines |
+| `GGML_XDNA_DEBUG` | `0` | Enable backend diagnostics |
+| `GGML_XDNA_HOST_PROFILE` | `0` | Profile nested CPU operations; diagnostic only |
+
+## Experimental kernels
+
+Default Phase 1 (`-DGGML_XDNA=ON`, `GGML_XDNA_EXPERIMENTAL` off) compiles and
+runs only the two weight-GEMM artifacts. GDN, ADD, MUL, RMS_NORM, fused
+pre-norm, and activation-GEMM do **not** run.
+
+To compile those research kernels:
+
+```sh
+cmake -B build-exp -DGGML_XDNA=ON -DGGML_XDNA_EXPERIMENTAL=ON \
+    -DGGML_XDNA_IRON_PYTHON="$HOME/ironenv/bin/python3"
+cmake --build build-exp -j --target llama-completion
+```
+
+That is not enough at runtime. The exact value `GGML_XDNA_ENABLE_EXPERIMENTAL=1`
+is also required; any other value leaves the experimental slots off.
+
+```sh
+GGML_XDNA_ENABLE_EXPERIMENTAL=1 ./build-exp/bin/llama-completion \
+    --device XDNA -ngl 99 -m MODEL -p "Hello" -n 32
+```
+
+With both gates set, experimental kernels still have their own switches:
+
+| Kernel | Artifact | Runtime enable | Default after both gates |
+| --- | --- | --- | --- |
+| ADD | `ggml-xdna-add-npu2-f32-<TILE>` | `GGML_XDNA_ADD` | on (`1`) |
+| MUL | `ggml-xdna-mul-npu2-f32-<TILE>` | `GGML_XDNA_MUL` | on (`1`) |
+| RMS_NORM | `ggml-xdna-rms-norm-npu2-f32-<RMS_ROW>` | `GGML_XDNA_RMS_NORM` | on (`1`) |
+| fused ADD+RMS_NORM+MUL | `ggml-xdna-add-rms-mul-npu2-f32-<RMS_ROW>` | off with `GGML_XDNA_DISABLE_FUSION=1` | on |
+| GATED_DELTA_NET | `ggml-xdna-gdn-npu2-s128-r32-cs64[-w4]` | `GGML_XDNA_GDN=1` | **off** |
+| GDN pre-L2 absorb | (host packing, no extra xclbin) | `GGML_XDNA_GDN_FUSE_PRE=1` | **off** |
+| activation GEMM | production GEMM artifact | `GGML_XDNA_ACT_GEMM=1` | **off** |
+
+GDN example:
+
+```sh
+GGML_XDNA_ENABLE_EXPERIMENTAL=1 GGML_XDNA_GDN=1 \
+    ./build-exp/bin/llama-completion --device XDNA -ngl 99 -m MODEL ...
+```
+
+None of this is part of the Phase 1 execution or performance contract.
+Phase 1 is single-op weight GEMM dispatch with nested CPU for everything else,
+including GDN.
+
+`GGML_XDNA_DEBUG` and `GGML_XDNA_HOST_PROFILE` are diagnostics on the
+production path. They do not enable experimental kernels.
+
+## Phase 1 coverage
+
+Present in this tree:
+
+- Weight `MUL_MAT` offload to the NPU for Qwen3.5 (0.8B, and 9B FFN `N=12288`
+  now that the compile-time `GGML_XDNA_GEMM_N_MAX` is 16384).
+- `llama-completion` E2E with `--device XDNA` / `-dev XDNA` and `-ngl 99`.
+- Two BF16 GEMM `.xclbin` artifacts, built by CMake when IRON is available.
+- Backend as a dynamic library via `-DGGML_BACKEND_DL=ON -DBUILD_SHARED_LIBS=ON`.
+- Nested standard CPU fallback (`GGML_XDNA_OWN_GRAPH=1`); no fusion on the
+  default path.
+- Microtest target `test-xdna-production` (`micro`, `fallback`, `no-npu`).
+
+Not in this tree, or not Phase 1:
+
+- `.xclbin` files are not committed; they must be built or copied into
+  `build/bin/`.
+- This branch is `xdna/selective-hybrid` on top of `exp-gemm`. It is not
+  automatically rebased onto a later Qvac drop; do that when the team provides
+  the new base.
+- Decode `MUL_MAT` (`M < GGML_XDNA_GEMM_M_MIN`) stays on nested CPU.
+- Attention QK/AV, GDN state update, RMS_NORM, ADD, MUL stay on CPU unless the
+  experimental build above is used.
+- `test-xdna-production` cannot be linked when `GGML_BACKEND_DL=ON`.
+- SoC RAPL energy is not available on the validated Ryzen AI MAX+ 395.
+
+## Validation
+
+```sh
+ctest --test-dir build -L xdna --output-on-failure
+
+GGML_XDNA_NPU=1 GGML_XDNA_OWN_GRAPH=1 ./build/bin/test-xdna-production micro
+GGML_XDNA_NPU=1 GGML_XDNA_OWN_GRAPH=1 ./build/bin/test-xdna-production fallback
+GGML_XDNA_NPU=0 GGML_XDNA_OWN_GRAPH=1 ./build/bin/test-xdna-production no-npu
+
+./build/bin/llama-completion \
+    -m Qwen3.5-0.8B-Q4_K_M.gguf \
+    --device XDNA -ngl 99 -p "Hello" -n 32
+```
+
+A passing `micro` run must increase the NPU GEMM call counter. Greedy token
+match alone is not a numerical correctness test.
+
+## Correctness
+
+The IRON GEMM design has a compile-time NumPy check using `rtol=0.2` and an
+absolute tolerance scaled by K. This loose elementwise bound reflects BF16
+input conversion and a different accumulation order. End-to-end changes must
+also pass the CPU-reference microtest and Qwen3.5 perplexity validation; greedy
+token equality alone is not a numerical correctness test.

--- a/docs/build.md
+++ b/docs/build.md
@@ -27,6 +27,7 @@ The following sections describe how to build with different backends and options
 * [OpenCL](#opencl)
 * [Android](#android-1)
 * [OpenVINO](#openvino)
+* [XDNA](#xdna)
 * [Notes about GPU-accelerated backends](#notes-about-gpu-accelerated-backends)
 
 ## CPU Build
@@ -756,6 +757,21 @@ Follow the instructions [here](https://dawn.googlesource.com/dawn/+/refs/heads/m
 ## IBM Z & LinuxONE
 
 To read documentation for how to build on IBM Z & LinuxONE, [click here](./build-s390x.md)
+
+## XDNA
+
+This provides NPU acceleration on AMD XDNA2 (Strix Halo / Ryzen AI MAX) using XRT. The ggml device name is `XDNA`; pass `--device XDNA`.
+
+XRT 2.25.x and mlir-aie **1.3.4** (not 1.4.1) are required. Install steps, CMake flags, and the E2E CLI are in [llama.cpp for XDNA](./backend/XDNA.md).
+
+```bash
+source /opt/xilinx/xrt/setup.sh
+cmake -B build -DGGML_XDNA=ON \
+    -DGGML_XDNA_IRON_PYTHON=$HOME/ironenv/bin/python3
+cmake --build build --config Release --target llama-completion
+./build/bin/llama-completion --list-devices
+./build/bin/llama-completion -m PATH_TO_MODEL --device XDNA -ngl 99 -p "Hello" -n 32
+```
 
 ## OpenVINO
 

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -274,6 +274,7 @@ set   (GGML_VULKAN_SHADERS_GEN_TOOLCHAIN "" CACHE FILEPATH "ggml: toolchain file
 
 option(GGML_ZENDNN                          "ggml: use ZenDNN"                                OFF)
 option(ZENDNN_ROOT                          "ggml: path to ZenDNN installation"               "")
+option(GGML_XDNA                            "ggml: use AMD XDNA (NPU) backend"                OFF)
 
 # extra artifacts
 option(GGML_BUILD_TESTS    "ggml: build tests"    ${GGML_STANDALONE})
@@ -338,6 +339,7 @@ set(GGML_PUBLIC_HEADERS
     include/ggml-vulkan.h
     include/ggml-webgpu.h
     include/ggml-zendnn.h
+    include/ggml-xdna.h
     include/ggml-openvino.h
     include/gguf.h)
 

--- a/ggml/include/ggml-xdna.h
+++ b/ggml/include/ggml-xdna.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+// AMD XDNA backend. Repacked weight MUL_MAT operations run on the NPU; with
+// own-graph enabled, unsupported operations use the standard CPU backend.
+
+GGML_BACKEND_API ggml_backend_t ggml_backend_xdna_init(void);
+
+GGML_BACKEND_API bool ggml_backend_is_xdna(ggml_backend_t backend);
+
+GGML_BACKEND_API ggml_backend_reg_t ggml_backend_xdna_reg(void);
+
+#ifdef  __cplusplus
+}
+#endif

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -507,6 +507,7 @@ ggml_add_backend(zDNN)
 ggml_add_backend(OpenCL)
 ggml_add_backend(Hexagon)
 ggml_add_backend(ZenDNN)
+ggml_add_backend(XDNA)
 ggml_add_backend(OPENVINO)
 
 foreach (target ggml-base ggml)

--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -84,6 +84,10 @@
 #include "ggml-zendnn.h"
 #endif
 
+#ifdef GGML_USE_XDNA
+#include "ggml-xdna.h"
+#endif
+
 #ifdef GGML_USE_OPENVINO
 #include "ggml-openvino.h"
 #endif
@@ -147,6 +151,9 @@ struct ggml_backend_registry {
 #endif
 #ifdef GGML_USE_ZENDNN
         register_backend(ggml_backend_zendnn_reg());
+#endif
+#ifdef GGML_USE_XDNA
+        register_backend(ggml_backend_xdna_reg());
 #endif
 #ifdef GGML_USE_HEXAGON
         register_backend(ggml_backend_hexagon_reg());

--- a/ggml/src/ggml-xdna/CMakeLists.txt
+++ b/ggml/src/ggml-xdna/CMakeLists.txt
@@ -1,0 +1,154 @@
+option(GGML_XDNA_BUILD_KERNELS "ggml-xdna: build NPU kernels with the IRON toolchain" ON)
+option(GGML_XDNA_EXPERIMENTAL "ggml-xdna: enable experimental kernels and graph paths" OFF)
+set(GGML_XDNA_TILE      "16384" CACHE STRING "ggml-xdna: elements per NPU submission")
+set(GGML_XDNA_DMA_TILE  "1024"  CACHE STRING "ggml-xdna: DMA tile size inside the designs")
+set(GGML_XDNA_RMS_ROW   "1024"  CACHE STRING "ggml-xdna: row length (ne0) baked into the RMS_NORM design")
+set(GGML_XDNA_GEMM_MB "16" CACHE STRING "ggml-xdna: row blocks per MUL_MAT submit (M = MB*128)")
+set(GGML_XDNA_IRON_PYTHON "$ENV{HOME}/ironenv/bin/python3" CACHE FILEPATH
+    "ggml-xdna: python interpreter with the IRON toolchain (mlir_aie + llvm-aie)")
+
+ggml_add_backend_library(ggml-xdna
+                         ggml-xdna.cpp
+                         xdna-npu.cpp
+                        )
+
+target_compile_definitions(ggml-xdna PRIVATE
+    GGML_XDNA_TILE=${GGML_XDNA_TILE}
+)
+if (GGML_XDNA_EXPERIMENTAL)
+    target_compile_definitions(ggml-xdna PRIVATE GGML_XDNA_EXPERIMENTAL=1)
+endif()
+
+# The host still packs GEMM operands into the swizzled layout the design reads,
+# which is pure memory traffic and the largest single cost of a prefill step.
+if (GGML_OPENMP)
+    find_package(OpenMP)
+    if (OpenMP_FOUND)
+        message(STATUS "ggml-xdna: parallelising host operand rearrangement with OpenMP")
+        target_compile_definitions(ggml-xdna PRIVATE GGML_XDNA_OPENMP=1)
+        target_link_libraries(ggml-xdna PRIVATE OpenMP::OpenMP_C OpenMP::OpenMP_CXX)
+    endif()
+endif()
+
+# XRT is the NPU runtime. It ships as a system package; without it the backend
+# still builds but reports no device.
+set(_XRT_ROOT "$ENV{XILINX_XRT}")
+if (NOT _XRT_ROOT)
+    set(_XRT_ROOT "/opt/xilinx/xrt")
+endif()
+
+if (EXISTS "${_XRT_ROOT}/include/xrt/xrt_device.h" AND EXISTS "${_XRT_ROOT}/lib/libxrt_coreutil.so")
+    message(STATUS "ggml-xdna: linking XRT from ${_XRT_ROOT}")
+    target_compile_definitions(ggml-xdna PRIVATE GGML_XDNA_HAS_XRT=1)
+    target_include_directories(ggml-xdna PRIVATE "${_XRT_ROOT}/include")
+    target_link_directories(ggml-xdna PRIVATE "${_XRT_ROOT}/lib")
+    target_link_libraries(ggml-xdna PRIVATE xrt_coreutil)
+    set_target_properties(ggml-xdna PROPERTIES
+        BUILD_RPATH   "${_XRT_ROOT}/lib"
+        INSTALL_RPATH "${_XRT_ROOT}/lib"
+    )
+
+    # Standalone residency diagnostic. Links XRT only - no ggml - so its answer
+    # about xclbin load/switch cost does not depend on the backend.
+    add_executable(xdna-probe xdna-probe.cpp)
+    target_include_directories(xdna-probe PRIVATE "${_XRT_ROOT}/include")
+    target_link_directories(xdna-probe PRIVATE "${_XRT_ROOT}/lib")
+    target_link_libraries(xdna-probe PRIVATE xrt_coreutil)
+
+    # xrt::uuid::to_string, used for the CSV, resolves against libuuid.
+    find_library(_XDNA_PROBE_UUID uuid)
+    if (_XDNA_PROBE_UUID)
+        target_link_libraries(xdna-probe PRIVATE "${_XDNA_PROBE_UUID}")
+    endif()
+
+    # aiebu ships with XRT and turns a transaction blob into an ELF, which is
+    # what lets the same design be driven by a module instead of a per-submit
+    # instruction buffer. Optional: without it the probe just skips that section.
+    if (EXISTS "${_XRT_ROOT}/lib/libaiebu.a" AND EXISTS "${_XRT_ROOT}/include/aiebu/aiebu_assembler.h")
+        message(STATUS "ggml-xdna: xdna-probe gets the module delivery path from ${_XRT_ROOT}/lib/libaiebu.a")
+        target_compile_definitions(xdna-probe PRIVATE XDNA_PROBE_HAS_AIEBU=1)
+        target_link_libraries(xdna-probe PRIVATE "${_XRT_ROOT}/lib/libaiebu.a")
+    endif()
+
+    set_target_properties(xdna-probe PROPERTIES
+        BUILD_RPATH   "${_XRT_ROOT}/lib"
+        INSTALL_RPATH "${_XRT_ROOT}/lib"
+    )
+else()
+    message(STATUS "ggml-xdna: XRT not found at ${_XRT_ROOT} - backend will report no NPU device")
+endif()
+
+# NPU kernel artifacts. Built out-of-line by the IRON/MLIR-AIE toolchain so the
+# host build never depends on it; the backend loads them at runtime from the
+# directory of the executable (see ggml_xdna_find_*_kernel).
+if (GGML_XDNA_BUILD_KERNELS)
+    if (NOT EXISTS "${GGML_XDNA_IRON_PYTHON}")
+        message(FATAL_ERROR
+            "ggml-xdna: GGML_XDNA_BUILD_KERNELS=ON but no IRON python at "
+            "${GGML_XDNA_IRON_PYTHON} - set -DGGML_XDNA_IRON_PYTHON=<venv>/bin/python3")
+    endif()
+
+    set(XDNA_KERNEL_ARTIFACTS "")
+    set(XDNA_KERNEL_DESIGNS   "")
+
+    # MUL_MAT: KT=16 (K=1024). Always build MB=16 and MB=32; runtime picks by M.
+    set(_stem16 "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-xdna-gemm-npu2-bf16-16-16")
+    set(_stem32 "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-xdna-gemm-npu2-bf16-16-32")
+    list(APPEND XDNA_KERNEL_ARTIFACTS
+         "${_stem16}.xclbin" "${_stem16}.insts.bin"
+         "${_stem32}.xclbin" "${_stem32}.insts.bin")
+    list(APPEND XDNA_KERNEL_DESIGNS "${CMAKE_CURRENT_SOURCE_DIR}/iron/ggml-xdna-gemm.py")
+
+    set(XDNA_KERNEL_ENV "${CMAKE_COMMAND}" -E env)
+    if (GGML_XDNA_EXPERIMENTAL)
+        list(APPEND XDNA_KERNEL_ENV "GGML_XDNA_EXPERIMENTAL=1")
+
+        foreach(op add mul)
+            set(_stem "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-xdna-${op}-npu2-f32-${GGML_XDNA_TILE}")
+            list(APPEND XDNA_KERNEL_ARTIFACTS "${_stem}.xclbin" "${_stem}.insts.bin")
+            list(APPEND XDNA_KERNEL_DESIGNS   "${CMAKE_CURRENT_SOURCE_DIR}/iron/ggml-xdna-${op}.py")
+        endforeach()
+
+        # RMS_NORM is sized by the model's row length, not by the elementwise tile
+        set(_rms "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-xdna-rms-norm-npu2-f32-${GGML_XDNA_RMS_ROW}")
+        list(APPEND XDNA_KERNEL_ARTIFACTS "${_rms}.xclbin" "${_rms}.insts.bin")
+        list(APPEND XDNA_KERNEL_DESIGNS   "${CMAKE_CURRENT_SOURCE_DIR}/iron/ggml-xdna-rms-norm.py")
+
+        set(_fuse "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-xdna-add-rms-mul-npu2-f32-${GGML_XDNA_RMS_ROW}")
+        list(APPEND XDNA_KERNEL_ARTIFACTS "${_fuse}.xclbin" "${_fuse}.insts.bin")
+        list(APPEND XDNA_KERNEL_DESIGNS   "${CMAKE_CURRENT_SOURCE_DIR}/iron/ggml-xdna-add-rms-mul.py")
+
+        # GATED_DELTA_NET: single-strip (legacy) + 4-worker full-state (w4).
+        set(_gdn "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-xdna-gdn-npu2-s128-r32-cs64")
+        set(_gdn4 "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-xdna-gdn-npu2-s128-r32-cs64-w4")
+        list(APPEND XDNA_KERNEL_ARTIFACTS
+             "${_gdn}.xclbin" "${_gdn}.insts.bin"
+             "${_gdn4}.xclbin" "${_gdn4}.insts.bin")
+        list(APPEND XDNA_KERNEL_DESIGNS "${CMAKE_CURRENT_SOURCE_DIR}/iron/ggml-xdna-gdn.py")
+    endif()
+
+    add_custom_command(
+        OUTPUT  ${XDNA_KERNEL_ARTIFACTS}
+        COMMAND ${XDNA_KERNEL_ENV} bash
+                "${CMAKE_CURRENT_SOURCE_DIR}/iron/build-kernels.sh"
+                "${GGML_XDNA_IRON_PYTHON}"
+                "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
+                "${GGML_XDNA_TILE}"
+                "${GGML_XDNA_DMA_TILE}"
+                "${CMAKE_CURRENT_BINARY_DIR}/kernels"
+                "${GGML_XDNA_RMS_ROW}"
+                "${GGML_XDNA_GEMM_MB}"
+        DEPENDS ${XDNA_KERNEL_DESIGNS}
+                "${CMAKE_CURRENT_SOURCE_DIR}/iron/build-kernels.sh"
+        COMMENT "ggml-xdna: building NPU kernel artifacts"
+        VERBATIM
+    )
+
+    add_custom_target(ggml-xdna-kernels ALL
+        DEPENDS ${XDNA_KERNEL_ARTIFACTS}
+    )
+    add_dependencies(ggml-xdna ggml-xdna-kernels)
+
+    install(FILES ${XDNA_KERNEL_ARTIFACTS}
+            DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()

--- a/ggml/src/ggml-xdna/ggml-xdna.cpp
+++ b/ggml/src/ggml-xdna/ggml-xdna.cpp
@@ -1,0 +1,2933 @@
+#include "ggml-impl.h"
+#include "ggml-xdna.h"
+#include "ggml-backend-impl.h"
+
+#include "xdna-npu.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#ifndef GGML_XDNA_TILE
+#define GGML_XDNA_TILE 1024
+#endif
+
+
+namespace fs = std::filesystem;
+
+static int ggml_xdna_env_int(const char * name, int def) {
+    const char * val = getenv(name);
+    return val ? atoi(val) : def;
+}
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+static bool ggml_xdna_experimental_enabled(void) {
+    const char * val = getenv("GGML_XDNA_ENABLE_EXPERIMENTAL");
+    return val && strcmp(val, "1") == 0;
+}
+#endif
+
+static int ggml_xdna_debug_level(void) {
+    static int level = -1;
+    if (level < 0) {
+        level = ggml_xdna_env_int("GGML_XDNA_DEBUG", 0);
+    }
+    return level;
+}
+
+static fs::path ggml_xdna_executable_dir(void) {
+#if defined(__linux__)
+    std::error_code ec;
+    fs::path exe = fs::read_symlink("/proc/self/exe", ec);
+    if (!ec) {
+        return exe.parent_path();
+    }
+#endif
+    return fs::path();
+}
+
+static std::vector<fs::path> ggml_xdna_kernel_dirs(void) {
+    std::vector<fs::path> dirs;
+    if (const char * env_dir = getenv("GGML_XDNA_KERNELS_DIR")) {
+        dirs.emplace_back(env_dir);
+    }
+#ifdef GGML_BACKEND_DIR
+    dirs.emplace_back(GGML_BACKEND_DIR);
+#endif
+    if (fs::path exe_dir = ggml_xdna_executable_dir(); !exe_dir.empty()) {
+        dirs.push_back(exe_dir);
+    }
+    dirs.emplace_back(fs::current_path());
+    return dirs;
+}
+
+static bool ggml_xdna_find_stem(const char * stem, std::string & xclbin_out, std::string & insts_out) {
+    for (const fs::path & dir : ggml_xdna_kernel_dirs()) {
+        const fs::path xclbin = dir / (std::string(stem) + ".xclbin");
+        const fs::path insts  = dir / (std::string(stem) + ".insts.bin");
+        if (fs::exists(xclbin) && fs::exists(insts)) {
+            xclbin_out = xclbin.string();
+            insts_out  = insts.string();
+            return true;
+        }
+    }
+    return false;
+}
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+static bool ggml_xdna_find_kernel(const char * op_name, size_t tile_elems,
+                                  std::string & xclbin_out, std::string & insts_out) {
+    char stem[96];
+    snprintf(stem, sizeof(stem), "ggml-xdna-%s-npu2-f32-%zu", op_name, tile_elems);
+    return ggml_xdna_find_stem(stem, xclbin_out, insts_out);
+}
+
+// One loaded xclbin. Each slot owns its own hw_context, so every kernel stays
+// resident on the NPU for the lifetime of the process and dispatching between
+// them is a submission to a different context, never an xclbin reload.
+struct ggml_xdna_kernel_slot {
+    const char *  env_name;   // GGML_XDNA_<env_name> toggles this kernel
+    ggml_xdna_op  op;
+
+    bool        enabled = true;
+    bool        found   = false;
+    size_t      tile    = 0;  // elements per submission, baked into the artifact
+    std::string xclbin_path;
+    std::string insts_path;
+
+    std::once_flag  init_once;
+    ggml_xdna_npu * npu = nullptr;
+};
+
+enum ggml_xdna_slot_idx {
+    GGML_XDNA_SLOT_ADD = 0,
+    GGML_XDNA_SLOT_MUL,
+    GGML_XDNA_SLOT_RMS_NORM,
+    GGML_XDNA_SLOT_ADD_RMS_MUL,
+    GGML_XDNA_N_SLOTS,
+};
+#endif
+
+// Per-worker tile and worker grid, both baked into the GEMM xclbin. Must match
+// iron/ggml-xdna-gemm.py.
+static constexpr int GGML_XDNA_GEMM_TILE_M = 32;
+static constexpr int GGML_XDNA_GEMM_TILE_K = 64;
+static constexpr int GGML_XDNA_GEMM_TILE_N = 64;
+static constexpr int GGML_XDNA_GEMM_GRID_R = 4;
+static constexpr int GGML_XDNA_GEMM_GRID_C = 8;
+
+// MMUL micro-tile the operands are swizzled into (bfp16 on aie2p)
+static constexpr int GGML_XDNA_GEMM_MAC_R = 8;
+static constexpr int GGML_XDNA_GEMM_MAC_S = 8;
+static constexpr int GGML_XDNA_GEMM_MAC_T = 8;
+
+// One GEMM artifact covers K=1024 (kt=16) per submit. Larger K is split on the
+// host with C accumulation; N is blocked into columns of grid_c*tile_n.
+// MB (row blocks) is baked into the xclbin: MB=16 -> M_block=2048, MB=32 -> 4096.
+struct ggml_xdna_gemm_slot {
+    const char * env_name;
+    int          kt = 16; // baked into the artifact; K_slice = kt * TILE_K
+    int          mb = 16; // row blocks per submit; M_block = mb*grid_r*tile_m
+
+    bool enabled = true;
+    bool found   = false;
+
+    ggml_xdna_gemm_shape shape{};
+    std::string          xclbin_path;
+    std::string          insts_path;
+
+    std::once_flag  init_once;
+    ggml_xdna_npu * npu = nullptr;
+};
+
+enum ggml_xdna_gemm_idx {
+    GGML_XDNA_GEMM_MB16 = 0,
+    GGML_XDNA_GEMM_MB32 = 1,
+    GGML_XDNA_N_GEMM    = 2,
+};
+
+// Skip lm_head (vocab-width) while still covering FFN like Qwen3.5-9B
+// (N=12288). The kernel already loops N in grid_c*tile_n=512 columns; this
+// is only a host cap on what lands in XDNA_REPACK.
+static constexpr int64_t GGML_XDNA_GEMM_N_MAX = 16384;
+static constexpr int     GGML_XDNA_GEMM_KT    = 16;  // K_slice = 1024
+// Upper bound on the K-slices the design keeps resident at once, so the slice
+// pointers can live on the stack.
+static constexpr int     GGML_XDNA_GEMM_KB_LIMIT = 64;
+
+struct ggml_backend_xdna_device_context {
+    bool        npu_present = false;
+    bool        npu_enabled = true;
+    std::string npu_name    = "none";
+    std::string description = "AMD XDNA (no NPU device)";
+
+    bool gemm_enabled = true;
+    // Below this many activation rows the NPU submit is bandwidth-wasteful;
+    // compute stays in this backend (weights are repacked) but runs on the host.
+    int64_t gemm_m_min = 128;
+    int     gemm_mb    = 16;
+    // Prefer the MB=32 (M_block=4096) artifact once M no longer fits one MB=16
+    // pass. At exactly M_block the smaller artifact covers it without padding,
+    // so the switch has to be strictly above the threshold.
+    int64_t gemm_mb32_min = 2048;
+    // Keep a host-DRAM copy of the GGUF bytes so decode (M < gemm_m_min) can
+    // use the nested CPU kernels on the same memory as `-ngl 0`. The XRT BO
+    // holds only the swizzled BF16 the NPU reads.
+    bool    keep_src   = true;
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+    bool        experimental = false;
+    size_t      tile_elems = GGML_XDNA_TILE;
+    size_t      rms_row    = 1024;
+    int64_t     op_min     = 1;
+    bool        fusion     = true;
+    bool        act_gemm   = false;
+    ggml_xdna_kernel_slot slots[GGML_XDNA_N_SLOTS] = {
+        { "ADD",         GGML_XDNA_OP_ADD         },
+        { "MUL",         GGML_XDNA_OP_MUL         },
+        { "RMS_NORM",    GGML_XDNA_OP_RMS_NORM    },
+        { "ADD_RMS_MUL", GGML_XDNA_OP_ADD_RMS_MUL },
+    };
+    bool                 gdn_enabled = false;
+    bool                 gdn_found   = false;
+    ggml_xdna_gdn_shape  gdn_shape{128, 32, 64, 1};
+    std::string          gdn_xclbin;
+    std::string          gdn_insts;
+    std::once_flag       gdn_init_once;
+    ggml_xdna_npu *      gdn_npu = nullptr;
+    bool                 gdn_fuse_pre = false;
+    bool                 chain_bf16 = false;
+#endif
+    // Claim every op so the scheduler keeps the whole prefill graph on this
+    // backend (zero splits). Ops without an NPU kernel run on a nested CPU
+    // backend; decode still works but is not the optimization target.
+    bool    own_graph    = true;
+    // 1: per-op timings, 2: also split by tensor shape.
+    int     host_profile = 0;
+    // Threads for the swizzle passes. Deliberately not the OpenMP default: with
+    // a thread per core the spinning workers delay the thread waiting on the
+    // NPU, which more than doubles the observed submit latency.
+    int     host_threads = 8;
+
+    ggml_xdna_gemm_slot gemm[GGML_XDNA_N_GEMM] = {
+        { "GEMM_MB16", GGML_XDNA_GEMM_KT, 16 },
+        { "GEMM_MB32", GGML_XDNA_GEMM_KT, 32 },
+    };
+
+    ggml_backend_buffer_type repack_buft{};
+};
+
+// Opens one NPU kernel exactly once and caches the result. Returns the shared
+// handle or nullptr when the NPU is absent/disabled, the artifact is missing,
+// or XRT init failed.
+//
+// The heavy work (load xclbin, create hw_context, allocate BOs, warm up) is
+// triggered eagerly from ggml_backend_xdna_init (backend init), so device
+// registration / enumeration stays cheap and side-effect free. By the time the
+// scheduler calls supports_op the call_once has already run, so this is a fast
+// idempotent guard there, not a per-query init.
+//
+// Semantics on failure: if this first init fails, the result is sticky for the
+// lifetime of the process - the kernel stays unavailable until restart. We do
+// NOT retry (here or in supports_op): the failure causes are deterministic
+// within a process, and retrying under supports_op would make scheduling both
+// expensive and unpredictable.
+#if defined(GGML_XDNA_EXPERIMENTAL)
+static ggml_xdna_npu * ggml_xdna_device_npu(ggml_backend_xdna_device_context * dctx, ggml_xdna_slot_idx idx) {
+    ggml_xdna_kernel_slot & slot = dctx->slots[idx];
+
+    if (!dctx->npu_present || !dctx->npu_enabled || !slot.enabled || !slot.found) {
+        return nullptr;
+    }
+
+    std::call_once(slot.init_once, [dctx, &slot]() {
+        slot.npu = ggml_xdna_npu_init(slot.op,
+                                      slot.xclbin_path.c_str(),
+                                      slot.insts_path.c_str(),
+                                      slot.tile);
+        if (!slot.npu) {
+            GGML_LOG_WARN("%s: NPU present (%s) but %s kernel init failed; "
+                          "XDNA will not claim it\n", "ggml-xdna",
+                          dctx->npu_name.c_str(), slot.env_name);
+        }
+    });
+
+    return slot.npu;
+}
+#endif
+
+static ggml_xdna_npu * ggml_xdna_device_gemm(ggml_backend_xdna_device_context * dctx, ggml_xdna_gemm_idx idx) {
+    ggml_xdna_gemm_slot & slot = dctx->gemm[idx];
+
+    if (!dctx->npu_present || !dctx->npu_enabled || !dctx->gemm_enabled ||
+        !slot.enabled || !slot.found) {
+        return nullptr;
+    }
+
+    std::call_once(slot.init_once, [dctx, &slot]() {
+        slot.npu = ggml_xdna_npu_gemm_init(slot.xclbin_path.c_str(),
+                                           slot.insts_path.c_str(),
+                                           &slot.shape);
+        if (!slot.npu) {
+            GGML_LOG_WARN("%s: NPU present (%s) but %s kernel init failed; "
+                          "XDNA will not claim MUL_MAT\n", "ggml-xdna",
+                          dctx->npu_name.c_str(), slot.env_name);
+        }
+    });
+
+    return slot.npu;
+}
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+static ggml_xdna_npu * ggml_xdna_device_gdn(ggml_backend_xdna_device_context * dctx) {
+    if (!dctx->npu_present || !dctx->npu_enabled || !dctx->gdn_enabled || !dctx->gdn_found) {
+        return nullptr;
+    }
+
+    std::call_once(dctx->gdn_init_once, [dctx]() {
+        dctx->gdn_npu = ggml_xdna_npu_gdn_init(dctx->gdn_xclbin.c_str(),
+                                               dctx->gdn_insts.c_str(),
+                                               &dctx->gdn_shape);
+        if (!dctx->gdn_npu) {
+            GGML_LOG_WARN("%s: NPU present (%s) but GDN kernel init failed\n",
+                          "ggml-xdna", dctx->npu_name.c_str());
+        }
+    });
+
+    return dctx->gdn_npu;
+}
+#endif
+
+// Shape gate shared by weight-buffer selection and runtime dispatch: K must be
+// a multiple of the tile depth, N a multiple of the column block. A K that does
+// not fill the last slice is padded with zeros by both packers, which costs
+// MACs on the tail but keeps wide-K projections on the NPU.
+static bool ggml_xdna_gemm_shape_ok(int64_t k_total, int64_t n_total) {
+    const int n_cols = GGML_XDNA_GEMM_GRID_C * GGML_XDNA_GEMM_TILE_N;
+
+    return k_total > 0 && n_total > 0 &&
+           n_total <= GGML_XDNA_GEMM_N_MAX &&
+           (k_total % GGML_XDNA_GEMM_TILE_K) == 0 &&
+           (n_total % n_cols) == 0;
+}
+
+// Returns the GEMM slot when K and N are compatible with host-side blocking
+// (K multiple of the tile depth, N multiple of the column width). When m_hint
+// is set, prefer the MB=32 artifact for prefills too long for one MB=16 pass.
+static ggml_xdna_gemm_slot * ggml_xdna_gemm_for_shape(ggml_backend_xdna_device_context * dctx,
+                                                      int64_t k_total, int64_t n_total,
+                                                      int64_t m_hint = 0) {
+    if (!ggml_xdna_gemm_shape_ok(k_total, n_total)) {
+        return nullptr;
+    }
+
+    if (m_hint > dctx->gemm_mb32_min &&
+        ggml_xdna_device_gemm(dctx, GGML_XDNA_GEMM_MB32)) {
+        return &dctx->gemm[GGML_XDNA_GEMM_MB32];
+    }
+    if (ggml_xdna_device_gemm(dctx, GGML_XDNA_GEMM_MB16)) {
+        return &dctx->gemm[GGML_XDNA_GEMM_MB16];
+    }
+    // Fall back to whatever slot actually initialised (e.g. only MB=32 built).
+    if (ggml_xdna_device_gemm(dctx, GGML_XDNA_GEMM_MB32)) {
+        return &dctx->gemm[GGML_XDNA_GEMM_MB32];
+    }
+    return nullptr;
+}
+
+static void ggml_xdna_gemm_init_slots(ggml_backend_xdna_device_context & ctx) {
+    ctx.gemm_mb       = ggml_xdna_env_int("GGML_XDNA_GEMM_MB", 16);
+    ctx.gemm_mb32_min = ggml_xdna_env_int("GGML_XDNA_GEMM_MB32_MIN", 2048);
+    ctx.gemm_m_min    = ggml_xdna_env_int("GGML_XDNA_GEMM_M_MIN", 128);
+    ctx.keep_src      = ggml_xdna_env_int("GGML_XDNA_KEEP_SRC", 1) != 0;
+
+    if (ctx.gemm_mb < 1) {
+        ctx.gemm_mb = 1;
+    }
+
+    for (ggml_xdna_gemm_slot & slot : ctx.gemm) {
+        char var[48];
+        snprintf(var, sizeof(var), "GGML_XDNA_%s", slot.env_name);
+        slot.enabled = ggml_xdna_env_int(var, 1) != 0;
+        slot.kt      = GGML_XDNA_GEMM_KT;
+        // Slot 0 tracks GGML_XDNA_GEMM_MB so custom single-geometry builds keep
+        // working; slot 1 is always the MB=32 sibling.
+        if (&slot == &ctx.gemm[GGML_XDNA_GEMM_MB16]) {
+            slot.mb = ctx.gemm_mb;
+        }
+
+        slot.shape = ggml_xdna_gemm_shape{
+            /* tile_m */ GGML_XDNA_GEMM_TILE_M,
+            /* tile_k */ GGML_XDNA_GEMM_TILE_K,
+            /* tile_n */ GGML_XDNA_GEMM_TILE_N,
+            /* grid_r */ GGML_XDNA_GEMM_GRID_R,
+            /* grid_c */ GGML_XDNA_GEMM_GRID_C,
+            /* kt     */ slot.kt,
+            /* nb     */ 1,
+            /* mb     */ slot.mb,
+        };
+
+        char stem[96];
+        snprintf(stem, sizeof(stem), "ggml-xdna-gemm-npu2-bf16-%d-%d",
+                 slot.shape.kt, slot.shape.mb);
+        slot.found = ggml_xdna_find_stem(stem, slot.xclbin_path, slot.insts_path);
+        if (!slot.found) {
+            GGML_LOG_WARN("%s: no %s artifact (%s); that geometry stays unavailable\n",
+                          "ggml-xdna", slot.env_name, stem);
+        }
+    }
+}
+
+static ggml_backend_xdna_device_context * ggml_xdna_device_context(void) {
+    static ggml_backend_xdna_device_context ctx;
+    static std::once_flag once;
+
+    std::call_once(once, [&]() {
+        ctx.own_graph    = ggml_xdna_env_int("GGML_XDNA_OWN_GRAPH", 1) != 0;
+        ctx.host_profile = (int) ggml_xdna_env_int("GGML_XDNA_HOST_PROFILE", 0);
+        ctx.host_threads = (int) ggml_xdna_env_int("GGML_XDNA_HOST_THREADS", 8);
+        if (ctx.host_threads < 1) {
+            ctx.host_threads = 1;
+        }
+        ctx.npu_enabled = ggml_xdna_env_int("GGML_XDNA_NPU", 1) != 0;
+        ctx.gemm_enabled = ggml_xdna_env_int("GGML_XDNA_GEMM", 1) != 0;
+#if defined(GGML_XDNA_EXPERIMENTAL)
+        ctx.experimental = ggml_xdna_experimental_enabled();
+        ctx.tile_elems  = (size_t) ggml_xdna_env_int("GGML_XDNA_TILE", GGML_XDNA_TILE);
+        ctx.op_min      = ggml_xdna_env_int("GGML_XDNA_OP_MIN", 1000000000);
+        ctx.rms_row     = (size_t) ggml_xdna_env_int("GGML_XDNA_RMS_ROW", 1024);
+        ctx.fusion      = ctx.experimental &&
+                          ggml_xdna_env_int("GGML_XDNA_DISABLE_FUSION", 0) == 0;
+        ctx.act_gemm     = ctx.experimental &&
+                           ggml_xdna_env_int("GGML_XDNA_ACT_GEMM", 0) != 0;
+        // Stage 4 GDN: off by default until MemTile-full-state cuts submit count.
+        ctx.gdn_enabled = ctx.experimental &&
+                          ggml_xdna_env_int("GGML_XDNA_GDN", 0) != 0;
+        ctx.gdn_fuse_pre = ctx.experimental &&
+                           ggml_xdna_env_int("GGML_XDNA_GDN_FUSE_PRE", 0) != 0;
+        ctx.chain_bf16   = ctx.gdn_enabled &&
+                           ggml_xdna_env_int("GGML_XDNA_CHAIN_BF16", 1) != 0;
+        if (ctx.experimental) {
+            const int S = 128;
+            const int ROWS = 32;
+            const int CS = 64;
+            const int NS = S / ROWS;
+            ctx.gdn_shape = ggml_xdna_gdn_shape{S, ROWS, CS, NS};
+            char stem_w4[96];
+            char stem_w1[96];
+            snprintf(stem_w4, sizeof(stem_w4), "ggml-xdna-gdn-npu2-s%d-r%d-cs%d-w%d",
+                     S, ROWS, CS, NS);
+            snprintf(stem_w1, sizeof(stem_w1), "ggml-xdna-gdn-npu2-s%d-r%d-cs%d",
+                     S, ROWS, CS);
+            if (ggml_xdna_find_stem(stem_w4, ctx.gdn_xclbin, ctx.gdn_insts)) {
+                ctx.gdn_shape.workers = NS;
+                ctx.gdn_found = true;
+            } else if (ggml_xdna_find_stem(stem_w1, ctx.gdn_xclbin, ctx.gdn_insts)) {
+                ctx.gdn_shape.workers = 1;
+                ctx.gdn_found = true;
+            } else {
+                ctx.gdn_found = false;
+            }
+            if (ctx.gdn_enabled && !ctx.gdn_found) {
+                GGML_LOG_WARN("%s: GGML_XDNA_GDN=1 but no artifact (%s or %s)\n",
+                              "ggml-xdna", stem_w4, stem_w1);
+            }
+        }
+#endif
+
+        char name[128] = "none";
+        ctx.npu_present = ggml_xdna_npu_probe(name, sizeof(name));
+        ctx.npu_name    = name;
+
+        if (!ctx.npu_present) {
+            ctx.description = "AMD XDNA (no NPU device)";
+            return;
+        }
+
+        std::string claimed;
+#if defined(GGML_XDNA_EXPERIMENTAL)
+        for (ggml_xdna_kernel_slot & slot : ctx.slots) {
+            char var[48];
+            snprintf(var, sizeof(var), "GGML_XDNA_%s", slot.env_name);
+            slot.enabled = ctx.experimental && ggml_xdna_env_int(var, 1) != 0;
+            if (!slot.enabled) {
+                continue;
+            }
+
+            slot.tile  = (slot.op == GGML_XDNA_OP_RMS_NORM || slot.op == GGML_XDNA_OP_ADD_RMS_MUL)
+                         ? ctx.rms_row : ctx.tile_elems;
+            slot.found = ggml_xdna_find_kernel(ggml_xdna_op_name(slot.op),
+                                               slot.tile, slot.xclbin_path, slot.insts_path);
+            if (!slot.found) {
+                GGML_LOG_WARN("%s: NPU present (%s) but no %s kernel for tile=%zu; "
+                              "build with -DGGML_XDNA_BUILD_KERNELS=ON\n",
+                              "ggml-xdna", ctx.npu_name.c_str(), slot.env_name, slot.tile);
+                continue;
+            }
+            if (ctx.npu_enabled && slot.enabled) {
+                claimed += claimed.empty() ? "" : ", ";
+                claimed += slot.env_name;
+            }
+        }
+#endif
+
+        ggml_xdna_gemm_init_slots(ctx);
+        for (const ggml_xdna_gemm_slot & slot : ctx.gemm) {
+            if (ctx.gemm_enabled && slot.enabled && slot.found) {
+                claimed += claimed.empty() ? "" : ", ";
+                claimed += slot.env_name;
+            }
+        }
+
+        ctx.description = "AMD XDNA " + ctx.npu_name +
+                          (claimed.empty() ? " (no NPU kernels)" : " (NPU " + claimed + ")") +
+                          (ctx.own_graph ? " [own-graph]" : "");
+    });
+
+    return &ctx;
+}
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+static ggml_xdna_slot_idx ggml_xdna_slot_for_op(enum ggml_op op) {
+    switch (op) {
+        case GGML_OP_MUL:      return GGML_XDNA_SLOT_MUL;
+        case GGML_OP_RMS_NORM: return GGML_XDNA_SLOT_RMS_NORM;
+        default:               return GGML_XDNA_SLOT_ADD;
+    }
+}
+#endif
+
+struct ggml_backend_xdna_context {
+    ggml_backend_xdna_device_context * dev = nullptr;
+
+    // Nested CPU backend for ops we claim but have no NPU kernel for. Keeps the
+    // scheduler from splitting the graph between XDNA and CPU.
+    ggml_backend_t host = nullptr;
+
+    // Threads the caller asked for. Used by the host GEMM (decode), which runs
+    // without a pending NPU submit and so can take every core, unlike the
+    // operand packing that dev->host_threads deliberately keeps narrow.
+    int n_threads = 0;
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+    uint64_t n_fused_add_rms_mul      = 0;
+    uint64_t n_fused_add_rms_mul_npu  = 0;
+#endif
+    uint64_t n_host_graph_runs        = 0;
+    uint64_t n_host_nodes             = 0;
+    uint64_t ns_host                  = 0;
+
+    // Per-op nested CPU time, only filled when host_profile is set: the slices
+    // are then computed one node at a time, which is slower but attributable.
+    std::unordered_map<std::string, uint64_t> host_op_ns;
+    std::unordered_map<std::string, uint64_t> host_op_calls;
+    std::unordered_map<std::string, uint64_t> host_op_bytes;
+
+    // Time spent rearranging operands on the host, which is not part of the
+    // kernel's own accounting. Kept apart because they scale differently: the
+    // A pack is O(M*K) per call and skippable, the C scatter is O(M*N*k_blocks)
+    // per call and is not.
+    uint64_t ns_gemm_pack    = 0;
+    uint64_t ns_gemm_scatter = 0;
+    uint64_t n_gemm_pack     = 0;
+    uint64_t n_gemm_pack_reused = 0;
+
+    // Last packed activation identity so consecutive weight GEMMs that share
+    // src1 can skip the A pack (gate/up style projections).
+    const ggml_tensor * gemm_pack_src = nullptr;
+    int64_t             gemm_pack_m0  = -1;
+    int                 gemm_pack_kb0 = -1;
+    int                 gemm_pack_kb_n = 0;
+    int                 gemm_pack_bank = 0;
+    ggml_xdna_npu *     gemm_pack_npu = nullptr;
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+    // BF16 side copies of recent GEMM destinations for GDN packing.
+    struct chain_entry {
+        const void * key = nullptr;
+        std::vector<ggml_bf16_t> data;
+        int64_t ne0 = 0;
+        int64_t ne1 = 0;
+    };
+    static constexpr int CHAIN_SLOTS = 8;
+    chain_entry chain[CHAIN_SLOTS];
+    int chain_next = 0;
+#endif
+};
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+static void ggml_xdna_chain_store(ggml_backend_xdna_context * ctx,
+                                  const void * key,
+                                  const float * src,
+                                  int64_t ne0,
+                                  int64_t ne1) {
+    if (!ctx || !ctx->dev->chain_bf16 || !key || !src || ne0 <= 0 || ne1 <= 0) {
+        return;
+    }
+    const size_t n = (size_t) ne0 * (size_t) ne1;
+    ggml_backend_xdna_context::chain_entry & e = ctx->chain[ctx->chain_next % ctx->CHAIN_SLOTS];
+    ctx->chain_next++;
+    e.key = key;
+    e.ne0 = ne0;
+    e.ne1 = ne1;
+    e.data.resize(n);
+#ifdef GGML_XDNA_OPENMP
+#   pragma omp parallel for schedule(static) num_threads(ctx->dev->host_threads)
+#endif
+    for (int64_t i = 0; i < (int64_t) n; i++) {
+        e.data[(size_t) i] = GGML_FP32_TO_BF16(src[(size_t) i]);
+    }
+}
+
+static const ggml_bf16_t * ggml_xdna_chain_find(ggml_backend_xdna_context * ctx,
+                                                const void * key,
+                                                int64_t ne0,
+                                                int64_t ne1) {
+    if (!ctx || !ctx->dev->chain_bf16 || !key) {
+        return nullptr;
+    }
+    for (int i = 0; i < ctx->CHAIN_SLOTS; i++) {
+        const auto & e = ctx->chain[i];
+        if (e.key == key && e.ne0 == ne0 && e.ne1 == ne1 && !e.data.empty()) {
+            return e.data.data();
+        }
+    }
+    return nullptr;
+}
+#endif
+
+static uint64_t ggml_xdna_now_ns(void) {
+    using clock = std::chrono::steady_clock;
+    return (uint64_t) std::chrono::duration_cast<std::chrono::nanoseconds>(
+        clock::now().time_since_epoch()).count();
+}
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+static void ggml_xdna_log_op(ggml_backend_xdna_context * ctx, const struct ggml_tensor * node,
+                             const ggml_xdna_kernel_slot & slot) {
+    const int level = ggml_xdna_debug_level();
+
+    ggml_xdna_npu_stats stats;
+    ggml_xdna_npu_get_stats(slot.npu, &stats);
+    const uint64_t n = stats.n_calls;
+
+    const bool log_now = (level >= 2) || (level >= 1 && (n == 1 || (n % 64) == 0)) || (level <= 0 && n == 1);
+    if (!log_now) {
+        return;
+    }
+
+    GGML_LOG_INFO("%s: graph_compute %s name=%s nelements=%lld on=NPU npu=%s calls=%llu runs=%llu "
+                  "avg_submit=%.1fus avg_total=%.1fus\n",
+                  "ggml-xdna",
+                  slot.env_name,
+                  node->name ? node->name : "?",
+                  (long long) ggml_nelements(node),
+                  ctx->dev->npu_name.c_str(),
+                  (unsigned long long) stats.n_calls,
+                  (unsigned long long) stats.n_runs,
+                  stats.n_runs  ? (double) stats.ns_submit / stats.n_runs  / 1e3 : 0.0,
+                  stats.n_calls ? (double) stats.ns_total  / stats.n_calls / 1e3 : 0.0);
+}
+
+// Runs an elementwise op on the NPU. There is no CPU fallback: supports_op only
+// claims an op when its kernel is live, so a submit failure here is a hard error.
+static bool ggml_xdna_compute_binary(ggml_backend_xdna_context * ctx, const struct ggml_tensor * node) {
+    ggml_xdna_kernel_slot & slot = ctx->dev->slots[ggml_xdna_slot_for_op(node->op)];
+
+    if (!slot.npu) {
+        GGML_LOG_ERROR("%s: graph_compute %s but its NPU kernel is not initialized\n",
+                       "ggml-xdna", slot.env_name);
+        return false;
+    }
+
+    const bool ok = ggml_xdna_npu_binary_f32(slot.npu,
+                                             (const float *) node->src[0]->data,
+                                             (const float *) node->src[1]->data,
+                                             (float *) node->data,
+                                             (size_t) ggml_nelements(node));
+    if (!ok) {
+        GGML_LOG_ERROR("%s: NPU %s submit failed for %s\n", "ggml-xdna", slot.env_name,
+                       node->name ? node->name : "?");
+        return false;
+    }
+
+    ggml_xdna_log_op(ctx, node, slot);
+    return true;
+}
+
+static bool ggml_xdna_compute_rms_norm(ggml_backend_xdna_context * ctx, const struct ggml_tensor * node) {
+    ggml_xdna_kernel_slot & slot = ctx->dev->slots[GGML_XDNA_SLOT_RMS_NORM];
+
+    if (!slot.npu) {
+        GGML_LOG_ERROR("%s: graph_compute %s but its NPU kernel is not initialized\n",
+                       "ggml-xdna", slot.env_name);
+        return false;
+    }
+
+    float eps;
+    memcpy(&eps, node->op_params, sizeof(float));
+
+    const bool ok = ggml_xdna_npu_rms_norm_f32(slot.npu,
+                                               (const float *) node->src[0]->data,
+                                               (float *) node->data,
+                                               ggml_nrows(node),
+                                               eps);
+    if (!ok) {
+        GGML_LOG_ERROR("%s: NPU %s submit failed for %s\n", "ggml-xdna", slot.env_name,
+                       node->name ? node->name : "?");
+        return false;
+    }
+
+    ggml_xdna_log_op(ctx, node, slot);
+    return true;
+}
+
+// ADD -> RMS_NORM -> MUL, the pre-norm block of every transformer layer.
+//
+// ggml_can_fuse is the wrong predicate here: it wants every node but the last
+// to have a single consumer, and the ADD is the residual, so it has two - the
+// RMS_NORM and the next layer's residual ADD. ggml_can_fuse_subgraph is the one
+// that models this, by letting both the ADD and the MUL be declared outputs of
+// the region. A single NPU design covering the pattern therefore has to write
+// two buffers, not one.
+static bool ggml_xdna_can_fuse_add_rms_mul(const ggml_backend_xdna_context * ctx,
+                                           const struct ggml_cgraph * cgraph, int i) {
+    if (!ctx->dev->fusion) {
+        return false;
+    }
+
+    if (!ggml_can_fuse_subgraph(cgraph, i, { GGML_OP_ADD, GGML_OP_RMS_NORM, GGML_OP_MUL }, { i, i + 2 })) {
+        return false;
+    }
+
+    // rms_norm consumes the add, mul consumes the rms_norm
+    if (!ggml_check_edges(cgraph, i, { { 1, 0, 0 }, { 2, 0, 1 } })) {
+        return false;
+    }
+
+    const struct ggml_tensor * add = cgraph->nodes[i];
+    const struct ggml_tensor * mul = cgraph->nodes[i + 2];
+    const struct ggml_tensor * w   = mul->src[1];
+
+    if (!w || w->type != GGML_TYPE_F32 || mul->type != GGML_TYPE_F32 ||
+        !ggml_is_contiguous_rows(w) || w->ne[0] != mul->ne[0]) {
+        return false;
+    }
+
+    // Artifact is baked to rms_row. The fused kernel still submits one run per
+    // row, so only use it for decode-sized batches; prefill residuals go through
+    // the nested CPU path (own_graph) or separate kernels. op_min gates it the
+    // same way as the plain elementwise ops: a submit costs ~330us, which no
+    // decode-sized residual can earn back.
+    return (size_t) add->ne[0] == ctx->dev->rms_row &&
+           ggml_nrows(add) <= 32 &&
+           ggml_nelements(add) >= ctx->dev->op_min &&
+           ggml_xdna_device_npu(ctx->dev, GGML_XDNA_SLOT_ADD_RMS_MUL) != nullptr;
+}
+
+// Executes the fused region. Uses the single-submission ADD_RMS_MUL design when
+// its artifact is loaded; otherwise falls back to three separate kernels.
+static bool ggml_xdna_compute_add_rms_mul(ggml_backend_xdna_context * ctx,
+                                          const struct ggml_cgraph * cgraph, int i) {
+    struct ggml_tensor * add = cgraph->nodes[i];
+    struct ggml_tensor * rms = cgraph->nodes[i + 1];
+    struct ggml_tensor * mul = cgraph->nodes[i + 2];
+
+    ctx->n_fused_add_rms_mul++;
+
+    ggml_xdna_kernel_slot & fused = ctx->dev->slots[GGML_XDNA_SLOT_ADD_RMS_MUL];
+    if (fused.npu) {
+        float eps;
+        memcpy(&eps, rms->op_params, sizeof(float));
+
+        const bool ok = ggml_xdna_npu_add_rms_mul_f32(fused.npu,
+                                                      (const float *) add->src[0]->data,
+                                                      (const float *) add->src[1]->data,
+                                                      (const float *) mul->src[1]->data,
+                                                      (float *) add->data,
+                                                      (float *) mul->data,
+                                                      ggml_nrows(add),
+                                                      /*weight_n_rows=*/ ggml_nrows(mul->src[1]),
+                                                      eps);
+        if (!ok) {
+            GGML_LOG_ERROR("%s: NPU %s submit failed for fused ADD+RMS_NORM+MUL\n",
+                           "ggml-xdna", fused.env_name);
+            return false;
+        }
+
+        ctx->n_fused_add_rms_mul_npu++;
+        ggml_xdna_log_op(ctx, add, fused);
+        return true;
+    }
+
+    return ggml_xdna_compute_binary(ctx, add) &&
+           ggml_xdna_compute_rms_norm(ctx, rms) &&
+           ggml_xdna_compute_binary(ctx, mul);
+}
+#endif
+
+static const char * ggml_backend_xdna_get_name(ggml_backend_t backend) {
+    GGML_UNUSED(backend);
+    return "XDNA";
+}
+
+// Per-kernel totals, so an A/B over GGML_XDNA_ADD / GGML_XDNA_MUL shows how
+// much of a run went into each hw_context and what a submission costs.
+static void ggml_xdna_log_slot_stats(const char * name, const ggml_xdna_npu * npu) {
+    ggml_xdna_npu_stats stats;
+    ggml_xdna_npu_get_stats(npu, &stats);
+    if (stats.n_calls == 0) {
+        return;
+    }
+    GGML_LOG_INFO("%s: summary %s: calls=%llu runs=%llu total=%.1fms submit=%.1fms "
+                  "(%.1f%% of total) sync=%.1fms avg_submit=%.1fus\n",
+                  "ggml-xdna",
+                  name,
+                  (unsigned long long) stats.n_calls,
+                  (unsigned long long) stats.n_runs,
+                  (double) stats.ns_total  / 1e6,
+                  (double) stats.ns_submit / 1e6,
+                  stats.ns_total ? 100.0 * (double) stats.ns_submit / (double) stats.ns_total : 0.0,
+                  (double) stats.ns_sync   / 1e6,
+                  stats.n_runs ? (double) stats.ns_submit / stats.n_runs / 1e3 : 0.0);
+}
+
+static void ggml_xdna_log_summary(ggml_backend_xdna_device_context * dev) {
+    if (ggml_xdna_debug_level() <= 0) {
+        return;
+    }
+
+    uint64_t n_calls = 0;
+#if defined(GGML_XDNA_EXPERIMENTAL)
+    for (const ggml_xdna_kernel_slot & slot : dev->slots) {
+        ggml_xdna_npu_stats stats;
+        ggml_xdna_npu_get_stats(slot.npu, &stats);
+        n_calls += stats.n_calls;
+    }
+#endif
+    for (const ggml_xdna_gemm_slot & slot : dev->gemm) {
+        ggml_xdna_npu_stats stats;
+        ggml_xdna_npu_get_stats(slot.npu, &stats);
+        n_calls += stats.n_calls;
+    }
+    // A backend can be created and freed before any work reaches the NPU, so
+    // that free must not consume the one-shot report.
+    if (n_calls == 0) {
+        return;
+    }
+
+    static std::once_flag once;
+    std::call_once(once, [dev]() {
+#if defined(GGML_XDNA_EXPERIMENTAL)
+        for (const ggml_xdna_kernel_slot & slot : dev->slots) {
+            ggml_xdna_log_slot_stats(slot.env_name, slot.npu);
+        }
+#endif
+        for (const ggml_xdna_gemm_slot & slot : dev->gemm) {
+            ggml_xdna_log_slot_stats(slot.env_name, slot.npu);
+        }
+    });
+}
+
+static void ggml_backend_xdna_free(ggml_backend_t backend) {
+    ggml_backend_xdna_context * ctx = (ggml_backend_xdna_context *)backend->context;
+    if (ggml_xdna_debug_level() > 0 && (ctx->ns_gemm_pack || ctx->ns_gemm_scatter)) {
+        GGML_LOG_INFO("%s: summary GEMM host: A pack %.1fms (%llu packs, %llu reused), "
+                      "C scatter %.1fms\n",
+                      "ggml-xdna",
+                      (double) ctx->ns_gemm_pack / 1e6,
+                      (unsigned long long) ctx->n_gemm_pack,
+                      (unsigned long long) ctx->n_gemm_pack_reused,
+                      (double) ctx->ns_gemm_scatter / 1e6);
+    }
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+    if (ggml_xdna_debug_level() > 0 && ctx->n_fused_add_rms_mul) {
+        GGML_LOG_INFO("%s: summary FUSION: ADD+RMS_NORM+MUL matched %llu times (%llu on fused kernel)\n",
+                      "ggml-xdna",
+                      (unsigned long long) ctx->n_fused_add_rms_mul,
+                      (unsigned long long) ctx->n_fused_add_rms_mul_npu);
+    }
+#endif
+    if (ggml_xdna_debug_level() > 0 && ctx->n_host_graph_runs) {
+        GGML_LOG_INFO("%s: summary HOST: nested CPU runs=%llu nodes=%llu total=%.1fms\n",
+                      "ggml-xdna",
+                      (unsigned long long) ctx->n_host_graph_runs,
+                      (unsigned long long) ctx->n_host_nodes,
+                      (double) ctx->ns_host / 1e6);
+
+        uint64_t all_ns = 0, all_bytes = 0;
+        for (const auto & kv : ctx->host_op_ns) {
+            if (kv.first.compare(0, 8, "[local] ") == 0) {
+                continue;
+            }
+            all_ns    += kv.second;
+            all_bytes += ctx->host_op_bytes[kv.first];
+        }
+        if (all_ns) {
+            GGML_LOG_INFO("%s: summary HOST profiled ops: %.1fms, %.1f GiB touched, %.1f GB/s\n",
+                          "ggml-xdna",
+                          (double) all_ns / 1e6,
+                          (double) all_bytes / (1024.0 * 1024.0 * 1024.0),
+                          (double) all_bytes / (double) all_ns);
+        }
+
+        std::vector<std::pair<std::string, uint64_t>> by_op(ctx->host_op_ns.begin(),
+                                                            ctx->host_op_ns.end());
+        std::sort(by_op.begin(), by_op.end(),
+                  [](const auto & a, const auto & b) { return a.second > b.second; });
+        for (size_t i = 0; i < by_op.size(); i++) {
+            const uint64_t ns    = by_op[i].second;
+            const uint64_t bytes = ctx->host_op_bytes[by_op[i].first];
+            GGML_LOG_INFO("%s: summary HOST op %-28s %8.1fms  calls=%-6llu %6.1f GB/s\n",
+                          "ggml-xdna",
+                          by_op[i].first.c_str(),
+                          (double) ns / 1e6,
+                          (unsigned long long) ctx->host_op_calls[by_op[i].first],
+                          ns ? (double) bytes / (double) ns : 0.0);
+        }
+    }
+    ggml_xdna_log_summary(ctx->dev);
+    // The kernels are owned by the device singleton (shared across backends),
+    // so they are intentionally not freed here; they live until process exit.
+    if (ctx->host) {
+        ggml_backend_free(ctx->host);
+    }
+    delete ctx;
+    delete backend;
+}
+
+// Defined with the repack buffer it reads its weights from.
+static ggml_xdna_gemm_slot * ggml_xdna_gemm_slot_for_op(ggml_backend_xdna_device_context * dctx,
+                                                       const struct ggml_tensor *                op);
+static bool ggml_xdna_gemm_runs_here(ggml_backend_xdna_device_context * dctx,
+                                     const struct ggml_tensor *         op);
+static bool ggml_xdna_uses_repack_buft(const ggml_backend_xdna_device_context * dctx,
+                                      const ggml_tensor *                      op);
+#if defined(GGML_XDNA_EXPERIMENTAL)
+static bool ggml_xdna_act_gemm_ok(ggml_backend_xdna_device_context * dctx,
+                                  const ggml_tensor *                op);
+static bool ggml_xdna_binary_shape_ok(const struct ggml_tensor * op, int64_t op_min);
+#endif
+static bool ggml_xdna_compute_mul_mat(ggml_backend_xdna_context * ctx,
+                                      const struct ggml_tensor * node,
+                                      float * dst_override);
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+// Stage 4: GATED_DELTA_NET on NPU (scalar gate, S=128, K=1). State is walked
+// as ROWS=32 strips; tok packs slide v so v[0:ROWS] match the active strip.
+static bool ggml_xdna_gdn_shape_ok(const struct ggml_tensor * node,
+                                   const ggml_xdna_gdn_shape & sh) {
+    if (!node || node->op != GGML_OP_GATED_DELTA_NET) {
+        return false;
+    }
+    const ggml_tensor * q = node->src[0];
+    const ggml_tensor * k = node->src[1];
+    const ggml_tensor * v = node->src[2];
+    const ggml_tensor * g = node->src[3];
+    const ggml_tensor * beta = node->src[4];
+    const ggml_tensor * state = node->src[5];
+    if (!q || !k || !v || !g || !beta || !state) {
+        return false;
+    }
+    if (q->type != GGML_TYPE_F32 || k->type != GGML_TYPE_F32 ||
+        v->type != GGML_TYPE_F32 || g->type != GGML_TYPE_F32 ||
+        beta->type != GGML_TYPE_F32 || state->type != GGML_TYPE_F32 ||
+        node->type != GGML_TYPE_F32) {
+        return false;
+    }
+    const int64_t S = v->ne[0];
+    if (S != sh.S || (S % sh.ROWS) != 0) {
+        return false;
+    }
+    if (g->ne[0] != 1 || beta->ne[0] != 1) {
+        return false; // KDA / non-scalar gate not in this artifact
+    }
+    if (ggml_get_op_params_i32(node, 0) != 1) {
+        return false; // only K=1 (final state)
+    }
+    if (!ggml_is_contiguous_rows(q) || !ggml_is_contiguous_rows(k) ||
+        !ggml_is_contiguous_rows(v) || !ggml_is_contiguous(g) ||
+        !ggml_is_contiguous(beta) || !ggml_is_contiguous(state)) {
+        return false;
+    }
+    return true;
+}
+
+static void ggml_xdna_l2_norm_row(float * dst, const float * src, int64_t n, float eps) {
+    float sum = 0.0f;
+    for (int64_t i = 0; i < n; ++i) {
+        sum += src[i] * src[i];
+    }
+    const float inv = 1.0f / sqrtf(sum / (float) n + eps);
+    for (int64_t i = 0; i < n; ++i) {
+        dst[i] = src[i] * inv;
+    }
+}
+
+// Stage 5: L2_NORM(q/k) that only feed a GDN we will run can be absorbed.
+static bool ggml_xdna_l2_absorbed_by_gdn(ggml_backend_xdna_device_context * dctx,
+                                         const struct ggml_tensor * l2) {
+    if (!dctx->gdn_fuse_pre || !ggml_xdna_device_gdn(dctx) || !l2 ||
+        l2->op != GGML_OP_L2_NORM || !l2->src[0]) {
+        return false;
+    }
+    // Shape must match a GDN head row: ne0 == S.
+    return l2->ne[0] == dctx->gdn_shape.S && l2->type == GGML_TYPE_F32;
+}
+
+static bool ggml_xdna_compute_gated_delta_net(ggml_backend_xdna_context * ctx,
+                                              const struct ggml_tensor * node) {
+    ggml_backend_xdna_device_context * dctx = ctx->dev;
+    ggml_xdna_npu * npu = ggml_xdna_device_gdn(dctx);
+    if (!npu || !ggml_xdna_gdn_shape_ok(node, dctx->gdn_shape)) {
+        return false;
+    }
+
+    const int S = dctx->gdn_shape.S;
+    const int ROWS = dctx->gdn_shape.ROWS;
+    const int CS = dctx->gdn_shape.CS;
+    const int workers = dctx->gdn_shape.workers > 0 ? dctx->gdn_shape.workers : 1;
+    const int NS = S / ROWS;
+    const bool full = workers > 1;
+
+    const ggml_tensor * src_q = node->src[0];
+    const ggml_tensor * src_k = node->src[1];
+    const ggml_tensor * src_v = node->src[2];
+    const ggml_tensor * src_g = node->src[3];
+    const ggml_tensor * src_beta = node->src[4];
+    const ggml_tensor * src_state = node->src[5];
+
+    float eps_q = 1e-6f;
+    float eps_k = 1e-6f;
+    bool fuse_q = false;
+    bool fuse_k = false;
+    if (dctx->gdn_fuse_pre) {
+        if (src_q->op == GGML_OP_L2_NORM && src_q->src[0]) {
+            eps_q = ggml_get_op_params_f32(src_q, 0);
+            src_q = src_q->src[0];
+            fuse_q = true;
+        }
+        if (src_k->op == GGML_OP_L2_NORM && src_k->src[0]) {
+            eps_k = ggml_get_op_params_f32(src_k, 0);
+            src_k = src_k->src[0];
+            fuse_k = true;
+        }
+    }
+
+    const int64_t H = src_v->ne[1];
+    const int64_t n_tokens = src_v->ne[2];
+    const int64_t n_seqs = src_v->ne[3];
+    const int64_t H_k = src_k->ne[1];
+    const int64_t H_q = src_q->ne[1];
+
+    const int64_t attn_elems = (int64_t) S * H * n_tokens * n_seqs;
+    float * attn_out = (float *) node->data;
+    float * state_out = attn_out + attn_elems;
+
+    const size_t tok_elems = (size_t) CS * (size_t) (3 * S + 2);
+    const size_t strip_elems = (size_t) ROWS * (size_t) S;
+    const size_t state_elems = full ? (size_t) S * (size_t) S : strip_elems;
+    const size_t attn_strip_elems = full ? (size_t) CS * (size_t) S
+                                         : (size_t) CS * (size_t) ROWS;
+    const int64_t n_chunks = (n_tokens + CS - 1) / CS;
+
+    std::vector<float> tok(tok_elems * (full ? (size_t) n_chunks : 1));
+    std::vector<float> state_buf(state_elems);
+    std::vector<float> attn_strip(attn_strip_elems * (full ? (size_t) n_chunks : 1));
+    std::vector<float> new_state(state_elems);
+    std::vector<float> q_tmp((size_t) S);
+    std::vector<float> k_tmp((size_t) S);
+
+    const ggml_bf16_t * q_bf = ggml_xdna_chain_find(ctx, src_q->data, src_q->ne[0], ggml_nrows(src_q));
+    const ggml_bf16_t * k_bf = ggml_xdna_chain_find(ctx, src_k->data, src_k->ne[0], ggml_nrows(src_k));
+    const ggml_bf16_t * v_bf = ggml_xdna_chain_find(ctx, src_v->data, src_v->ne[0], ggml_nrows(src_v));
+
+    auto load_row = [](float * dst, const float * src_f, const ggml_bf16_t * src_bf,
+                       size_t off, int64_t n, bool fuse, float eps, float * tmp) {
+        if (src_bf) {
+            for (int64_t i = 0; i < n; ++i) {
+                tmp[i] = GGML_BF16_TO_FP32(src_bf[off + (size_t) i]);
+            }
+            if (fuse) {
+                ggml_xdna_l2_norm_row(dst, tmp, n, eps);
+            } else {
+                memcpy(dst, tmp, (size_t) n * sizeof(float));
+            }
+        } else if (fuse) {
+            ggml_xdna_l2_norm_row(dst, src_f, n, eps);
+        } else {
+            memcpy(dst, src_f, (size_t) n * sizeof(float));
+        }
+    };
+
+    for (int64_t is = 0; is < n_seqs; ++is) {
+        for (int64_t ih = 0; ih < H; ++ih) {
+            const int64_t iq1 = ih % H_q;
+            const int64_t ik1 = ih % H_k;
+
+            float * s_dst = state_out + (is * H + ih) * S * S;
+            const float * s_src = (const float *) src_state->data +
+                is * (src_state->nb[3] / sizeof(float)) + ih * S * S;
+            memcpy(s_dst, s_src, (size_t) S * S * sizeof(float));
+            if (full) {
+                memcpy(state_buf.data(), s_dst, state_elems * sizeof(float));
+            }
+
+            for (int64_t t0 = 0; t0 < n_tokens; t0 += CS) {
+                const int64_t n_chunk = std::min((int64_t) CS, n_tokens - t0);
+                const int64_t chunk = t0 / CS;
+                float * tok_chunk = tok.data() + (full ? (size_t) chunk * tok_elems : 0);
+
+                memset(tok_chunk, 0, tok_elems * sizeof(float));
+                for (int64_t t = 0; t < n_chunk; ++t) {
+                    const int64_t tt = t0 + t;
+                    const size_t q_off = (size_t) ((is * n_tokens + tt) * H_q + iq1) * (size_t) S;
+                    const size_t k_off = (size_t) ((is * n_tokens + tt) * H_k + ik1) * (size_t) S;
+                    const size_t v_off = (size_t) ((is * n_tokens + tt) * H + ih) * (size_t) S;
+
+                    const float * q = (const float *) ((const char *) src_q->data +
+                        is * src_q->nb[3] + tt * src_q->nb[2] + iq1 * src_q->nb[1]);
+                    const float * k = (const float *) ((const char *) src_k->data +
+                        is * src_k->nb[3] + tt * src_k->nb[2] + ik1 * src_k->nb[1]);
+                    const float * v = (const float *) ((const char *) src_v->data +
+                        is * src_v->nb[3] + tt * src_v->nb[2] + ih * src_v->nb[1]);
+                    const float g = *(const float *) ((const char *) src_g->data +
+                        is * src_g->nb[3] + tt * src_g->nb[2] + ih * src_g->nb[1]);
+                    const float beta = *(const float *) ((const char *) src_beta->data +
+                        is * src_beta->nb[3] + tt * src_beta->nb[2] + ih * src_beta->nb[1]);
+
+                    float * pack = tok_chunk + t * (3 * S + 2);
+                    load_row(pack, q, q_bf, q_off, S, fuse_q, eps_q, q_tmp.data());
+                    load_row(pack + S, k, k_bf, k_off, S, fuse_k, eps_k, k_tmp.data());
+                    if (v_bf) {
+                        for (int64_t i = 0; i < S; ++i) {
+                            pack[2 * S + i] = GGML_BF16_TO_FP32(v_bf[v_off + (size_t) i]);
+                        }
+                    } else {
+                        memcpy(pack + 2 * S, v, (size_t) S * sizeof(float));
+                    }
+                    pack[3 * S] = expf(g);
+                    pack[3 * S + 1] = beta;
+                }
+                for (int64_t t = n_chunk; t < CS; ++t) {
+                    tok_chunk[t * (3 * S + 2) + 3 * S] = 1.0f;
+                }
+
+                if (full) {
+                    continue;
+                } else {
+                    for (int ns = 0; ns < NS; ++ns) {
+                        const int j0 = ns * ROWS;
+                        memcpy(state_buf.data(), s_dst + j0 * S, strip_elems * sizeof(float));
+
+                        std::vector<float> tok_slid = tok;
+                        for (int64_t t = 0; t < n_chunk; ++t) {
+                            float * pack = tok_slid.data() + t * (3 * S + 2);
+                            memmove(pack + 2 * S, pack + 2 * S + j0, (size_t) ROWS * sizeof(float));
+                        }
+
+                        if (!ggml_xdna_npu_gdn_submit(npu, tok_slid.data(), state_buf.data(),
+                                                      attn_strip.data(), new_state.data())) {
+                            return false;
+                        }
+
+                        memcpy(s_dst + j0 * S, new_state.data(), strip_elems * sizeof(float));
+                        for (int64_t t = 0; t < n_chunk; ++t) {
+                            float * a = attn_out + ((is * n_tokens + t0 + t) * H + ih) * S + j0;
+                            memcpy(a, attn_strip.data() + t * ROWS, (size_t) ROWS * sizeof(float));
+                        }
+                    }
+                }
+            }
+
+            if (full) {
+                if (!ggml_xdna_npu_gdn_submit_full_chunks(
+                        npu, tok.data(), (int) n_chunks, state_buf.data(),
+                        attn_strip.data(), new_state.data())) {
+                    return false;
+                }
+                memcpy(s_dst, new_state.data(), state_elems * sizeof(float));
+                for (int64_t chunk = 0; chunk < n_chunks; chunk++) {
+                    const int64_t t0 = chunk * CS;
+                    const int64_t n_chunk = std::min((int64_t) CS, n_tokens - t0);
+                    const float * chunk_attn =
+                        attn_strip.data() + (size_t) chunk * attn_strip_elems;
+                    for (int64_t t = 0; t < n_chunk; ++t) {
+                        float * a = attn_out + ((is * n_tokens + t0 + t) * H + ih) * S;
+                        for (int ns = 0; ns < NS; ++ns) {
+                            memcpy(a + ns * ROWS,
+                                   chunk_attn + ((size_t) ns * CS + (size_t) t) * ROWS,
+                                   (size_t) ROWS * sizeof(float));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return true;
+}
+#endif
+
+// Ops we execute inside this backend.
+// Everything else goes to the nested CPU backend when own_graph is on.
+static bool ggml_xdna_is_local_op(ggml_backend_xdna_context * ctx, const struct ggml_tensor * node) {
+    ggml_backend_xdna_device_context * dctx = ctx->dev;
+
+    switch (node->op) {
+        case GGML_OP_NONE:
+        case GGML_OP_RESHAPE:
+        case GGML_OP_VIEW:
+        case GGML_OP_PERMUTE:
+        case GGML_OP_TRANSPOSE:
+            // With own_graph, absorb into nested-CPU slices. In split mode the
+            // scheduler only assigns these here as no-ops on this backend.
+            return ctx->host == nullptr;
+
+        case GGML_OP_MUL_MAT:
+            // Prefill (large M): NPU weight GEMM. Decode
+            // falls through to the nested CPU like every other op.
+            return ggml_xdna_gemm_runs_here(dctx, node)
+#if defined(GGML_XDNA_EXPERIMENTAL)
+                   || ggml_xdna_act_gemm_ok(dctx, node)
+#endif
+                   ;
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+        case GGML_OP_GATED_DELTA_NET:
+            return ggml_xdna_device_gdn(dctx) != nullptr &&
+                   ggml_xdna_gdn_shape_ok(node, dctx->gdn_shape);
+
+        case GGML_OP_L2_NORM:
+            return ggml_xdna_l2_absorbed_by_gdn(dctx, node);
+
+        case GGML_OP_ADD:
+        case GGML_OP_MUL:
+            return ggml_xdna_device_npu(dctx, ggml_xdna_slot_for_op(node->op)) != nullptr &&
+                   !ggml_xdna_uses_repack_buft(dctx, node) &&
+                   ggml_xdna_binary_shape_ok(node, dctx->op_min);
+
+        case GGML_OP_RMS_NORM:
+            return ggml_xdna_device_npu(dctx, GGML_XDNA_SLOT_RMS_NORM) != nullptr &&
+                   node->src[0] &&
+                   node->type == GGML_TYPE_F32 && node->src[0]->type == GGML_TYPE_F32 &&
+                   ggml_is_contiguous(node) && ggml_is_contiguous(node->src[0]) &&
+                   ggml_are_same_shape(node, node->src[0]) &&
+                   (size_t) node->ne[0] == dctx->rms_row &&
+                   ggml_nelements(node) >= dctx->op_min &&
+                   !ggml_xdna_uses_repack_buft(dctx, node);
+#endif
+
+        default:
+            return false;
+    }
+}
+
+static enum ggml_status ggml_xdna_compute_host_slice(ggml_backend_xdna_context * ctx,
+                                                     struct ggml_cgraph * cgraph,
+                                                     int i0, int i1) {
+    if (!ctx->host) {
+        GGML_LOG_ERROR("%s: own-graph host CPU backend is not initialized\n", "ggml-xdna");
+        return GGML_STATUS_FAILED;
+    }
+    if (i1 <= i0) {
+        return GGML_STATUS_SUCCESS;
+    }
+
+    const uint64_t t0 = ggml_xdna_now_ns();
+
+    if (ctx->dev->host_profile) {
+        // One node per submission so the time lands on a single op. Slower than
+        // the batched path, so this is a diagnostic mode only.
+        for (int i = i0; i < i1; i++) {
+            struct ggml_cgraph one = ggml_graph_view(cgraph, i, i + 1);
+            const uint64_t t_node = ggml_xdna_now_ns();
+            const enum ggml_status st = ggml_backend_graph_compute(ctx->host, &one);
+            const uint64_t ns = ggml_xdna_now_ns() - t_node;
+            if (st != GGML_STATUS_SUCCESS) {
+                GGML_LOG_ERROR("%s: nested CPU compute failed for node %d (%s)\n",
+                               "ggml-xdna", i, ggml_op_desc(cgraph->nodes[i]));
+                return st;
+            }
+            const struct ggml_tensor * n = cgraph->nodes[i];
+            const char * name = ggml_op_desc(n);
+
+            std::string key = name ? name : "?";
+            if (ctx->dev->host_profile > 1) {
+                char buf[128];
+                snprintf(buf, sizeof(buf), " d[%lld,%lld,%lld,%lld]",
+                         (long long) n->ne[0], (long long) n->ne[1],
+                         (long long) n->ne[2], (long long) n->ne[3]);
+                key += buf;
+                if (n->src[0]) {
+                    snprintf(buf, sizeof(buf), " s0[%lld,%lld,%lld,%lld]%s",
+                             (long long) n->src[0]->ne[0], (long long) n->src[0]->ne[1],
+                             (long long) n->src[0]->ne[2], (long long) n->src[0]->ne[3],
+                             ggml_is_contiguous(n->src[0]) ? "c" : "-");
+                    key += buf;
+                }
+            } else if (n->op == GGML_OP_MUL_MAT && n->src[0] && n->src[1]) {
+                // Shape decides whether an NPU submit can ever pay for itself,
+                // so keep matmuls apart by their dimensions.
+                char buf[64];
+                snprintf(buf, sizeof(buf), " K=%lld M=%lld N=%lld x%lld",
+                         (long long) n->src[1]->ne[0],
+                         (long long) n->src[1]->ne[1],
+                         (long long) n->ne[0],
+                         (long long) (n->ne[2] * n->ne[3]));
+                key += buf;
+            }
+
+            uint64_t bytes = ggml_nbytes(n);
+            for (int s = 0; s < GGML_MAX_SRC && n->src[s]; s++) {
+                bytes += ggml_nbytes(n->src[s]);
+            }
+
+            ctx->host_op_ns[key]    += ns;
+            ctx->host_op_calls[key] += 1;
+            ctx->host_op_bytes[key] += bytes;
+        }
+    } else {
+        struct ggml_cgraph view = ggml_graph_view(cgraph, i0, i1);
+        const enum ggml_status st = ggml_backend_graph_compute(ctx->host, &view);
+        if (st != GGML_STATUS_SUCCESS) {
+            GGML_LOG_ERROR("%s: nested CPU compute failed for nodes [%d, %d)\n",
+                           "ggml-xdna", i0, i1);
+            return st;
+        }
+    }
+
+    const uint64_t nested_ns = ggml_xdna_now_ns() - t0;
+    ctx->ns_host += nested_ns;
+    ctx->n_host_graph_runs++;
+    ctx->n_host_nodes += (uint64_t) (i1 - i0);
+    return GGML_STATUS_SUCCESS;
+}
+
+static enum ggml_status ggml_backend_xdna_graph_compute(ggml_backend_t backend, struct ggml_cgraph * cgraph) {
+    ggml_backend_xdna_context * ctx = (ggml_backend_xdna_context *)backend->context;
+
+    for (int i = 0; i < cgraph->n_nodes; i++) {
+        struct ggml_tensor * node = cgraph->nodes[i];
+
+        if ((node->flags & GGML_TENSOR_FLAG_COMPUTE) == 0) {
+            continue;
+        }
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+        if (ggml_xdna_can_fuse_add_rms_mul(ctx, cgraph, i)) {
+            if (!ggml_xdna_compute_add_rms_mul(ctx, cgraph, i)) {
+                return GGML_STATUS_FAILED;
+            }
+            i += 2;
+            continue;
+        }
+#endif
+
+        if (!ggml_xdna_is_local_op(ctx, node)) {
+            int j = i + 1;
+            while (j < cgraph->n_nodes) {
+                struct ggml_tensor * next = cgraph->nodes[j];
+                if ((next->flags & GGML_TENSOR_FLAG_COMPUTE) == 0) {
+                    j++;
+                    continue;
+                }
+                if (
+#if defined(GGML_XDNA_EXPERIMENTAL)
+                    ggml_xdna_can_fuse_add_rms_mul(ctx, cgraph, j) ||
+#endif
+                    ggml_xdna_is_local_op(ctx, next)) {
+                    break;
+                }
+                j++;
+            }
+            const enum ggml_status st = ggml_xdna_compute_host_slice(ctx, cgraph, i, j);
+            if (st != GGML_STATUS_SUCCESS) {
+                return st;
+            }
+            i = j - 1;
+            continue;
+        }
+
+        const uint64_t t_local = ctx->dev->host_profile ? ggml_xdna_now_ns() : 0;
+
+        switch (node->op) {
+            case GGML_OP_MUL_MAT:
+                if (!ggml_xdna_compute_mul_mat(ctx, node, nullptr)) {
+                    return GGML_STATUS_FAILED;
+                }
+                break;
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+            case GGML_OP_ADD:
+            case GGML_OP_MUL:
+                if (!ggml_xdna_compute_binary(ctx, node)) {
+                    return GGML_STATUS_FAILED;
+                }
+                break;
+
+            case GGML_OP_RMS_NORM:
+                if (!ggml_xdna_compute_rms_norm(ctx, node)) {
+                    return GGML_STATUS_FAILED;
+                }
+                break;
+
+            case GGML_OP_GATED_DELTA_NET:
+                if (!ggml_xdna_compute_gated_delta_net(ctx, node)) {
+                    return GGML_STATUS_FAILED;
+                }
+                break;
+
+            case GGML_OP_L2_NORM:
+                // Absorbed into GDN packing (stage 5). No device write.
+                break;
+#endif
+
+            case GGML_OP_NONE:
+            case GGML_OP_RESHAPE:
+            case GGML_OP_VIEW:
+            case GGML_OP_PERMUTE:
+            case GGML_OP_TRANSPOSE:
+                break;
+
+            default:
+                GGML_ABORT("%s: local-op table out of sync for %s\n",
+                           __func__, ggml_op_desc(node));
+        }
+
+        if (t_local) {
+            const std::string key = std::string("[local] ") + ggml_op_desc(node);
+            uint64_t bytes = ggml_nbytes(node);
+            for (int s = 0; s < GGML_MAX_SRC && node->src[s]; s++) {
+                bytes += ggml_nbytes(node->src[s]);
+            }
+            ctx->host_op_ns[key]    += ggml_xdna_now_ns() - t_local;
+            ctx->host_op_calls[key] += 1;
+            ctx->host_op_bytes[key] += bytes;
+        }
+    }
+
+    return GGML_STATUS_SUCCESS;
+}
+
+static struct ggml_backend_i xdna_backend_i = {
+    /* .get_name                = */ ggml_backend_xdna_get_name,
+    /* .free                    = */ ggml_backend_xdna_free,
+    /* .set_tensor_async        = */ NULL,
+    /* .get_tensor_async        = */ NULL,
+    /* .set_tensor_2d_async     = */ NULL,
+    /* .get_tensor_2d_async     = */ NULL,
+    /* .cpy_tensor_async        = */ NULL,
+    /* .synchronize             = */ NULL,
+    /* .graph_plan_create       = */ NULL,
+    /* .graph_plan_free         = */ NULL,
+    /* .graph_plan_update       = */ NULL,
+    /* .graph_plan_compute      = */ NULL,
+    /* .graph_compute           = */ ggml_backend_xdna_graph_compute,
+    /* .event_record            = */ NULL,
+    /* .event_wait              = */ NULL,
+    /* .graph_optimize          = */ NULL,
+};
+
+static ggml_guid_t ggml_backend_xdna_guid(void) {
+    static ggml_guid guid = { 0xd1, 0xa5, 0x0d, 0xda, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb };
+    return &guid;
+}
+
+ggml_backend_t ggml_backend_xdna_init(void) {
+    ggml_backend_xdna_device_context * dev = ggml_xdna_device_context();
+
+    ggml_backend_xdna_context * ctx = new ggml_backend_xdna_context;
+    ctx->dev = dev;
+
+    if (dev->own_graph) {
+        ctx->host = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+        if (!ctx->host) {
+            GGML_LOG_WARN("%s: OWN_GRAPH enabled but CPU backend init failed; "
+                          "falling back to split scheduling\n", __func__);
+            dev->own_graph = false;
+        }
+    }
+
+    std::string live;
+    for (const ggml_xdna_gemm_slot & slot : dev->gemm) {
+        if (slot.enabled && slot.found) {
+            live += live.empty() ? "" : ", ";
+            live += slot.env_name;
+        }
+    }
+#if defined(GGML_XDNA_EXPERIMENTAL)
+    // Load every available experimental kernel up front.
+    for (int i = 0; i < GGML_XDNA_N_SLOTS; i++) {
+        if (ggml_xdna_device_npu(dev, (ggml_xdna_slot_idx) i)) {
+            live += live.empty() ? "" : ", ";
+            live += dev->slots[i].env_name;
+        }
+    }
+    if (ggml_xdna_device_gdn(dev)) {
+        live += live.empty() ? "" : ", ";
+        live += "GDN";
+    }
+#endif
+
+    GGML_LOG_INFO("%s: XDNA backend init: device=%s, kernels=%s, own_graph=%s\n",
+                  __func__,
+                  dev->npu_name.c_str(),
+                  live.empty() ? "none" : live.c_str(),
+                  dev->own_graph ? "on" : "off");
+
+    ggml_backend_t backend = new ggml_backend {
+        /* .guid    = */ ggml_backend_xdna_guid(),
+        /* .iface   = */ xdna_backend_i,
+        /* .device  = */ ggml_backend_reg_dev_get(ggml_backend_xdna_reg(), 0),
+        /* .context = */ ctx,
+    };
+
+    return backend;
+}
+
+bool ggml_backend_is_xdna(ggml_backend_t backend) {
+    return backend != NULL && ggml_guid_matches(backend->guid, ggml_backend_xdna_guid());
+}
+
+static const char * ggml_backend_xdna_device_get_name(ggml_backend_dev_t dev) {
+    GGML_UNUSED(dev);
+    return "XDNA";
+}
+
+static const char * ggml_backend_xdna_device_get_description(ggml_backend_dev_t dev) {
+    return ((ggml_backend_xdna_device_context *)dev->context)->description.c_str();
+}
+
+static void ggml_backend_xdna_device_get_memory(ggml_backend_dev_t dev, size_t * free, size_t * total) {
+    *free  = 0;
+    *total = 0;
+    GGML_UNUSED(dev);
+}
+
+static enum ggml_backend_dev_type ggml_backend_xdna_device_get_type(ggml_backend_dev_t dev) {
+    GGML_UNUSED(dev);
+    return GGML_BACKEND_DEVICE_TYPE_ACCEL;
+}
+
+static void ggml_backend_xdna_device_get_props(ggml_backend_dev_t dev, struct ggml_backend_dev_props * props) {
+    props->name        = ggml_backend_xdna_device_get_name(dev);
+    props->description = ggml_backend_xdna_device_get_description(dev);
+    props->type        = ggml_backend_xdna_device_get_type(dev);
+    ggml_backend_xdna_device_get_memory(dev, &props->memory_free, &props->memory_total);
+    props->caps = {
+        /* .async                 = */ false,
+        /* .host_buffer           = */ false,
+        /* .buffer_from_host_ptr  = */ true,
+        /* .events                = */ false,
+    };
+}
+
+static ggml_backend_t ggml_backend_xdna_device_init_backend(ggml_backend_dev_t dev, const char * params) {
+    GGML_UNUSED(dev);
+    GGML_UNUSED(params);
+    return ggml_backend_xdna_init();
+}
+
+// ** MUL_MAT **
+//
+// The design takes bf16 operands swizzled into the MMUL micro-tile order and
+// returns f32 in the same order, so every operand has to be laid out for it.
+// Weights are converted once at model load into device-visible memory; only the
+// activations and the result are rearranged per submit.
+//
+// Streams a submit consumes, in the order the runtime pushes them:
+//   A  [grid_r][nb][kt]  swizzled (tile_m x tile_k)
+//   B  [grid_c][nb][kt]  swizzled (tile_k x tile_n)
+//   C  [grid_c][nb][grid_r] swizzled (tile_m x tile_n)
+// with the column block a worker sees at n0 = (nb*grid_c + j)*tile_n.
+
+static inline size_t ggml_xdna_swz_a(int mm, int kk, int tile_k) {
+    const int r = GGML_XDNA_GEMM_MAC_R, s = GGML_XDNA_GEMM_MAC_S;
+    return ((size_t) (mm / r) * (tile_k / s) + kk / s) * r * s + (size_t) (mm % r) * s + (kk % s);
+}
+
+static inline size_t ggml_xdna_swz_b(int kk, int nn, int tile_n) {
+    const int s = GGML_XDNA_GEMM_MAC_S, t = GGML_XDNA_GEMM_MAC_T;
+    return ((size_t) (kk / s) * (tile_n / t) + nn / t) * s * t + (size_t) (kk % s) * t + (nn % t);
+}
+
+static inline size_t ggml_xdna_swz_c(int mm, int nn, int tile_n) {
+    const int r = GGML_XDNA_GEMM_MAC_R, t = GGML_XDNA_GEMM_MAC_T;
+    return ((size_t) (mm / r) * (tile_n / t) + nn / t) * r * t + (size_t) (mm % r) * t + (nn % t);
+}
+
+// Bytes a full weight tensor occupies after repack.
+// Layout: [n_block][k_block][grid_c][kt][swizzled tile]
+static size_t ggml_xdna_gemm_weight_bytes(int64_t k_src, int64_t n_src,
+                                          const ggml_xdna_gemm_shape & s) {
+    const int n_cols  = s.grid_c * s.tile_n;
+    const int k_slice = s.kt * s.tile_k;
+    const int n_blocks = (int) ((n_src + n_cols - 1) / n_cols);
+    const int k_blocks = (int) ((k_src + k_slice - 1) / k_slice);
+    return (size_t) n_blocks * k_blocks * s.grid_c * s.kt * s.tile_k * s.tile_n * sizeof(ggml_bf16_t);
+}
+
+static size_t ggml_xdna_gemm_b_block_bytes(const ggml_xdna_gemm_shape & s) {
+    return (size_t) s.grid_c * s.kt * s.tile_k * s.tile_n * sizeof(ggml_bf16_t);
+}
+
+// Pack weights as [n_block][k_block][grid_c][kt][tile].
+static void ggml_xdna_gemm_pack_weights(const ggml_tensor *          tensor,
+                                        const void *                 data,
+                                        ggml_bf16_t *                out,
+                                        const ggml_xdna_gemm_shape & s) {
+    const int64_t k_src = tensor->ne[0];
+    const int64_t n_src = tensor->ne[1];
+    const int     k_slice = s.kt * s.tile_k;
+    const int     n_cols  = s.grid_c * s.tile_n;
+    const int     k_blocks = (int) ((k_src + k_slice - 1) / k_slice);
+    const int     n_blocks = (int) ((n_src + n_cols - 1) / n_cols);
+
+    const ggml_type_traits * traits = ggml_get_type_traits(tensor->type);
+    const size_t row_bytes = ggml_row_size(tensor->type, k_src);
+
+    std::vector<float> row(k_blocks * k_slice, 0.0f);
+    const size_t b_block = ggml_xdna_gemm_b_block_bytes(s) / sizeof(ggml_bf16_t);
+
+    memset(out, 0, (size_t) n_blocks * k_blocks * b_block * sizeof(ggml_bf16_t));
+
+    for (int64_t n = 0; n < n_src; n++) {
+        traits->to_float((const char *) data + (size_t) n * row_bytes, row.data(), k_src);
+
+        const int n_blk = (int) (n / s.tile_n);
+        const int nn    = (int) (n % s.tile_n);
+        const int nb    = n_blk / s.grid_c;
+        const int j     = n_blk % s.grid_c;
+
+        for (int kb = 0; kb < k_blocks; kb++) {
+            ggml_bf16_t * base = out + ((size_t) nb * k_blocks + kb) * b_block;
+            for (int kt = 0; kt < s.kt; kt++) {
+                const int k0 = kb * k_slice + kt * s.tile_k;
+                ggml_bf16_t * tile = base + ((size_t) j * s.kt + kt) * s.tile_k * s.tile_n;
+                for (int kk = 0; kk < s.tile_k; kk++) {
+                    tile[ggml_xdna_swz_b(kk, nn, s.tile_n)] =
+                        GGML_FP32_TO_BF16(row[k0 + kk]);
+                }
+            }
+        }
+    }
+}
+
+// Pack activations for one K-slice starting at k0 (length s.kt*tile_k).
+static void ggml_xdna_gemm_pack_activations(const float *                src,
+                                            int64_t                      k_src,
+                                            int64_t                      m_src,
+                                            int64_t                      m0,
+                                            int64_t                      k0,
+                                            ggml_bf16_t *                out,
+                                            const ggml_xdna_gemm_shape & s,
+                                            int                          n_threads) {
+    const size_t per_mb  = (size_t) s.kt * s.tile_m * s.tile_k;
+    const int    k_slice = s.kt * s.tile_k;
+    const bool   k_full  = (k0 + k_slice) <= k_src;
+    const int    n_units = s.grid_r * s.mb;
+
+    // Each unit owns one contiguous per_mb region, so the zero fill for padded
+    // rows/columns can be done per unit and the loop parallelised.
+#ifdef GGML_XDNA_OPENMP
+#   pragma omp parallel for schedule(static) num_threads(n_threads)
+#else
+    GGML_UNUSED(n_threads);
+#endif
+    for (int unit = 0; unit < n_units; unit++) {
+        const int i  = unit / s.mb;
+        const int mb = unit % s.mb;
+
+        ggml_bf16_t * base = out + (size_t) unit * per_mb;
+        const int64_t m_base = m0 + (int64_t) (mb * s.grid_r + i) * s.tile_m;
+
+        if (m_base >= m_src || !k_full || m_base + s.tile_m > m_src) {
+            memset(base, 0, per_mb * sizeof(ggml_bf16_t));
+        }
+        if (m_base >= m_src) {
+            continue;
+        }
+
+        for (int kt = 0; kt < s.kt; kt++) {
+            ggml_bf16_t * tile = base + (size_t) kt * s.tile_m * s.tile_k;
+            const int64_t k_base = k0 + (int64_t) kt * s.tile_k;
+
+            for (int mm = 0; mm < s.tile_m; mm++) {
+                const int64_t m = m_base + mm;
+                if (m >= m_src) {
+                    break;
+                }
+                const float * row = src + (size_t) m * k_src + k_base;
+                if (k_full) {
+                    for (int kk = 0; kk < s.tile_k; kk++) {
+                        tile[ggml_xdna_swz_a(mm, kk, s.tile_k)] =
+                            GGML_FP32_TO_BF16(row[kk]);
+                    }
+                } else {
+                    for (int kk = 0; kk < s.tile_k; kk++) {
+                        if (k_base + kk < k_src) {
+                            tile[ggml_xdna_swz_a(mm, kk, s.tile_k)] =
+                                GGML_FP32_TO_BF16(row[kk]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+// Pack activations for one K-slice. Supports dim-0-contiguous tensors with
+// arbitrary row/head strides (permuted K/Q after attention reshape).
+static void ggml_xdna_gemm_pack_activations_strided(const char *                src,
+                                                    size_t                      nb1,
+                                                    int64_t                     k_src,
+                                                    int64_t                     m_src,
+                                                    int64_t                     m0,
+                                                    int64_t                     k0,
+                                                    ggml_bf16_t *               out,
+                                                    const ggml_xdna_gemm_shape & s,
+                                                    int                         n_threads) {
+    const size_t per_mb  = (size_t) s.kt * s.tile_m * s.tile_k;
+    const int    k_slice = s.kt * s.tile_k;
+    const bool   k_full  = (k0 + k_slice) <= k_src;
+    const int    n_units = s.grid_r * s.mb;
+
+#ifdef GGML_XDNA_OPENMP
+#   pragma omp parallel for schedule(static) num_threads(n_threads)
+#else
+    GGML_UNUSED(n_threads);
+#endif
+    for (int unit = 0; unit < n_units; unit++) {
+        const int i  = unit / s.mb;
+        const int mb = unit % s.mb;
+
+        ggml_bf16_t * base = out + (size_t) unit * per_mb;
+        const int64_t m_base = m0 + (int64_t) (mb * s.grid_r + i) * s.tile_m;
+
+        if (m_base >= m_src || !k_full || m_base + s.tile_m > m_src) {
+            memset(base, 0, per_mb * sizeof(ggml_bf16_t));
+        }
+        if (m_base >= m_src) {
+            continue;
+        }
+
+        for (int kt = 0; kt < s.kt; kt++) {
+            ggml_bf16_t * tile = base + (size_t) kt * s.tile_m * s.tile_k;
+            const int64_t k_base = k0 + (int64_t) kt * s.tile_k;
+
+            for (int mm = 0; mm < s.tile_m; mm++) {
+                const int64_t m = m_base + mm;
+                if (m >= m_src) {
+                    break;
+                }
+                const float * row = (const float *) (src + (size_t) m * nb1) + k_base;
+                if (k_full) {
+                    for (int kk = 0; kk < s.tile_k; kk++) {
+                        tile[ggml_xdna_swz_a(mm, kk, s.tile_k)] =
+                            GGML_FP32_TO_BF16(row[kk]);
+                    }
+                } else {
+                    for (int kk = 0; kk < s.tile_k; kk++) {
+                        if (k_base + kk < k_src) {
+                            tile[ggml_xdna_swz_a(mm, kk, s.tile_k)] =
+                                GGML_FP32_TO_BF16(row[kk]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Pack one column block of an F32/F16 activation matrix as the B operand.
+// src is [K, N] with dim-0 contiguous; nb1 is the byte stride of dimension 1.
+static void ggml_xdna_gemm_pack_b_activations(const char *                 src,
+                                              size_t                       nb1,
+                                              enum ggml_type               type,
+                                              int64_t                      k_src,
+                                              int64_t                      n_src,
+                                              int64_t                      n0,
+                                              int64_t                      k0,
+                                              ggml_bf16_t *                out,
+                                              const ggml_xdna_gemm_shape & s,
+                                              int                          n_threads) {
+    const size_t b_elems = (size_t) s.grid_c * s.kt * s.tile_k * s.tile_n;
+    const size_t ts      = ggml_type_size(type);
+
+    memset(out, 0, b_elems * sizeof(ggml_bf16_t));
+
+#ifdef GGML_XDNA_OPENMP
+#   pragma omp parallel for schedule(static) num_threads(n_threads) collapse(2)
+#else
+    GGML_UNUSED(n_threads);
+#endif
+    for (int j = 0; j < s.grid_c; j++) {
+        for (int nn = 0; nn < s.tile_n; nn++) {
+            const int64_t n = n0 + (int64_t) j * s.tile_n + nn;
+            if (n >= n_src) {
+                continue;
+            }
+            const char * col = src + (size_t) n * nb1 + (size_t) k0 * ts;
+            for (int kt = 0; kt < s.kt; kt++) {
+                ggml_bf16_t * tile = out + ((size_t) j * s.kt + kt) * s.tile_k * s.tile_n;
+                const int64_t k_base = (int64_t) kt * s.tile_k;
+                for (int kk = 0; kk < s.tile_k; kk++) {
+                    if (k0 + k_base + kk >= k_src) {
+                        continue;
+                    }
+                    float v;
+                    if (type == GGML_TYPE_F16) {
+                        v = GGML_FP16_TO_FP32(((const ggml_fp16_t *) col)[k_base + kk]);
+                    } else {
+                        v = ((const float *) col)[k_base + kk];
+                    }
+                    tile[ggml_xdna_swz_b(kk, nn, s.tile_n)] = GGML_FP32_TO_BF16(v);
+                }
+            }
+        }
+    }
+}
+#endif
+
+// Sum the K-slices of one column block straight out of the device buffers into
+// dst. Units write disjoint (row, column) regions, so the flattened loop is
+// safe to run in parallel, and dst is touched exactly once per column block.
+static void ggml_xdna_gemm_scatter_result(const float * const *        c_slices,
+                                          int                          n_slices,
+                                          float *                      dst,
+                                          int64_t                      n_dst,
+                                          int64_t                      n0,
+                                          int64_t                      m_src,
+                                          int64_t                      m0,
+                                          const ggml_xdna_gemm_shape & s,
+                                          bool                         accumulate,
+                                          int                          n_threads) {
+    const int n_units = s.grid_c * s.mb * s.grid_r;
+
+#ifdef GGML_XDNA_OPENMP
+#   pragma omp parallel for schedule(static) num_threads(n_threads)
+#else
+    GGML_UNUSED(n_threads);
+#endif
+    for (int unit = 0; unit < n_units; unit++) {
+        const int i  = unit % s.grid_r;
+        const int mb = (unit / s.grid_r) % s.mb;
+        const int j  = unit / (s.grid_r * s.mb);
+
+        const size_t  tile_off = (size_t) unit * s.tile_m * s.tile_n;
+        const int64_t m_base   = m0 + (int64_t) (mb * s.grid_r + i) * s.tile_m;
+        if (m_base >= m_src) {
+            continue;
+        }
+
+        for (int mm = 0; mm < s.tile_m; mm++) {
+            const int64_t m = m_base + mm;
+            if (m >= m_src) {
+                break;
+            }
+            float * row = dst + (size_t) m * n_dst;
+
+            for (int nn = 0; nn < s.tile_n; nn++) {
+                const int64_t n = n0 + (int64_t) j * s.tile_n + nn;
+                if (n >= n_dst) {
+                    continue;
+                }
+                const size_t e = tile_off + ggml_xdna_swz_c(mm, nn, s.tile_n);
+
+                float v = c_slices[0][e];
+                for (int k = 1; k < n_slices; k++) {
+                    v += c_slices[k][e];
+                }
+                row[n] = accumulate ? row[n] + v : v;
+            }
+        }
+    }
+}
+
+// ** repack buffer **
+//
+// The XRT BO holds the swizzled BF16 the GEMM design reads, so a submit never
+// copies weights. With keep_src, tensor->data is a separate host allocation of
+// the original GGUF bytes (same DRAM as `-ngl 0`); packed[] maps each weight
+// back to its BO address. Without keep_src, tensor->data is the swizzle and
+// the nested CPU cannot read it.
+
+struct ggml_xdna_host_src {
+    void * ptr  = nullptr;
+    size_t size = 0;
+};
+
+struct ggml_backend_xdna_buffer_context {
+    ggml_xdna_buf * buf  = nullptr;
+    void *          base = nullptr;
+    size_t          size = 0;
+    std::vector<ggml_xdna_host_src> host_src;
+    std::unordered_map<const ggml_tensor *, char *> packed;
+};
+
+static char * ggml_xdna_weight_packed(ggml_backend_xdna_buffer_context * ctx,
+                                      const ggml_tensor * tensor) {
+    auto it = ctx->packed.find(tensor);
+    if (it != ctx->packed.end()) {
+        return it->second;
+    }
+    return (char *) tensor->data;
+}
+
+static ggml_xdna_gemm_slot * ggml_xdna_gemm_for_weight(ggml_backend_xdna_device_context * dctx,
+                                                       const ggml_tensor * tensor) {
+    if (!tensor || tensor->ne[2] != 1 || tensor->ne[3] != 1) {
+        return nullptr;
+    }
+    return ggml_xdna_gemm_for_shape(dctx, tensor->ne[0], tensor->ne[1]);
+}
+
+// Weight-buffer probe: return false on the host buft so select_weight_buft
+// lands on XDNA_REPACK. Quantized was used as a proxy for "model weight";
+// BF16/F16 GGUF weights also pack (to_float) and must take the same path.
+// F32 src0 with matching K/N is usually an activation (QK/AV has ne[2]!=1).
+static bool ggml_xdna_gemm_should_repack_weight(ggml_backend_xdna_device_context * dctx,
+                                                const ggml_tensor * w) {
+    if (!ggml_xdna_gemm_for_weight(dctx, w)) {
+        return false;
+    }
+    if (w->type == GGML_TYPE_F32) {
+        return false;
+    }
+    const ggml_type_traits * traits = ggml_get_type_traits(w->type);
+    return traits && traits->to_float != nullptr;
+}
+
+static void ggml_backend_xdna_buffer_free(ggml_backend_buffer_t buffer) {
+    ggml_backend_xdna_buffer_context * ctx = (ggml_backend_xdna_buffer_context *) buffer->context;
+    for (ggml_xdna_host_src & src : ctx->host_src) {
+        ggml_aligned_free(src.ptr, src.size);
+    }
+    ggml_xdna_buf_free(ctx->buf);
+    delete ctx;
+}
+
+static enum ggml_status ggml_backend_xdna_buffer_init_tensor(ggml_backend_buffer_t buffer,
+                                                             ggml_tensor *         tensor) {
+    ggml_backend_xdna_buffer_context * ctx = (ggml_backend_xdna_buffer_context *) buffer->context;
+    ggml_backend_xdna_device_context * dctx =
+        (ggml_backend_xdna_device_context *) buffer->buft->device->context;
+
+    if (!dctx->keep_src || !ggml_xdna_gemm_for_weight(dctx, tensor)) {
+        return GGML_STATUS_SUCCESS;
+    }
+
+    const size_t nbytes = ggml_nbytes(tensor);
+    void * host = ggml_aligned_malloc(nbytes);
+    if (!host) {
+        GGML_LOG_ERROR("%s: host copy of '%s' (%zu bytes) failed\n",
+                       "ggml-xdna", tensor->name, nbytes);
+        return GGML_STATUS_FAILED;
+    }
+
+    ctx->packed[tensor] = (char *) tensor->data;
+    ctx->host_src.push_back({ host, nbytes });
+    tensor->data = host;
+    return GGML_STATUS_SUCCESS;
+}
+
+static void * ggml_backend_xdna_buffer_get_base(ggml_backend_buffer_t buffer) {
+    return ((ggml_backend_xdna_buffer_context *) buffer->context)->base;
+}
+
+static void ggml_backend_xdna_buffer_set_tensor(ggml_backend_buffer_t buffer,
+                                                ggml_tensor *         tensor,
+                                                const void *          data,
+                                                size_t                offset,
+                                                size_t                size) {
+    ggml_backend_xdna_buffer_context * ctx = (ggml_backend_xdna_buffer_context *) buffer->context;
+    ggml_backend_xdna_device_context * dctx =
+        (ggml_backend_xdna_device_context *) buffer->buft->device->context;
+
+    ggml_xdna_gemm_slot * slot = ggml_xdna_gemm_for_weight(dctx, tensor);
+    if (!slot) {
+        // Not a tensor we repack: it was placed here only because it shares a
+        // buffer with ones we do, so keep the plain bytes.
+        memcpy((char *) tensor->data + offset, data, size);
+        return;
+    }
+
+    GGML_ASSERT(offset == 0 && size == ggml_nbytes(tensor));
+
+    if (dctx->keep_src) {
+        memcpy(tensor->data, data, size);
+    }
+
+    char * packed = ggml_xdna_weight_packed(ctx, tensor);
+    ggml_xdna_gemm_pack_weights(tensor, data, (ggml_bf16_t *) packed, slot->shape);
+
+    const size_t w_off = (size_t) (packed - (char *) ctx->base);
+    ggml_xdna_buf_sync_to_device(ctx->buf, w_off,
+        ggml_xdna_gemm_weight_bytes(tensor->ne[0], tensor->ne[1], slot->shape));
+}
+
+static void ggml_backend_xdna_buffer_get_tensor(ggml_backend_buffer_t buffer,
+                                                const ggml_tensor *   tensor,
+                                                void *                data,
+                                                size_t                offset,
+                                                size_t                size) {
+    ggml_backend_xdna_device_context * dctx =
+        (ggml_backend_xdna_device_context *) buffer->buft->device->context;
+
+    if (dctx->keep_src || !ggml_xdna_gemm_for_weight(dctx, tensor)) {
+        memcpy(data, (const char *) tensor->data + offset, size);
+        return;
+    }
+
+    // Without the source copy only the swizzled bf16 is left, and reading it
+    // back would mean requantizing into the source format.
+    GGML_ABORT("ggml-xdna: reading back repacked weight '%s' (%s [%lld,%lld]) is not supported\n",
+               tensor->name, ggml_type_name(tensor->type),
+               (long long) tensor->ne[0], (long long) tensor->ne[1]);
+}
+
+static void ggml_backend_xdna_buffer_clear(ggml_backend_buffer_t buffer, uint8_t value) {
+    ggml_backend_xdna_buffer_context * ctx = (ggml_backend_xdna_buffer_context *) buffer->context;
+    memset(ctx->base, value, ctx->size);
+    ggml_xdna_buf_sync_to_device(ctx->buf, 0, ctx->size);
+}
+
+static const ggml_backend_buffer_i ggml_backend_xdna_buffer_i = {
+    /* .free_buffer     = */ ggml_backend_xdna_buffer_free,
+    /* .get_base        = */ ggml_backend_xdna_buffer_get_base,
+    /* .init_tensor     = */ ggml_backend_xdna_buffer_init_tensor,
+    /* .memset_tensor   = */ NULL,
+    /* .set_tensor      = */ ggml_backend_xdna_buffer_set_tensor,
+    /* .get_tensor      = */ ggml_backend_xdna_buffer_get_tensor,
+    /* .set_tensor_2d   = */ NULL,
+    /* .get_tensor_2d   = */ NULL,
+    /* .cpy_tensor      = */ NULL,
+    /* .clear           = */ ggml_backend_xdna_buffer_clear,
+    /* .reset           = */ NULL,
+};
+
+static const char * ggml_backend_xdna_buffer_type_name(ggml_backend_buffer_type_t buft) {
+    GGML_UNUSED(buft);
+    return "XDNA_REPACK";
+}
+
+static ggml_backend_buffer_t ggml_backend_xdna_buffer_type_alloc(ggml_backend_buffer_type_t buft,
+                                                                 size_t                     size) {
+    ggml_backend_xdna_device_context * dctx =
+        (ggml_backend_xdna_device_context *) buft->device->context;
+
+    // Any GEMM context can own the allocation: the BOs are host-only and all
+    // artifacts sit on the same device with the same memory topology.
+    ggml_xdna_npu * npu = nullptr;
+    for (int i = 0; i < GGML_XDNA_N_GEMM && !npu; i++) {
+        npu = ggml_xdna_device_gemm(dctx, (ggml_xdna_gemm_idx) i);
+    }
+    if (!npu) {
+        return nullptr;
+    }
+
+    ggml_xdna_buf * buf = ggml_xdna_buf_alloc(npu, size);
+    if (!buf) {
+        return nullptr;
+    }
+
+    ggml_backend_xdna_buffer_context * ctx = new ggml_backend_xdna_buffer_context;
+    ctx->buf  = buf;
+    ctx->base = ggml_xdna_buf_host(buf);
+    ctx->size = size;
+
+    return ggml_backend_buffer_init(buft, ggml_backend_xdna_buffer_i, ctx, size);
+}
+
+static size_t ggml_backend_xdna_buffer_type_get_alignment(ggml_backend_buffer_type_t buft) {
+    GGML_UNUSED(buft);
+    return 64;
+}
+
+static size_t ggml_backend_xdna_buffer_type_get_alloc_size(ggml_backend_buffer_type_t buft,
+                                                           const ggml_tensor *        tensor) {
+    ggml_backend_xdna_device_context * dctx =
+        (ggml_backend_xdna_device_context *) buft->device->context;
+
+    if (tensor->ne[2] != 1 || tensor->ne[3] != 1) {
+        return ggml_nbytes(tensor);
+    }
+
+    for (const ggml_xdna_gemm_slot & slot : dctx->gemm) {
+        if (!slot.found) {
+            continue;
+        }
+        if (ggml_xdna_gemm_shape_ok(tensor->ne[0], tensor->ne[1])) {
+            return ggml_xdna_gemm_weight_bytes(tensor->ne[0], tensor->ne[1], slot.shape);
+        }
+    }
+
+    return ggml_nbytes(tensor);
+}
+
+static bool ggml_backend_xdna_buffer_type_is_host(ggml_backend_buffer_type_t buft) {
+    GGML_UNUSED(buft);
+    return false;
+}
+
+static ggml_backend_buffer_type_t ggml_backend_xdna_repack_buffer_type(ggml_backend_dev_t dev) {
+    ggml_backend_xdna_device_context * dctx = (ggml_backend_xdna_device_context *) dev->context;
+
+    if (dctx->repack_buft.device == nullptr) {
+        dctx->repack_buft = {
+            /* .iface = */ {
+                /* .get_name       = */ ggml_backend_xdna_buffer_type_name,
+                /* .alloc_buffer   = */ ggml_backend_xdna_buffer_type_alloc,
+                /* .get_alignment  = */ ggml_backend_xdna_buffer_type_get_alignment,
+                /* .get_max_size   = */ NULL,
+                /* .get_alloc_size = */ ggml_backend_xdna_buffer_type_get_alloc_size,
+                /* .is_host        = */ ggml_backend_xdna_buffer_type_is_host,
+            },
+            /* .device  = */ dev,
+            /* .context = */ nullptr,
+        };
+    }
+
+    return &dctx->repack_buft;
+}
+
+// A MUL_MAT is ours only when src0 was repacked into our buffer: no other layout
+// matches the design, and equally nothing else can read ours.
+static ggml_xdna_gemm_slot * ggml_xdna_gemm_slot_for_op(ggml_backend_xdna_device_context * dctx,
+                                                       const ggml_tensor *                op) {
+    const ggml_tensor * src0 = op->src[0];
+    const ggml_tensor * src1 = op->src[1];
+
+    if (!src0 || !src1 || op->type != GGML_TYPE_F32 || src1->type != GGML_TYPE_F32) {
+        return nullptr;
+    }
+    if (!src0->buffer || src0->buffer->buft != &dctx->repack_buft) {
+        return nullptr;
+    }
+    if (src0->ne[2] != 1 || src0->ne[3] != 1 || src1->ne[2] != 1 || src1->ne[3] != 1) {
+        return nullptr;
+    }
+    if (!ggml_is_contiguous(src1) || !ggml_is_contiguous(op)) {
+        return nullptr;
+    }
+    if (src1->ne[0] != src0->ne[0] || op->ne[0] != src0->ne[1] || op->ne[1] != src1->ne[1]) {
+        return nullptr;
+    }
+
+    return ggml_xdna_gemm_for_shape(dctx, src0->ne[0], src0->ne[1], src1->ne[1]);
+}
+
+static bool ggml_xdna_gemm_supports(ggml_backend_xdna_device_context * dctx,
+                                    const ggml_tensor *                op) {
+    return ggml_xdna_gemm_slot_for_op(dctx, op) != nullptr;
+}
+
+// A repacked MUL_MAT the NPU would not take (decode-sized M) is better off on
+// the nested CPU: with keep_src the original GGUF bytes live in host DRAM, so
+// the quantized kernels beat a bf16 host GEMM on twice the weight traffic.
+static bool ggml_xdna_gemm_runs_here(ggml_backend_xdna_device_context * dctx,
+                                     const ggml_tensor *                op) {
+    if (!ggml_xdna_gemm_slot_for_op(dctx, op)) {
+        return false;
+    }
+    return !dctx->keep_src || op->src[1]->ne[1] >= dctx->gemm_m_min;
+}
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+// Act x act MUL_MAT (attention QK/AV): pad K/N up to the artifact quantum and
+// run on the same GEMM design with a runtime-packed B. src0 may be F16 (KV
+// cache); src1/dst are F32.
+static bool ggml_xdna_act_gemm_ok(ggml_backend_xdna_device_context * dctx,
+                                  const ggml_tensor *                op) {
+    const ggml_tensor * src0 = op->src[0];
+    const ggml_tensor * src1 = op->src[1];
+
+    if (!dctx->gemm_enabled || !dctx->npu_enabled || !src0 || !src1) {
+        return false;
+    }
+    if (!dctx->act_gemm) {
+        return false;
+    }
+    if (op->type != GGML_TYPE_F32 || src1->type != GGML_TYPE_F32) {
+        return false;
+    }
+    if (src0->type != GGML_TYPE_F32 && src0->type != GGML_TYPE_F16) {
+        return false;
+    }
+    // Permuted K/V are common; require only dim-0 contiguous (element stride).
+    if (src0->nb[0] != ggml_type_size(src0->type) || src1->nb[0] != sizeof(float) ||
+        !ggml_is_contiguous(op)) {
+        return false;
+    }
+    if (ggml_xdna_uses_repack_buft(dctx, op)) {
+        return false;
+    }
+    if (src1->ne[0] != src0->ne[0] || op->ne[0] != src0->ne[1] || op->ne[1] != src1->ne[1]) {
+        return false;
+    }
+    if (op->ne[3] != 1 || src0->ne[3] != 1 || src1->ne[3] != 1) {
+        return false;
+    }
+
+    const int64_t k = src0->ne[0];
+    const int64_t n = src0->ne[1];
+    const int64_t m = src1->ne[1];
+    if (m < dctx->gemm_m_min || k <= 0 || n <= 0) {
+        return false;
+    }
+
+    const int     k_slice = GGML_XDNA_GEMM_KT * GGML_XDNA_GEMM_TILE_K;
+    const int     n_cols  = GGML_XDNA_GEMM_GRID_C * GGML_XDNA_GEMM_TILE_N;
+    const int64_t k_pad   = ((k + k_slice - 1) / k_slice) * k_slice;
+    const int64_t n_pad   = ((n + n_cols  - 1) / n_cols)  * n_cols;
+
+    // Skip GDN-scale mats (64/128): submit overhead dominates there.
+    if ((int64_t) k * m * n < (int64_t) 256 * 512 * 256) {
+        return false;
+    }
+
+    return ggml_xdna_gemm_for_shape(dctx, k_pad, n_pad, m) != nullptr;
+}
+
+static bool ggml_xdna_compute_mul_mat_act(ggml_backend_xdna_context * ctx,
+                                          const struct ggml_tensor * node) {
+    const ggml_tensor * src0 = node->src[0];
+    const ggml_tensor * src1 = node->src[1];
+
+    const int64_t k_src = src0->ne[0];
+    const int64_t n_src = src0->ne[1];
+    const int64_t m_src = src1->ne[1];
+
+    const int     k_slice = GGML_XDNA_GEMM_KT * GGML_XDNA_GEMM_TILE_K;
+    const int     n_cols  = GGML_XDNA_GEMM_GRID_C * GGML_XDNA_GEMM_TILE_N;
+    const int64_t k_pad   = ((k_src + k_slice - 1) / k_slice) * k_slice;
+    const int64_t n_pad   = ((n_src + n_cols  - 1) / n_cols)  * n_cols;
+
+    ggml_xdna_gemm_slot * slot = ggml_xdna_gemm_for_shape(ctx->dev, k_pad, n_pad, m_src);
+    if (!slot || !slot->npu) {
+        return false;
+    }
+
+    const ggml_xdna_gemm_shape & s = slot->shape;
+    const int64_t m_block = (int64_t) s.mb * s.grid_r * s.tile_m;
+    const int     k_blocks = (int) (k_pad / k_slice);
+    const int     nth      = ctx->dev->host_threads;
+    const int     kb_max   = std::min(ggml_xdna_npu_gemm_kb_max(slot->npu), GGML_XDNA_GEMM_KB_LIMIT);
+    if (kb_max < 1) {
+        return false;
+    }
+
+    const int64_t n_heads = node->ne[2];
+    const int64_t n_h0    = src0->ne[2];
+    const int64_t n_h1    = src1->ne[2];
+
+    ggml_xdna_npu_gemm_acquire(slot->npu);
+
+    const float * c_slices[GGML_XDNA_GEMM_KB_LIMIT];
+
+    for (int64_t h = 0; h < n_heads; h++) {
+        const int64_t h0 = h * n_h0 / n_heads;
+        const int64_t h1 = h * n_h1 / n_heads;
+
+        const char * a_base = (const char *) src1->data + (size_t) h1 * src1->nb[2];
+        const char * b_base = (const char *) src0->data + (size_t) h0 * src0->nb[2];
+        float *      dst    = (float *) ((char *) node->data + (size_t) h * node->nb[2]);
+
+        for (int64_t m0 = 0; m0 < m_src; m0 += m_block) {
+            for (int kb0 = 0; kb0 < k_blocks; kb0 += kb_max) {
+                const int kb_n = std::min(kb_max, k_blocks - kb0);
+
+                const uint64_t t_pack = ggml_xdna_now_ns();
+                for (int kb = 0; kb < kb_n; kb++) {
+                    ggml_xdna_gemm_pack_activations_strided(
+                        a_base, src1->nb[1], k_src, m_src, m0,
+                        (int64_t) (kb0 + kb) * k_slice,
+                        (ggml_bf16_t *) ggml_xdna_npu_gemm_a_slice(slot->npu, kb),
+                        s, nth);
+                    c_slices[kb] = ggml_xdna_npu_gemm_c_slice(slot->npu, kb);
+                }
+                ctx->ns_gemm_pack += ggml_xdna_now_ns() - t_pack;
+
+                for (int64_t n0 = 0; n0 < n_pad; n0 += n_cols) {
+                    const uint64_t t_b = ggml_xdna_now_ns();
+                    for (int kb = 0; kb < kb_n; kb++) {
+                        ggml_xdna_gemm_pack_b_activations(
+                            b_base, src0->nb[1], src0->type, k_src, n_src, n0,
+                            (int64_t) (kb0 + kb) * k_slice,
+                            (ggml_bf16_t *) ggml_xdna_npu_gemm_b_slice(slot->npu, kb),
+                            s, nth);
+                    }
+                    ctx->ns_gemm_pack += ggml_xdna_now_ns() - t_b;
+
+                    if (!ggml_xdna_npu_gemm_submit_ab_list(slot->npu, kb_n)) {
+                        ggml_xdna_npu_gemm_release(slot->npu);
+                        return false;
+                    }
+
+                    const uint64_t t_scatter = ggml_xdna_now_ns();
+                    ggml_xdna_gemm_scatter_result(c_slices, kb_n, dst, n_src, n0, m_src, m0, s,
+                                                  /*accumulate=*/ kb0 > 0, nth);
+                    ctx->ns_gemm_pack += ggml_xdna_now_ns() - t_scatter;
+                }
+            }
+        }
+    }
+
+    ggml_xdna_npu_gemm_release(slot->npu);
+    return true;
+}
+#endif
+
+// The repack buffer is offered for every weight, so it also gets tried for the
+// norm weights that feed MUL. Only MUL_MAT can read that layout, and the
+// elementwise kernels take plain host pointers, so anything else has to refuse
+// operands that landed there - otherwise the weight is placed in a buffer whose
+// contents nothing can read back.
+static bool ggml_xdna_uses_repack_buft(const ggml_backend_xdna_device_context * dctx,
+                                       const ggml_tensor *                      op) {
+    for (int i = 0; i < GGML_MAX_SRC; i++) {
+        const ggml_tensor * src = op->src[i];
+        if (src && src->buffer && src->buffer->buft == &dctx->repack_buft) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Host-side GEMM from the swizzled bf16 weight layout. Used when M is below
+// gemm_m_min: an NPU submit would still move a full B block for almost no MACs.
+//
+// The swizzle keeps MAC_S x MAC_T (k x n) contiguous, so the weights are walked
+// in storage order and accumulated into a tile_n-wide column block. Decode then
+// streams each weight tensor once instead of gathering one K column per output.
+static void ggml_xdna_gemm_host(const ggml_bf16_t *          w,
+                                const float *                a,
+                                float *                      dst,
+                                int64_t                      k_src,
+                                int64_t                      m_src,
+                                int64_t                      n_dst,
+                                const ggml_xdna_gemm_shape & s,
+                                int                          n_threads) {
+    const int    ks       = GGML_XDNA_GEMM_MAC_S;
+    const int    ns       = GGML_XDNA_GEMM_MAC_T;
+    const int    k_slice  = s.kt * s.tile_k;
+    const int    k_blocks = (int) ((k_src + k_slice - 1) / k_slice);
+    const size_t b_block  = ggml_xdna_gemm_b_block_bytes(s) / sizeof(ggml_bf16_t);
+    const int    n_groups = (int) ((n_dst + s.tile_n - 1) / s.tile_n);
+
+#ifdef GGML_XDNA_OPENMP
+#   pragma omp parallel for schedule(static) num_threads(n_threads)
+#else
+    GGML_UNUSED(n_threads);
+#endif
+    for (int g = 0; g < n_groups; g++) {
+        const int nb = g / s.grid_c;
+        const int j  = g % s.grid_c;
+
+        std::vector<float> acc((size_t) m_src * s.tile_n, 0.0f);
+
+        for (int kb = 0; kb < k_blocks; kb++) {
+            const ggml_bf16_t * base = w + ((size_t) nb * k_blocks + kb) * b_block;
+            for (int kt = 0; kt < s.kt; kt++) {
+                const ggml_bf16_t * tile = base + ((size_t) j * s.kt + kt) * s.tile_k * s.tile_n;
+                const int64_t k0 = (int64_t) kb * k_slice + (int64_t) kt * s.tile_k;
+                for (int ki = 0; ki < s.tile_k / ks; ki++) {
+                    for (int kk = 0; kk < ks; kk++) {
+                        const int64_t k = k0 + (int64_t) ki * ks + kk;
+                        if (k >= k_src) {
+                            break;
+                        }
+                        // Column groups are independent accumulators, so keeping
+                        // them in the inner loop leaves the FMAs free to pipeline.
+                        for (int ni = 0; ni < s.tile_n / ns; ni++) {
+                            const ggml_bf16_t * blk =
+                                tile + ((size_t) ki * (s.tile_n / ns) + ni) * ks * ns + kk * ns;
+                            float wv[GGML_XDNA_GEMM_MAC_T];
+                            for (int nn = 0; nn < ns; nn++) {
+                                wv[nn] = GGML_BF16_TO_FP32(blk[nn]);
+                            }
+                            for (int64_t m = 0; m < m_src; m++) {
+                                const float av = a[(size_t) m * k_src + k];
+                                float * ac = acc.data() + (size_t) m * s.tile_n + ni * ns;
+                                for (int nn = 0; nn < ns; nn++) {
+                                    ac[nn] += av * wv[nn];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        const int64_t n0 = (int64_t) g * s.tile_n;
+        const int64_t nn_max = std::min<int64_t>(s.tile_n, n_dst - n0);
+        for (int64_t m = 0; m < m_src; m++) {
+            memcpy(dst + (size_t) m * n_dst + n0,
+                   acc.data() + (size_t) m * s.tile_n,
+                   (size_t) nn_max * sizeof(float));
+        }
+    }
+}
+
+static bool ggml_xdna_compute_mul_mat(ggml_backend_xdna_context * ctx,
+                                      const struct ggml_tensor * node,
+                                      float * dst_override) {
+#if defined(GGML_XDNA_EXPERIMENTAL)
+    if (dst_override == nullptr && ggml_xdna_act_gemm_ok(ctx->dev, node)) {
+        return ggml_xdna_compute_mul_mat_act(ctx, node);
+    }
+#endif
+
+    ggml_xdna_gemm_slot * slot = ggml_xdna_gemm_slot_for_op(ctx->dev, node);
+    if (!slot || !slot->npu) {
+        return false;
+    }
+
+    const ggml_xdna_gemm_shape & s = slot->shape;
+
+    const ggml_tensor * src1 = node->src[1];
+    const ggml_tensor * src0 = node->src[0];
+
+    const int64_t k_src = src1->ne[0];
+    const int64_t m_src = src1->ne[1];
+    const int64_t n_dst = node->ne[0];
+
+    ggml_backend_xdna_buffer_context * wctx =
+        (ggml_backend_xdna_buffer_context *) src0->buffer->context;
+    const char * w = ggml_xdna_weight_packed(wctx, src0);
+    const size_t w_base = (size_t) (w - (char *) wctx->base);
+
+    const float * src = (const float *) src1->data;
+    float *       dst = dst_override ? dst_override : (float *) node->data;
+
+    if (m_src < ctx->dev->gemm_m_min) {
+        const uint64_t t0 = ggml_xdna_now_ns();
+        ggml_xdna_gemm_host((const ggml_bf16_t *) w, src, dst,
+                            k_src, m_src, n_dst, s,
+                            ctx->n_threads > 0 ? ctx->n_threads : ctx->dev->host_threads);
+        ctx->ns_gemm_pack += ggml_xdna_now_ns() - t0;
+#if defined(GGML_XDNA_EXPERIMENTAL)
+        if (dst_override == nullptr) {
+            ggml_xdna_chain_store(ctx, node->data, dst, n_dst, m_src);
+        }
+#endif
+        return true;
+    }
+
+    const int64_t m_block = (int64_t) s.mb * s.grid_r * s.tile_m;
+    const int64_t n_cols  = (int64_t) s.grid_c * s.tile_n;
+    const int64_t k_slice = (int64_t) s.kt * s.tile_k;
+    const int     k_blocks = (int) ((k_src + k_slice - 1) / k_slice);
+    const size_t  b_bytes = ggml_xdna_gemm_b_block_bytes(s);
+
+    const int nth    = ctx->dev->host_threads;
+    const int kb_max = std::min(ggml_xdna_npu_gemm_kb_max(slot->npu), GGML_XDNA_GEMM_KB_LIMIT);
+    const int n_banks = std::max(1, ggml_xdna_npu_gemm_n_banks(slot->npu));
+    if (kb_max < 1) {
+        return false;
+    }
+
+    ggml_xdna_npu_gemm_acquire(slot->npu);
+
+    // Pending scatter from the previous async submit (other bank).
+    bool pending = false;
+    int  pend_bank = 0;
+    int  pend_kb_n = 0;
+    int64_t pend_n0 = 0;
+    int64_t pend_m0 = 0;
+    int  pend_kb0 = 0;
+    const float * pend_c[GGML_XDNA_GEMM_KB_LIMIT];
+
+    auto flush_pending = [&]() -> bool {
+        if (!pending) {
+            return true;
+        }
+        if (!ggml_xdna_npu_gemm_runlist_wait(slot->npu)) {
+            return false;
+        }
+        const uint64_t t_scatter = ggml_xdna_now_ns();
+        ggml_xdna_gemm_scatter_result(pend_c, pend_kb_n, dst, n_dst, pend_n0, m_src, pend_m0, s,
+                                      /*accumulate=*/ pend_kb0 > 0, nth);
+        ctx->ns_gemm_scatter += ggml_xdna_now_ns() - t_scatter;
+        pending = false;
+        return true;
+    };
+
+    int bank = 0;
+    for (int64_t m0 = 0; m0 < m_src; m0 += m_block) {
+        for (int kb0 = 0; kb0 < k_blocks; kb0 += kb_max) {
+            const int kb_n = std::min(kb_max, k_blocks - kb0);
+
+            const bool reuse_a =
+                ctx->gemm_pack_npu == slot->npu &&
+                ctx->gemm_pack_src == src1 &&
+                ctx->gemm_pack_m0 == m0 &&
+                ctx->gemm_pack_kb0 == kb0 &&
+                ctx->gemm_pack_kb_n == kb_n &&
+                ctx->gemm_pack_bank == bank;
+
+            const float * c_slices[GGML_XDNA_GEMM_KB_LIMIT];
+            if (!reuse_a) {
+                // Overlap next A pack with the previous NPU run when double-buffered.
+                if (pending && n_banks > 1) {
+                    bank = 1 - pend_bank;
+                }
+                ggml_xdna_npu_gemm_set_bank(slot->npu, bank);
+                const uint64_t t_pack = ggml_xdna_now_ns();
+                for (int kb = 0; kb < kb_n; kb++) {
+                    ggml_xdna_gemm_pack_activations(
+                        src, k_src, m_src, m0,
+                        (int64_t) (kb0 + kb) * k_slice,
+                        (ggml_bf16_t *) ggml_xdna_npu_gemm_a_slice_bank(slot->npu, bank, kb),
+                        s, nth);
+                    c_slices[kb] = ggml_xdna_npu_gemm_c_slice_bank(slot->npu, bank, kb);
+                }
+                ctx->ns_gemm_pack += ggml_xdna_now_ns() - t_pack;
+                ctx->n_gemm_pack++;
+                ctx->gemm_pack_src = src1;
+                ctx->gemm_pack_m0 = m0;
+                ctx->gemm_pack_kb0 = kb0;
+                ctx->gemm_pack_kb_n = kb_n;
+                ctx->gemm_pack_bank = bank;
+                ctx->gemm_pack_npu = slot->npu;
+            } else {
+                ctx->n_gemm_pack_reused++;
+                ggml_xdna_npu_gemm_set_bank(slot->npu, bank);
+                for (int kb = 0; kb < kb_n; kb++) {
+                    c_slices[kb] = ggml_xdna_npu_gemm_c_slice_bank(slot->npu, bank, kb);
+                }
+            }
+
+            for (int64_t n0 = 0; n0 < n_dst; n0 += n_cols) {
+                if (!flush_pending()) {
+                    ggml_xdna_npu_gemm_release(slot->npu);
+                    return false;
+                }
+
+                const int nb = (int) (n0 / n_cols);
+                size_t w_offs[GGML_XDNA_GEMM_KB_LIMIT];
+                for (int kb = 0; kb < kb_n; kb++) {
+                    w_offs[kb] = w_base + ((size_t) nb * k_blocks + kb0 + kb) * b_bytes;
+                }
+
+                ggml_xdna_npu_gemm_set_bank(slot->npu, bank);
+                if (!ggml_xdna_npu_gemm_submit_list_async(slot->npu, wctx->buf, w_offs, kb_n)) {
+                    ggml_xdna_npu_gemm_release(slot->npu);
+                    return false;
+                }
+
+                pending = true;
+                pend_bank = bank;
+                pend_kb_n = kb_n;
+                pend_n0 = n0;
+                pend_m0 = m0;
+                pend_kb0 = kb0;
+                for (int kb = 0; kb < kb_n; kb++) {
+                    pend_c[kb] = c_slices[kb];
+                }
+
+                // Next column reuses the same A; next M-block packs into the
+                // other bank while this submit runs.
+                if (n_banks > 1 && n0 + n_cols >= n_dst) {
+                    bank = 1 - bank;
+                }
+            }
+        }
+    }
+
+    if (!flush_pending()) {
+        ggml_xdna_npu_gemm_release(slot->npu);
+        return false;
+    }
+
+    ggml_xdna_npu_gemm_release(slot->npu);
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+    if (dst_override == nullptr) {
+        ggml_xdna_chain_store(ctx, node->data, dst, n_dst, m_src);
+    }
+#endif
+
+    const int level = ggml_xdna_debug_level();
+    if (level > 0) {
+        ggml_xdna_npu_stats stats;
+        ggml_xdna_npu_get_stats(slot->npu, &stats);
+        const uint64_t n = stats.n_calls;
+        if (level >= 2 || n == 1 || (n % 64) == 0) {
+            GGML_LOG_INFO("%s: graph_compute %s name=%s M=%lld K=%lld N=%lld on=NPU npu=%s "
+                          "calls=%llu runs=%llu total=%.1fms submit=%.1fms sync=%.1fms "
+                          "A_pack=%.1fms C_scatter=%.1fms\n",
+                          "ggml-xdna", slot->env_name,
+                          node->name[0] ? node->name : "?",
+                          (long long) m_src, (long long) k_src, (long long) n_dst,
+                          ctx->dev->npu_name.c_str(),
+                          (unsigned long long) stats.n_calls,
+                          (unsigned long long) stats.n_runs,
+                          (double) stats.ns_total / 1e6,
+                          (double) stats.ns_submit / 1e6,
+                          (double) stats.ns_sync / 1e6,
+                          (double) ctx->ns_gemm_pack / 1e6,
+                          (double) ctx->ns_gemm_scatter / 1e6);
+        }
+    }
+
+    return true;
+}
+
+static ggml_backend_buffer_type_t ggml_backend_xdna_device_get_buffer_type(ggml_backend_dev_t dev) {
+    GGML_UNUSED(dev);
+    return ggml_backend_cpu_buffer_type();
+}
+
+static ggml_backend_buffer_t ggml_backend_xdna_device_buffer_from_host_ptr(ggml_backend_dev_t dev, void * ptr, size_t size, size_t max_tensor_size) {
+    GGML_UNUSED(dev);
+    GGML_UNUSED(max_tensor_size);
+    return ggml_backend_cpu_buffer_from_ptr(ptr, size);
+}
+
+static void ggml_xdna_log_supports_op(const struct ggml_tensor * op, bool supported) {
+    const int level = ggml_xdna_debug_level();
+    if (level <= 0 || op == nullptr) {
+        return;
+    }
+
+    if (op->op == GGML_OP_NONE || op->op == GGML_OP_RESHAPE || op->op == GGML_OP_VIEW ||
+        op->op == GGML_OP_PERMUTE || op->op == GGML_OP_TRANSPOSE) {
+        return;
+    }
+
+    static std::mutex mu;
+    static std::unordered_map<std::string, int> seen_result;
+    static std::unordered_map<std::string, uint64_t> reject_counts;
+    static uint64_t total_queries = 0;
+    static uint64_t total_rejects = 0;
+    static bool intro_logged = false;
+
+    const char * op_name = ggml_op_desc(op);
+    std::string key = op_name ? op_name : "?";
+
+    std::lock_guard<std::mutex> lock(mu);
+    total_queries++;
+    if (!supported) {
+        total_rejects++;
+        reject_counts[key]++;
+    }
+
+    if (!intro_logged) {
+        GGML_LOG_INFO("%s: graph scheduling debug enabled (GGML_XDNA_DEBUG=%d). "
+                      "own_graph claims the full graph; non-local ops -> nested CPU.\n",
+                      "ggml-xdna", level);
+        intro_logged = true;
+    }
+
+    auto it = seen_result.find(key);
+    if (it == seen_result.end()) {
+        GGML_LOG_INFO("%s: supports_op(%s) = %s -> %s\n",
+                      "ggml-xdna",
+                      key.c_str(),
+                      supported ? "true" : "false",
+                      supported ? "XDNA runs this" : "CPU fallback");
+        seen_result[key] = supported ? 1 : 0;
+    } else if (it->second == 0 && supported) {
+        GGML_LOG_INFO("%s: supports_op(%s) = true -> XDNA runs some shapes "
+                      "(earlier rejects were size/type/broadcast filters)\n",
+                      "ggml-xdna", key.c_str());
+        it->second = 1;
+    }
+
+    if (level >= 2 && (total_queries == 1 || total_queries % 1024 == 0)) {
+        GGML_LOG_INFO("%s: supports_op stats: queries=%llu rejects=%llu (unique ops=%zu)\n",
+                      "ggml-xdna",
+                      (unsigned long long) total_queries,
+                      (unsigned long long) total_rejects,
+                      reject_counts.size());
+    }
+
+    if (level >= 2) {
+        GGML_LOG_DEBUG("%s: supports_op(%s name=%s) = %s\n",
+                       "ggml-xdna",
+                       key.c_str(),
+                       op->name ? op->name : "?",
+                       supported ? "true" : "false");
+    }
+}
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+// The kernels take two equally sized contiguous F32 vectors and write a third.
+static bool ggml_xdna_binary_shape_ok(const struct ggml_tensor * op, int64_t op_min) {
+    const struct ggml_tensor * src0 = op->src[0];
+    const struct ggml_tensor * src1 = op->src[1];
+
+    return src0 && src1 &&
+           op->type   == GGML_TYPE_F32 &&
+           src0->type == GGML_TYPE_F32 &&
+           src1->type == GGML_TYPE_F32 &&
+           ggml_is_contiguous(op) &&
+           ggml_is_contiguous(src0) &&
+           ggml_is_contiguous(src1) &&
+           // Require identical shapes, not just matching element counts:
+           // same nelements can still differ in layout (e.g. broadcast).
+           ggml_are_same_shape(src0, src1) &&
+           ggml_are_same_shape(op, src0) &&
+           ggml_nelements(op) >= op_min;
+}
+#endif
+
+static bool ggml_backend_xdna_device_supports_op(ggml_backend_dev_t dev, const struct ggml_tensor * op) {
+    ggml_backend_xdna_device_context * dctx = (ggml_backend_xdna_device_context *)dev->context;
+
+    bool supported = false;
+
+    switch (op->op) {
+        case GGML_OP_NONE:
+        case GGML_OP_RESHAPE:
+        case GGML_OP_VIEW:
+        case GGML_OP_PERMUTE:
+        case GGML_OP_TRANSPOSE:
+            supported = true;
+            break;
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+        case GGML_OP_RMS_NORM:
+            // The design bakes in the row length, and it normalises a whole row
+            // per submission, so only exactly-sized contiguous rows qualify.
+            supported = op->src[0] &&
+                        op->type == GGML_TYPE_F32 &&
+                        op->src[0]->type == GGML_TYPE_F32 &&
+                        ggml_is_contiguous(op) &&
+                        ggml_is_contiguous(op->src[0]) &&
+                        ggml_are_same_shape(op, op->src[0]) &&
+                        (size_t) op->ne[0] == dctx->rms_row &&
+                        ggml_nelements(op) >= dctx->op_min &&
+                        !ggml_xdna_uses_repack_buft(dctx, op) &&
+                        ggml_xdna_device_npu(dctx, GGML_XDNA_SLOT_RMS_NORM) != nullptr;
+            if (!supported && dctx->own_graph && dctx->npu_present && dctx->npu_enabled &&
+                !ggml_xdna_uses_repack_buft(dctx, op)) {
+                supported = true; // nested CPU
+            }
+            break;
+
+        case GGML_OP_ADD:
+        case GGML_OP_MUL:
+            // Only claim the op once its kernel is actually live. This gates on
+            // npu_present, npu_enabled, the per-op toggle and a successful
+            // XRT/kernel init. Cheap in practice: init is triggered at backend
+            // init, so this is just the call_once fast path (a safety net if
+            // supports_op is queried for a device whose backend was never
+            // created).
+            supported = ggml_xdna_device_npu(dctx, ggml_xdna_slot_for_op(op->op)) != nullptr &&
+                        !ggml_xdna_uses_repack_buft(dctx, op) &&
+                        ggml_xdna_binary_shape_ok(op, dctx->op_min);
+            if (!supported && dctx->own_graph && dctx->npu_present && dctx->npu_enabled &&
+                !ggml_xdna_uses_repack_buft(dctx, op)) {
+                supported = true; // nested CPU
+            }
+            break;
+#endif
+
+        case GGML_OP_MUL_MAT:
+            // Claimed only for weights that were repacked into our buffer, and
+            // then for every batch size: nothing else can read that layout, so
+            // handing any of these back to the CPU would feed it garbage. A
+            // batch shorter than gemm_m_min runs as a host GEMM inside this
+            // backend rather than an NPU submit.
+            supported = ggml_xdna_gemm_supports(dctx, op)
+#if defined(GGML_XDNA_EXPERIMENTAL)
+                        || ggml_xdna_act_gemm_ok(dctx, op)
+#endif
+                        ;
+            if (!supported && dctx->own_graph && dctx->npu_present && dctx->npu_enabled &&
+                !ggml_xdna_uses_repack_buft(dctx, op)) {
+                // Refuse packable 2D weights whose shape fits the NPU GEMM so
+                // select_weight_buft skips the default host buft and lands on
+                // XDNA_REPACK under -ngl > 0. Act x act and odd shapes
+                // (lm_head, gate proj N=16) stay as nested CPU.
+                const ggml_tensor * w = op->src[0];
+                if (ggml_xdna_gemm_should_repack_weight(dctx, w)) {
+                    supported = false;
+                } else {
+                    supported = true;
+                }
+            }
+            break;
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+        case GGML_OP_FLASH_ATTN_EXT:
+            // Stage 3: with act-GEMM on, refuse it so the expanded QK / SOFT_MAX
+            // / AV graph is built and its large act x act MUL_MATs reach the NPU
+            // GEMM. A fused FLASH kernel is a later step.
+            //
+            // Otherwise claim it for the nested CPU. Refusing makes
+            // resolve_fused_ops turn flash attention off for the whole model,
+            // and the expanded graph then needs an n_ctx x n_ubatch scratch:
+            // 36 GiB at this model's 256k default context and -ub 4096.
+            supported = !dctx->act_gemm && dctx->own_graph &&
+                        dctx->npu_present && dctx->npu_enabled &&
+                        !ggml_xdna_uses_repack_buft(dctx, op);
+            break;
+#endif
+
+        default:
+            // Prefill ops with no NPU kernel (ROPE, SSM_CONV, GATED_DELTA_NET,
+            // ...): claim them so the graph stays one split.
+            // With layers assigned to XDNA (-ngl > 0) this also keeps
+            // resolve_fused_ops happy: device_fused == device_layer.
+            supported = dctx->own_graph && dctx->npu_present && dctx->npu_enabled &&
+                        !ggml_xdna_uses_repack_buft(dctx, op);
+            break;
+    }
+
+    ggml_xdna_log_supports_op(op, supported);
+    return supported;
+}
+
+static bool ggml_backend_xdna_device_supports_buft(ggml_backend_dev_t dev, ggml_backend_buffer_type_t buft) {
+    ggml_backend_xdna_device_context * dctx = (ggml_backend_xdna_device_context *) dev->context;
+
+    return ggml_backend_buft_is_host(buft) || buft == &dctx->repack_buft;
+}
+
+static const struct ggml_backend_device_i ggml_backend_xdna_device_i = {
+    /* .get_name             = */ ggml_backend_xdna_device_get_name,
+    /* .get_description      = */ ggml_backend_xdna_device_get_description,
+    /* .get_memory           = */ ggml_backend_xdna_device_get_memory,
+    /* .get_type             = */ ggml_backend_xdna_device_get_type,
+    /* .get_props            = */ ggml_backend_xdna_device_get_props,
+    /* .init_backend         = */ ggml_backend_xdna_device_init_backend,
+    /* .get_buffer_type      = */ ggml_backend_xdna_device_get_buffer_type,
+    /* .get_host_buffer_type = */ NULL,
+    /* .buffer_from_host_ptr = */ ggml_backend_xdna_device_buffer_from_host_ptr,
+    /* .supports_op          = */ ggml_backend_xdna_device_supports_op,
+    /* .supports_buft        = */ ggml_backend_xdna_device_supports_buft,
+    /* .offload_op           = */ NULL,
+    /* .event_new            = */ NULL,
+    /* .event_free           = */ NULL,
+    /* .event_synchronize    = */ NULL,
+};
+
+static const char * ggml_backend_xdna_reg_get_name(ggml_backend_reg_t reg) {
+    GGML_UNUSED(reg);
+    return "XDNA";
+}
+
+static size_t ggml_backend_xdna_reg_get_device_count(ggml_backend_reg_t reg) {
+    GGML_UNUSED(reg);
+    return ggml_xdna_device_context()->npu_present ? 1 : 0;
+}
+
+static ggml_backend_dev_t ggml_backend_xdna_reg_get_device(ggml_backend_reg_t reg, size_t index) {
+    GGML_ASSERT(index == 0);
+    GGML_UNUSED(index);
+
+    static ggml_backend_device ggml_backend_xdna_device = {
+        /* .iface   = */ ggml_backend_xdna_device_i,
+        /* .reg     = */ reg,
+        /* .context = */ ggml_xdna_device_context(),
+    };
+
+    return &ggml_backend_xdna_device;
+}
+
+// Weights have to be repacked into the layout the GEMM design reads, and for an
+// ACCEL device the only way into the weight buffer list is as an extra buft: the
+// device's default buffer type is also what the scheduler allocates activations
+// in, and those must stay plain host memory for the elementwise kernels.
+static ggml_backend_buffer_type_t * ggml_backend_xdna_device_get_extra_bufts(ggml_backend_dev_t dev) {
+    static ggml_backend_buffer_type_t bufts[2] = { nullptr, nullptr };
+
+    ggml_backend_xdna_device_context * dctx = (ggml_backend_xdna_device_context *) dev->context;
+    if (!dctx->npu_present || !dctx->npu_enabled || !dctx->gemm_enabled) {
+        return nullptr;
+    }
+
+    bool any = false;
+    for (const ggml_xdna_gemm_slot & slot : dctx->gemm) {
+        any = any || (slot.enabled && slot.found);
+    }
+    if (!any) {
+        return nullptr;
+    }
+
+    bufts[0] = ggml_backend_xdna_repack_buffer_type(dev);
+    return bufts;
+}
+
+static void ggml_backend_xdna_set_n_threads(ggml_backend_t backend, int n_threads) {
+    ggml_backend_xdna_context * ctx = (ggml_backend_xdna_context *) backend->context;
+    ctx->n_threads = n_threads;
+    if (!ctx->host) {
+        return;
+    }
+    ggml_backend_dev_t  host_dev = ggml_backend_get_device(ctx->host);
+    ggml_backend_reg_t  host_reg = host_dev ? ggml_backend_dev_backend_reg(host_dev) : nullptr;
+    auto set_n = host_reg
+        ? (ggml_backend_set_n_threads_t) ggml_backend_reg_get_proc_address(
+              host_reg, "ggml_backend_set_n_threads")
+        : nullptr;
+    if (set_n) {
+        set_n(ctx->host, n_threads);
+    }
+}
+
+static uint64_t ggml_backend_xdna_get_npu_call_count(ggml_backend_t backend) {
+    if (!ggml_backend_is_xdna(backend)) {
+        return 0;
+    }
+
+    ggml_backend_xdna_context * ctx = (ggml_backend_xdna_context *) backend->context;
+    uint64_t n_calls = 0;
+    for (const ggml_xdna_gemm_slot & slot : ctx->dev->gemm) {
+        if (slot.npu) {
+            ggml_xdna_npu_stats stats;
+            ggml_xdna_npu_get_stats(slot.npu, &stats);
+            n_calls += stats.n_calls;
+        }
+    }
+    return n_calls;
+}
+
+static void * ggml_backend_xdna_get_proc_address(ggml_backend_reg_t reg, const char * name) {
+    GGML_UNUSED(reg);
+
+    if (strcmp(name, "ggml_backend_dev_get_extra_bufts") == 0) {
+        return (void *) ggml_backend_xdna_device_get_extra_bufts;
+    }
+    if (strcmp(name, "ggml_backend_set_n_threads") == 0) {
+        return (void *) ggml_backend_xdna_set_n_threads;
+    }
+    if (strcmp(name, "ggml_backend_xdna_get_npu_call_count") == 0) {
+        return (void *) ggml_backend_xdna_get_npu_call_count;
+    }
+
+    return nullptr;
+}
+
+static const struct ggml_backend_reg_i ggml_backend_xdna_reg_i = {
+    /* .get_name         = */ ggml_backend_xdna_reg_get_name,
+    /* .get_device_count = */ ggml_backend_xdna_reg_get_device_count,
+    /* .get_device       = */ ggml_backend_xdna_reg_get_device,
+    /* .get_proc_address = */ ggml_backend_xdna_get_proc_address,
+};
+
+ggml_backend_reg_t ggml_backend_xdna_reg(void) {
+    static struct ggml_backend_reg ggml_backend_xdna_reg = {
+        /* .api_version = */ GGML_BACKEND_API_VERSION,
+        /* .iface       = */ ggml_backend_xdna_reg_i,
+        /* .context     = */ NULL,
+    };
+
+    return &ggml_backend_xdna_reg;
+}
+
+GGML_BACKEND_DL_IMPL(ggml_backend_xdna_reg)

--- a/ggml/src/ggml-xdna/iron/README.md
+++ b/ggml/src/ggml-xdna/iron/README.md
@@ -1,0 +1,97 @@
+# IRON kernels for ggml-xdna
+
+The NPU kernels used by the `ggml-xdna` backend, written with IRON
+(`@iron.jit` / MLIR-AIE).
+
+Phase 1 builds **only** the production GEMM. Everything else is experimental
+and is compiled only with `-DGGML_XDNA_EXPERIMENTAL=ON`. Even then the
+process must set `GGML_XDNA_ENABLE_EXPERIMENTAL=1`. GDN still needs
+`GGML_XDNA_GDN=1`. See [`docs/backend/XDNA.md`](../../../../docs/backend/XDNA.md).
+
+| File | Status | Purpose |
+| --- | --- | --- |
+| `ggml-xdna-gemm.py` | production | BF16 weight GEMM |
+| `ggml-xdna-add.py` | experimental | element-wise ADD |
+| `ggml-xdna-mul.py` | experimental | element-wise MUL |
+| `ggml-xdna-rms-norm.py` | experimental | per-row RMS_NORM |
+| `ggml-xdna-add-rms-mul.py` | experimental | fused pre-norm block |
+| `ggml-xdna-gdn.py` | experimental | GATED_DELTA_NET strip (off unless `GGML_XDNA_GDN=1`) |
+| `build-kernels.sh` | build | wrapper called by `../CMakeLists.txt` |
+| `env_setup.sh` | build | interactive env setup |
+
+ADD and MUL are element-wise, so `transform_binary` covers them with a lambda
+and their artifact is sized by the elementwise tile. RMS_NORM has to sum a whole
+row before it can emit anything, so it carries an inline `ExternalFunction`
+compiled by Peano and its artifact is sized by the model's `ne0`
+(`GGML_XDNA_RMS_ROW`, default 1024). `eps` travels in a one-element buffer
+rather than being baked in, so one xclbin serves any model.
+
+Each design compiles to its own xclbin. The backend gives every one of them a
+separate `xrt::hw_context` over a shared `xrt::device`, so all of them stay
+resident on the NPU and dispatching between ops never reloads a design.
+
+The backend never calls Python: `build-kernels.sh` produces
+`ggml-xdna-<op>-npu2-f32-<N>.*`, and the C++ side loads them through XRT.
+See [`docs/backend/XDNA.md`](../../../../docs/backend/XDNA.md).
+
+## Setup
+
+Production kernels need mlir-aie **1.3.4** (not 1.4.1). Install steps are in
+[`docs/backend/XDNA.md`](../../../../docs/backend/XDNA.md).
+
+```bash
+source ~/ironenv/bin/activate
+source /opt/xilinx/xrt/setup.sh
+source ggml/src/ggml-xdna/iron/env_setup.sh
+```
+
+## Run / compile
+
+```bash
+python ggml/src/ggml-xdna/iron/ggml-xdna-add.py -n 1024 --tile-size 256 --dtype f32 -v
+python ggml/src/ggml-xdna/iron/ggml-xdna-mul.py -n 1024 --tile-size 256 --dtype f32 -v
+
+# compile-only (CMake does this with -DGGML_XDNA_BUILD_KERNELS=ON)
+python ggml/src/ggml-xdna/iron/ggml-xdna-add.py -d npu2 -n 1024 --tile-size 256 --dtype f32 \
+  --xclbin-path build/bin/ggml-xdna-add-npu2-f32-1024.xclbin \
+  --insts-path  build/bin/ggml-xdna-add-npu2-f32-1024.insts.bin
+```
+
+## Runtime toggles (experimental build only)
+
+These apply only after `-DGGML_XDNA_EXPERIMENTAL=ON` and
+`GGML_XDNA_ENABLE_EXPERIMENTAL=1`. The production GEMM path ignores them.
+
+`GGML_XDNA_ADD=0` / `GGML_XDNA_MUL=0` / `GGML_XDNA_RMS_NORM=0` drop one kernel
+from `supports_op`. `GGML_XDNA_NPU=0` disables the backend entirely.
+`GGML_XDNA_DISABLE_FUSION=1` keeps every experimental op separate.
+`GGML_XDNA_GDN=1` enables the GDN strip kernel (still off by default).
+
+## Stage 5 fusion boundary (GDN surround)
+
+Elementwise ops around GDN (`SSM_CONV`, `CONCAT`, `SIGMOID`, `L2_NORM`,
+`RMS_NORM`, `SWIGLU`) must not be ported one-by-one: NPU streaming is ~30 GB/s
+vs ~140 GB/s on the host. They only win when absorbed into the GDN kernel so
+intermediates stay in MemTile/L1.
+
+Current knobs:
+
+- `GGML_XDNA_GDN=1` enables the strip kernel (default off: not yet faster).
+- `GGML_XDNA_GDN_FUSE_PRE=1` absorbs surrounding `L2_NORM(q/k)` into GDN
+  packing (reads pre-L2 inputs, applies L2 on the host while packing; L2 nodes
+  become no-ops). SSM_CONV / SIGMOID / SWIGLU still need MemTile-full state.
+
+
+## Residency
+
+`xdna-probe` (built next to the backend) separates three costs that are easy to
+confuse: *holding* a design resident, *switching* to it, and *reloading* it. It
+reports the one-time load per design, how many `hw_context`s the driver grants,
+submit latency while rotating over K contexts, submit latency on a single context
+while N others merely exist, and a control run that rebuilds the context before
+every submit. It also dumps the driver's own `aie-partitions` view while the
+contexts are held.
+
+On Strix Halo the answer is 16 contexts, all inside one partition spanning all 8
+columns, and the count does not change with the data buffer size. Holding them
+costs nothing measurable; switching costs a constant.

--- a/ggml/src/ggml-xdna/iron/build-kernels.sh
+++ b/ggml/src/ggml-xdna/iron/build-kernels.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Build the ggml-xdna NPU kernel artifacts (xclbin + instruction stream).
+#
+#   build-kernels.sh <python> <out-dir> <tile> [dma-tile] [work-dir] [rms-row]
+#                    [gemm-mb]
+#
+# By default, builds only the two GEMM artifact pairs. Set
+# GGML_XDNA_EXPERIMENTAL=1 to additionally build:
+#   ggml-xdna-add-npu2-f32-<tile>.{xclbin,insts.bin}
+#   ggml-xdna-mul-npu2-f32-<tile>.{xclbin,insts.bin}
+#   ggml-xdna-rms-norm-npu2-f32-<rms-row>.{xclbin,insts.bin}
+#   ggml-xdna-add-rms-mul-npu2-f32-<rms-row>.{xclbin,insts.bin}
+#   ggml-xdna-gdn-npu2-s128-r32-cs64[-w4].{xclbin,insts.bin}
+#
+# GEMM artifacts use ggml-xdna-gemm-npu2-bf16-<KT>-<MB>:
+#   KT=16 (K=1024) staged as one MemTile chain per column, replayed MB times.
+#   Host splits larger K (accumulate C) and loops N in blocks of 512 (NB=1).
+#
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+PYTHON="${1:?usage: build-kernels.sh <python> <out-dir> <tile> [dma-tile] [work-dir]}"
+OUT_DIR="${2:?missing out-dir}"
+TILE="${3:?missing tile}"
+DMA_TILE="${4:-256}"
+WORK_DIR="${5:-$OUT_DIR}"
+RMS_ROW="${6:-1024}"
+GEMM_MB="${7:-16}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ ! -x "$PYTHON" ]; then
+    echo "ggml-xdna: IRON python not found: $PYTHON" >&2
+    exit 1
+fi
+
+MLIR_AIE_INSTALL_DIR="$("$PYTHON" - <<'PY'
+import mlir_aie
+print(list(mlir_aie.__path__)[0])
+PY
+)"
+PEANO_INSTALL_DIR="$("$PYTHON" - <<'PY'
+from importlib.metadata import distribution
+print(distribution("llvm-aie").locate_file("llvm-aie"))
+PY
+)"
+export MLIR_AIE_INSTALL_DIR PEANO_INSTALL_DIR
+
+XRT_DIR="${XILINX_XRT:-/opt/xilinx/xrt}"
+export PATH="$MLIR_AIE_INSTALL_DIR/bin:$XRT_DIR/bin:$PATH"
+export LD_LIBRARY_PATH="$MLIR_AIE_INSTALL_DIR/lib:$XRT_DIR/lib:${LD_LIBRARY_PATH:-}"
+
+if ! command -v xclbinutil >/dev/null 2>&1; then
+    echo "ggml-xdna: xclbinutil not found (need XRT at $XRT_DIR)" >&2
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR" "$WORK_DIR"
+
+build_op() {
+    local op="$1"
+    local n="$2"
+    local design="$SCRIPT_DIR/ggml-xdna-$op.py"
+    local name="ggml-xdna-$op-npu2-f32-$n"
+    local stem="$WORK_DIR/$name"
+
+    "$PYTHON" "$design" \
+        -d npu2 \
+        -n "$n" \
+        --tile-size "$DMA_TILE" \
+        --dtype f32 \
+        --xclbin-path "$stem.xclbin" \
+        --insts-path  "$stem.insts.bin"
+
+    if [ "$WORK_DIR" != "$OUT_DIR" ]; then
+        cp -f "$stem.xclbin" "$stem.insts.bin" "$OUT_DIR/"
+    fi
+
+    echo "ggml-xdna: built $OUT_DIR/$name.xclbin + .insts.bin"
+}
+
+# One GEMM artifact: KT=16 (K=1024 per submit), MB row blocks. Host splits larger
+# K and loops over N column blocks. Keep geometry in step with ggml-xdna.cpp.
+build_gemm() {
+    local kt="$1"
+    local mb="$2"
+    local name="ggml-xdna-gemm-npu2-bf16-$kt-$mb"
+    local stem="$WORK_DIR/$name"
+
+    "$PYTHON" "$SCRIPT_DIR/ggml-xdna-gemm.py" \
+        -d npu2 \
+        --KT "$kt" \
+        --MB "$mb" \
+        --grid 4 8 \
+        --xclbin-path "$stem.xclbin" \
+        --insts-path  "$stem.insts.bin"
+
+    if [ "$WORK_DIR" != "$OUT_DIR" ]; then
+        cp -f "$stem.xclbin" "$stem.insts.bin" "$OUT_DIR/"
+    fi
+
+    echo "ggml-xdna: built $OUT_DIR/$name.xclbin + .insts.bin (KT=$kt, MB=$mb)"
+}
+
+build_gemm 16 "$GEMM_MB"
+# Also build MB=32 (M_block=4096) so long prefills can cover a full ubatch in
+# one row-block pass. Weight layout is MB-independent; host picks at runtime.
+if [ "$GEMM_MB" != "32" ]; then
+    build_gemm 16 32
+fi
+if [ "$GEMM_MB" != "16" ]; then
+    build_gemm 16 16
+fi
+
+# GDN strip kernel: S=128, ROWS=32, CS=64.
+build_gdn() {
+    local s="$1" rows="$2" cs="$3" workers="${4:-1}"
+    local name="ggml-xdna-gdn-npu2-s${s}-r${rows}-cs${cs}"
+    if [ "$workers" -gt 1 ]; then
+        name="${name}-w${workers}"
+    fi
+    local stem="$WORK_DIR/$name"
+
+    "$PYTHON" "$SCRIPT_DIR/ggml-xdna-gdn.py" \
+        -d npu2 \
+        --S "$s" \
+        --ROWS "$rows" \
+        --CS "$cs" \
+        --workers "$workers" \
+        --xclbin-path "$stem.xclbin" \
+        --insts-path  "$stem.insts.bin"
+
+    if [ "$WORK_DIR" != "$OUT_DIR" ]; then
+        cp -f "$stem.xclbin" "$stem.insts.bin" "$OUT_DIR/"
+    fi
+
+    echo "ggml-xdna: built $OUT_DIR/$name.xclbin + .insts.bin (S=$s ROWS=$rows CS=$cs workers=$workers)"
+}
+
+if [ "${GGML_XDNA_EXPERIMENTAL:-0}" = "1" ]; then
+    build_op add "$TILE"
+    build_op mul "$TILE"
+
+    # RMS_NORM normalises one whole row per submission, so its artifact is sized
+    # by the model's ne0, not by the elementwise tile.
+    build_op rms-norm "$RMS_ROW"
+    build_op add-rms-mul "$RMS_ROW"
+
+    build_gdn 128 32 64 1
+    build_gdn 128 32 64 4
+fi

--- a/ggml/src/ggml-xdna/iron/env_setup.sh
+++ b/ggml/src/ggml-xdna/iron/env_setup.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Local env setup for ggml-xdna/iron (adapted from Xilinx/mlir-aie utils/env_setup.sh).
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Usage (from any cwd, with ironenv activated):
+#   source /opt/xilinx/xrt/setup.sh
+#   source ggml/src/ggml-xdna/iron/env_setup.sh
+
+if [ -z "${VIRTUAL_ENV:-}" ] && [ -d "$HOME/ironenv" ]; then
+    # shellcheck disable=SC1091
+    source "$HOME/ironenv/bin/activate"
+fi
+
+MLIR_AIE_INSTALL_DIR="$(python3 - <<'PY'
+import pathlib
+try:
+    import mlir_aie
+except ImportError:
+    raise SystemExit("")
+# namespace package: site-packages/mlir_aie
+locs = list(getattr(mlir_aie, "__path__", []))
+print(locs[0] if locs else "")
+PY
+)"
+
+if [ -z "$MLIR_AIE_INSTALL_DIR" ]; then
+    echo "ERROR: mlir_aie not found. Activate ~/ironenv first." >&2
+    return 1 2>/dev/null || exit 1
+fi
+export MLIR_AIE_INSTALL_DIR
+
+PEANO_INSTALL_DIR="$(python3 - <<'PY'
+from importlib.metadata import distribution
+import pathlib
+dist = distribution("llvm-aie")
+root = pathlib.Path(str(dist.locate_file("llvm-aie")))
+print(root if root.exists() else "")
+PY
+)"
+
+if [ -z "$PEANO_INSTALL_DIR" ] || [ ! -d "$PEANO_INSTALL_DIR" ]; then
+    echo "ERROR: llvm-aie (Peano) not found in the active venv." >&2
+    return 1 2>/dev/null || exit 1
+fi
+export PEANO_INSTALL_DIR
+
+export PATH="${MLIR_AIE_INSTALL_DIR}/bin:${PATH}"
+export PYTHONPATH="${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH:-}"
+export LD_LIBRARY_PATH="${MLIR_AIE_INSTALL_DIR}/lib:${LD_LIBRARY_PATH:-}"
+
+if ! command -v xrt-smi >/dev/null 2>&1; then
+    echo "ERROR: xrt-smi not found. Run: source /opt/xilinx/xrt/setup.sh" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+NPUPAT='NPU Phoenix|NPU Strix|NPU Strix Halo|NPU Krackan|RyzenAI-npu[1456]'
+NPU="$(xrt-smi examine 2>/dev/null | tr -d '\r' | grep -E "$NPUPAT" || true)"
+if echo "$NPU" | grep -qiE "NPU Strix|NPU Strix Halo|NPU Krackan|RyzenAI-npu[456]"; then
+    export NPU2=1
+else
+    export NPU2=0
+fi
+
+if ! python3 -c "import pyxrt" 2>/dev/null; then
+    echo "ERROR: pyxrt not importable. source /opt/xilinx/xrt/setup.sh first." >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+echo "IRON env ready:"
+echo "  MLIR_AIE_INSTALL_DIR=$MLIR_AIE_INSTALL_DIR"
+echo "  PEANO_INSTALL_DIR=$PEANO_INSTALL_DIR"
+echo "  NPU2=$NPU2  ($NPU)"

--- a/ggml/src/ggml-xdna/iron/ggml-xdna-add-rms-mul.py
+++ b/ggml/src/ggml-xdna/iron/ggml-xdna-add-rms-mul.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# ggml-xdna-add-rms-mul.py -*- Python -*-
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+"""IRON design for the ggml-xdna ADD + RMS_NORM + MUL fused kernel.
+
+  run+verify   python3 ggml-xdna-add-rms-mul.py -n 1024
+  compile-only python3 ggml-xdna-add-rms-mul.py -n 1024 -d npu2 \
+                   --xclbin-path ggml-xdna-add-rms-mul-npu2-f32-1024.xclbin \
+                   --insts-path  ggml-xdna-add-rms-mul-npu2-f32-1024.insts.bin
+
+This is the pre-norm transformer block: residual add, row RMS normalisation,
+then multiply by the learned scale. The design writes two outputs in one
+submission - the residual sum and the normalised, scaled row.
+
+The host ABI uses three DMA buffers to fit the core tile's channel budget:
+
+  ab_eps : [a[n], b[n], eps]            (2*n + 1 floats)
+  weight : [w[n]]
+  out    : [add_out[n], mul_out[n]]     (2*n floats)
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+
+import aie.iron as iron
+from aie.iron import CompileTime, In, ObjectFifo, Out, Program, Runtime, Worker
+from aie.iron.kernel import ExternalFunction
+from aie.iron.kernels._common import _include_dirs
+from aie.utils.hostruntime.argparse import add_compile_args
+from aie.utils.hostruntime.cli import run_design_cli
+from aie.utils.verify import assert_pass
+
+KERNEL_SOURCE = r"""
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+
+// ab_eps = [a[n], b[n], eps]
+// out    = [add_out[n], mul_out[n]]
+extern "C" void ggml_xdna_add_rms_mul_f32(
+    const float * ab_eps, const float * weight, float * out, int32_t n) {
+    const float * a = ab_eps;
+    const float * b = ab_eps + n;
+    const float eps = ab_eps[2 * n];
+    float * add_out = out;
+    float * mul_out = out + n;
+
+    float sum = 0.0f;
+    for (int32_t i = 0; i < n; i++) {
+        const float s = a[i] + b[i];
+        add_out[i] = s;
+        sum += s * s;
+    }
+
+    const float scale = aie::invsqrt(sum / (float) n + eps);
+
+    for (int32_t i = 0; i < n; i++) {
+        mul_out[i] = add_out[i] * scale * weight[i];
+    }
+}
+"""
+
+
+def _add_rms_mul_program(num_elements: int):
+    ab_ty = np.ndarray[(2 * num_elements + 1,), np.dtype[np.float32]]
+    row_ty = np.ndarray[(num_elements,), np.dtype[np.float32]]
+    out_ty = np.ndarray[(2 * num_elements,), np.dtype[np.float32]]
+
+    kernel = ExternalFunction(
+        "ggml_xdna_add_rms_mul_f32",
+        source_string=KERNEL_SOURCE,
+        arg_types=[ab_ty, row_ty, out_ty, np.int32],
+        include_dirs=_include_dirs(),
+    )
+
+    of_ab = ObjectFifo(ab_ty, name="ab")
+    of_w = ObjectFifo(row_ty, name="w")
+    of_out = ObjectFifo(out_ty, name="out")
+
+    def core_body(of_ab, of_w, of_out, kernel):
+        ab = of_ab.acquire(1)
+        w = of_w.acquire(1)
+        out = of_out.acquire(1)
+        kernel(ab, w, out, num_elements)
+        of_ab.release(1)
+        of_w.release(1)
+        of_out.release(1)
+
+    worker = Worker(core_body, fn_args=[of_ab.cons(), of_w.cons(), of_out.prod(), kernel])
+
+    rt = Runtime()
+    with rt.sequence(ab_ty, row_ty, out_ty) as (a_ab, a_w, a_out):
+        rt.start(worker)
+        rt.fill(of_ab.prod(), a_ab)
+        rt.fill(of_w.prod(), a_w)
+        rt.drain(of_out.cons(), a_out, wait=True)
+
+    return Program(iron.get_current_device(), rt).resolve_program()
+
+
+@iron.jit
+def ggml_xdna_add_rms_mul(
+    ab_eps: In,
+    weight: In,
+    out: Out,
+    *,
+    num_elements: CompileTime[int],
+):
+    return _add_rms_mul_program(num_elements)
+
+
+def _compile_kwargs(opts) -> dict:
+    return {"num_elements": opts.num_elements}
+
+
+def _run_and_verify(opts) -> None:
+    n = opts.num_elements
+
+    a = iron.rand(n, dtype=np.float32, device="npu")
+    b = iron.rand(n, dtype=np.float32, device="npu")
+    weight = iron.rand(n, dtype=np.float32, device="npu")
+    ab_eps = iron.zeros(2 * n + 1, dtype=np.float32, device="npu")
+    ab_eps[:n] = a
+    ab_eps[n:2 * n] = b
+    ab_eps[2 * n] = opts.eps
+    out = iron.zeros(2 * n, dtype=np.float32, device="npu")
+
+    ggml_xdna_add_rms_mul(ab_eps, weight, out, **_compile_kwargs(opts))
+
+    an = a.numpy().astype(np.float64)
+    bn = b.numpy().astype(np.float64)
+    wn = weight.numpy().astype(np.float64)
+    expected_add = (an + bn).astype(np.float32)
+    sum_ab = an + bn
+    scale = 1.0 / np.sqrt(np.mean(sum_ab * sum_ab) + opts.eps)
+    expected_mul = (sum_ab * scale * wn).astype(np.float32)
+
+    add_out = out.numpy()[:n]
+    mul_out = out.numpy()[n:]
+
+    if opts.verbose:
+        print(f"{'i':>4}  {'add':>12}  {'mul':>12}  {'ref_mul':>12}")
+        print("-" * 48)
+        for i in range(min(8, n)):
+            print(f"{i:4d}  {add_out[i]:12.6f}  {mul_out[i]:12.6f}  {expected_mul[i]:12.6f}")
+
+    assert_pass(expected_add, add_out, rtol=1e-4,
+                fail_msg="ggml-xdna ADD_RMS_MUL add_out mismatch vs NumPy")
+    assert_pass(expected_mul, mul_out, rtol=1e-4,
+                fail_msg="ggml-xdna ADD_RMS_MUL mul_out mismatch vs NumPy")
+    print(f"PASS: NPU ADD_RMS_MUL matches NumPy (n={n}, eps={opts.eps})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="ggml-xdna-add-rms-mul",
+        description="Build/run the ggml-xdna NPU ADD+RMS_NORM+MUL fused kernel",
+    )
+    add_compile_args(parser)
+    parser.add_argument("-n", "--num-elements", type=int, default=1024,
+                        help="row length (ggml ne0), baked into the artifacts (default: %(default)s)")
+    parser.add_argument("--eps", type=float, default=1e-6,
+                        help="epsilon used by the verify path only (default: %(default)s)")
+    parser.add_argument("--tile-size", type=int, default=256,
+                        help="accepted for symmetry with the elementwise designs; unused")
+    parser.add_argument("--dtype", choices=["f32"], default="f32")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    opts = parser.parse_args()
+
+    run_design_cli(
+        ggml_xdna_add_rms_mul,
+        opts,
+        compile_kwargs=_compile_kwargs,
+        run_and_verify=_run_and_verify,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ggml/src/ggml-xdna/iron/ggml-xdna-add.py
+++ b/ggml/src/ggml-xdna/iron/ggml-xdna-add.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# ggml-xdna-add.py -*- Python -*-
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Derived from Xilinx/mlir-aie programming_examples/basic/vector_vector_add
+#
+"""IRON design for the ggml-xdna ADD kernel.
+
+Two modes:
+
+  run+verify   python3 ggml-xdna-add.py -n 1024              (JIT, checks vs NumPy)
+  compile-only python3 ggml-xdna-add.py -n 1024 -d npu2 \
+                   --xclbin-path ggml-xdna-add-npu2-1024.xclbin \
+                   --insts-path  ggml-xdna-add-npu2-1024.insts.bin
+
+The compile-only mode is what the CMake build uses: the C++ backend loads the
+resulting xclbin + instruction stream through XRT and never calls into Python.
+
+``num_elements`` is baked into the artifacts and *is* the host ABI: the backend
+submits exactly this many elements per NPU run and chunks larger tensors.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+
+import aie.iron as iron
+from aie.iron import CompileTime, In, Out
+from aie.iron.algorithms import transform_binary
+from aie.utils.hostruntime.argparse import add_compile_args
+from aie.utils.hostruntime.cli import run_design_cli
+from aie.utils.verify import assert_pass
+
+DTYPES = {
+    "f32": np.float32,
+    "i32": np.int32,
+}
+
+
+@iron.jit
+def ggml_xdna_add(
+    input0: In,
+    input1: In,
+    output: Out,
+    *,
+    num_elements: CompileTime[int],
+    dtype: CompileTime[type],
+    tile_size: CompileTime[int],
+):
+    """output[i] = input0[i] + input1[i] for a fixed-length vector."""
+    tensor_ty = np.ndarray[(num_elements,), np.dtype[dtype]]
+    return transform_binary(lambda a, b: a + b, tensor_ty, tile_size=tile_size)
+
+
+def _compile_kwargs(opts) -> dict:
+    return {
+        "num_elements": opts.num_elements,
+        "dtype": DTYPES[opts.dtype],
+        "tile_size": opts.tile_size,
+    }
+
+
+def _validate(opts) -> None:
+    if opts.num_elements % opts.tile_size != 0:
+        raise SystemExit(
+            f"--num-elements ({opts.num_elements}) must be a multiple of "
+            f"--tile-size ({opts.tile_size})"
+        )
+
+
+def _run_and_verify(opts) -> None:
+    dtype = DTYPES[opts.dtype]
+    n = opts.num_elements
+
+    if np.issubdtype(dtype, np.integer):
+        input0 = iron.randint(0, 100, (n,), dtype=dtype, device="npu")
+        input1 = iron.randint(0, 100, (n,), dtype=dtype, device="npu")
+    else:
+        input0 = iron.rand(n, dtype=dtype, device="npu")
+        input1 = iron.rand(n, dtype=dtype, device="npu")
+    output = iron.zeros_like(input0)
+
+    ggml_xdna_add(input0, input1, output, **_compile_kwargs(opts))
+
+    expected = input0.numpy() + input1.numpy()
+    actual = output.numpy()
+
+    if opts.verbose:
+        print(f"{'i':>4}  {'a':>12} + {'b':>12} = {'c':>12}  (ref)")
+        print("-" * 60)
+        for i in range(min(8, n)):
+            print(
+                f"{i:4d}  {input0[i]:12} + {input1[i]:12} = "
+                f"{output[i]:12}  ({expected[i]})"
+            )
+
+    if np.issubdtype(dtype, np.integer):
+        assert_pass(expected, actual, fail_msg="ggml-xdna ADD mismatch vs NumPy")
+    else:
+        # AIE f32 add rounds slightly differently than the host FPU (~1 ULP).
+        assert_pass(expected, actual, rtol=1e-6,
+                    fail_msg="ggml-xdna ADD mismatch vs NumPy")
+    print(f"PASS: NPU ADD matches NumPy (n={n}, dtype={opts.dtype})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="ggml-xdna-add",
+        description="Build/run the ggml-xdna NPU ADD kernel",
+    )
+    add_compile_args(parser)
+    parser.add_argument("-n", "--num-elements", type=int, default=1024,
+                        help="elements per NPU run, baked into the artifacts (default: %(default)s)")
+    parser.add_argument("--tile-size", type=int, default=256,
+                        help="DMA tile size; must divide --num-elements (default: %(default)s)")
+    parser.add_argument("--dtype", choices=sorted(DTYPES), default="f32",
+                        help="element type (default: %(default)s)")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    opts = parser.parse_args()
+
+    run_design_cli(
+        ggml_xdna_add,
+        opts,
+        compile_kwargs=_compile_kwargs,
+        run_and_verify=_run_and_verify,
+        validate=_validate,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ggml/src/ggml-xdna/iron/ggml-xdna-gdn.py
+++ b/ggml/src/ggml-xdna/iron/ggml-xdna-gdn.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+# ggml-xdna-gdn.py -*- Python -*-
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+"""IRON design for GGML_OP_GATED_DELTA_NET (chunked prefill, scalar gate).
+
+Qwen3.5-0.8B: head dim S=128. Full state is 64 KiB (over L1), so one Worker
+keeps a ROWS=32 strip (16 KiB) resident. Two artifact modes:
+
+  --workers 1  (legacy): host issues NS=S/ROWS submits per head/chunk with v
+               slid so v[0:ROWS] match the active strip.
+  --workers 4  (w4): one submit fans the tok stream to NS workers; each keeps
+               its own state strip. Host state/attn are full-width.
+
+Host ABI (3 DMA buffers), workers=1:
+
+  tok   : CS*(3*S+2); v already slid to the active strip
+  state : ROWS*S, updated in place
+  out   : attn[CS*ROWS]
+
+Host ABI, workers=4 (NS=4):
+
+  tok   : CS*(3*S+2); v is the full S-wide vector
+  state : NS*ROWS*S (full SxS, row-major strips), updated in place
+  out   : attn[CS*S]
+
+Build:
+  python3 ggml-xdna-gdn.py -d npu2 --S 128 --ROWS 32 --CS 64 --workers 4 \\
+      --xclbin-path ggml-xdna-gdn-npu2-s128-r32-cs64-w4.xclbin \\
+      --insts-path  ggml-xdna-gdn-npu2-s128-r32-cs64-w4.insts.bin
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+import numpy as np
+
+import aie.iron as iron
+from aie.iron import CompileTime, In, InOut, ObjectFifo, Out, Program, Runtime, Worker
+from aie.iron.controlflow import range_
+from aie.iron.kernel import ExternalFunction
+from aie.iron.kernels._common import _include_dirs
+from aie.utils.hostruntime.argparse import add_compile_args
+from aie.utils.hostruntime.cli import run_design_cli
+from aie.utils.verify import assert_pass
+
+DEFAULT_S = 128
+DEFAULT_ROWS = 32
+DEFAULT_CS = 64
+L1_BUDGET = 60 * 1024
+
+KERNEL_SOURCE = r"""
+#include <stdint.h>
+
+// attn_col is CS*ROWS; this call writes rows for token t at attn_col[t*ROWS+r].
+// For workers=1, v already starts at the active strip (j0=0). For workers>1
+// the kernel indexes v[j0 + r] while state_strip is that worker's local strip.
+extern "C" void ggml_xdna_gdn_strip_f32(
+    float * state_strip,
+    const float * tok_t,
+    float * attn_col,
+    int32_t S,
+    int32_t ROWS,
+    int32_t t,
+    int32_t j0,
+    float scale) {
+    const float * q = tok_t;
+    const float * k = tok_t + S;
+    const float * v = tok_t + 2 * S + j0;
+    const float eg = tok_t[3 * S];
+    const float beta = tok_t[3 * S + 1];
+    float * attn_rows = attn_col + t * ROWS;
+
+    for (int32_t r = 0; r < ROWS; ++r) {
+        float * row = state_strip + r * S;
+        float dot_k = 0.0f;
+        for (int32_t i = 0; i < S; ++i) {
+            row[i] *= eg;
+            dot_k += row[i] * k[i];
+        }
+        const float delta = (v[r] - dot_k) * beta;
+        float dot_q = 0.0f;
+        for (int32_t i = 0; i < S; ++i) {
+            row[i] += k[i] * delta;
+            dot_q += row[i] * q[i];
+        }
+        attn_rows[r] = scale * dot_q;
+    }
+}
+"""
+
+
+def _gdn_program(S: int, ROWS: int, CS: int, workers: int, fuse_pre: int):
+    del fuse_pre
+    NS = S // ROWS
+    if workers not in (1, NS):
+        raise ValueError(f"workers must be 1 or {NS} (S/ROWS), got {workers}")
+
+    tok_elems = 3 * S + 2
+    strip_elems = ROWS * S
+    state_elems = workers * strip_elems
+    attn_elems = CS * ROWS * workers
+
+    tok_t_ty = np.ndarray[(tok_elems,), np.dtype[np.float32]]
+    strip_ty = np.ndarray[(strip_elems,), np.dtype[np.float32]]
+    attn_strip_ty = np.ndarray[(CS * ROWS,), np.dtype[np.float32]]
+    tok_pack_ty = np.ndarray[(CS * tok_elems,), np.dtype[np.float32]]
+    state_ty = np.ndarray[(state_elems,), np.dtype[np.float32]]
+    attn_ty = np.ndarray[(attn_elems,), np.dtype[np.float32]]
+
+    # Per-worker L1: state strip + tok double-buffer + attn column.
+    l1_worker = 2 * strip_elems * 4 + 2 * tok_elems * 4 + CS * ROWS * 4
+    if l1_worker > L1_BUDGET:
+        raise ValueError(f"L1 needs {l1_worker} B, over {L1_BUDGET}")
+
+    strip_fn = ExternalFunction(
+        "ggml_xdna_gdn_strip_f32",
+        source_string=KERNEL_SOURCE,
+        arg_types=[
+            strip_ty,
+            tok_t_ty,
+            attn_strip_ty,
+            np.int32,
+            np.int32,
+            np.int32,
+            np.int32,
+            np.float32,
+        ],
+        include_dirs=_include_dirs(),
+    )
+    scale = float(1.0 / math.sqrt(S))
+
+    def make_body(j0: int):
+        def body(of_tok, of_sin, of_sout, of_attn, strip_fn):
+            sin = of_sin.acquire(1)
+            sout = of_sout.acquire(1)
+            for i in range_(strip_elems):
+                sout[i] = sin[i]
+            of_sin.release(1)
+
+            attn = of_attn.acquire(1)
+            for t in range_(CS):
+                tok = of_tok.acquire(1)
+                strip_fn(sout, tok, attn, S, ROWS, t, j0, scale)
+                of_tok.release(1)
+            of_attn.release(1)
+            of_sout.release(1)
+
+        return body
+
+    if workers == 1:
+        of_sin = ObjectFifo(strip_ty, name="sin", depth=1)
+        of_sout = ObjectFifo(strip_ty, name="sout", depth=1)
+        of_tok = ObjectFifo(
+            tok_pack_ty,
+            name="tok",
+            depth=1,
+            consumer_obj_type=tok_t_ty,
+        )
+        of_attn = ObjectFifo(attn_strip_ty, name="attn", depth=1)
+
+        worker = Worker(
+            make_body(0),
+            fn_args=[
+                of_tok.cons(depth=2),
+                of_sin.cons(),
+                of_sout.prod(),
+                of_attn.prod(),
+                strip_fn,
+            ],
+        )
+
+        rt = Runtime()
+        with rt.sequence(tok_pack_ty, strip_ty, attn_ty) as (tok, st, out):
+            rt.start(worker)
+            rt.fill(of_tok.prod(), tok)
+            rt.fill(of_sin.prod(), st)
+            rt.drain(of_attn.cons(), out, wait=False)
+            rt.drain(of_sout.cons(), st, wait=True)
+        return Program(iron.get_current_device(), rt).resolve_program()
+
+    # Multi-worker: broadcast tok; MemTile join/split keeps shim DMA to 4 channels.
+    of_tok = ObjectFifo(
+        tok_pack_ty,
+        name="tok",
+        depth=1,
+        consumer_obj_type=tok_t_ty,
+    )
+
+    of_sin_shim = ObjectFifo(state_ty, name="sin", depth=1)
+    of_sin = of_sin_shim.cons().split(
+        offsets=[w * strip_elems for w in range(workers)],
+        obj_types=[strip_ty] * workers,
+        depths=[1] * workers,
+        names=[f"sin{w}" for w in range(workers)],
+    )
+
+    of_attn_shim = ObjectFifo(
+        np.ndarray[(attn_elems,), np.dtype[np.float32]],
+        name="attn",
+        depth=1,
+    )
+    of_attn = of_attn_shim.prod().join(
+        offsets=[w * CS * ROWS for w in range(workers)],
+        obj_types=[attn_strip_ty] * workers,
+        depths=[1] * workers,
+        names=[f"attn{w}" for w in range(workers)],
+    )
+
+    of_sout_shim = ObjectFifo(state_ty, name="sout", depth=1)
+    of_sout = of_sout_shim.prod().join(
+        offsets=[w * strip_elems for w in range(workers)],
+        obj_types=[strip_ty] * workers,
+        depths=[1] * workers,
+        names=[f"sout{w}" for w in range(workers)],
+    )
+
+    worker_list = [
+        Worker(
+            make_body(w * ROWS),
+            fn_args=[
+                of_tok.cons(depth=2),
+                of_sin[w].cons(),
+                of_sout[w].prod(),
+                of_attn[w].prod(),
+                strip_fn,
+            ],
+        )
+        for w in range(workers)
+    ]
+
+    rt = Runtime()
+    with rt.sequence(tok_pack_ty, state_ty, attn_ty) as (tok, st, out):
+        for w in worker_list:
+            rt.start(w)
+        rt.fill(of_tok.prod(), tok)
+        rt.fill(of_sin_shim.prod(), st)
+        rt.drain(of_attn_shim.cons(), out, wait=False)
+        rt.drain(of_sout_shim.cons(), st, wait=True)
+
+    return Program(iron.get_current_device(), rt).resolve_program()
+
+
+@iron.jit
+def ggml_xdna_gdn(
+    tok: In,
+    state: InOut,
+    out: Out,
+    *,
+    S: CompileTime[int],
+    ROWS: CompileTime[int],
+    CS: CompileTime[int],
+    workers: CompileTime[int],
+    fuse_pre: CompileTime[int],
+):
+    return _gdn_program(S, ROWS, CS, workers, fuse_pre)
+
+
+def _compile_kwargs(opts) -> dict:
+    return {
+        "S": opts.S,
+        "ROWS": opts.ROWS,
+        "CS": opts.CS,
+        "workers": opts.workers,
+        "fuse_pre": opts.fuse_pre,
+    }
+
+
+def _ref_strip(q, k, v, g, beta, state_strip, S, ROWS, CS, j0=0):
+    scale = 1.0 / math.sqrt(S)
+    s = state_strip.copy()
+    attn = np.empty((CS, ROWS), dtype=np.float32)
+    for t in range(CS):
+        s *= math.exp(float(g[t]))
+        delta = (v[t, j0:j0 + ROWS] - s @ k[t]) * float(beta[t])
+        s += np.outer(delta, k[t])
+        attn[t] = scale * (s @ q[t])
+    return attn, s
+
+
+def _run_and_verify(opts) -> None:
+    S, ROWS, CS, workers = opts.S, opts.ROWS, opts.CS, opts.workers
+    NS = S // ROWS
+    tok_elems = 3 * S + 2
+    rng = np.random.default_rng(0)
+
+    q = rng.standard_normal((CS, S), dtype=np.float32)
+    k = rng.standard_normal((CS, S), dtype=np.float32)
+    q /= np.linalg.norm(q, axis=1, keepdims=True)
+    k /= np.linalg.norm(k, axis=1, keepdims=True)
+    v = rng.standard_normal((CS, S), dtype=np.float32)
+    g = -np.abs(rng.standard_normal(CS, dtype=np.float32)) * 0.01
+    beta = np.clip(np.abs(rng.standard_normal(CS, dtype=np.float32)), 0.01, 1.0)
+    state = rng.standard_normal((NS * ROWS, S), dtype=np.float32) * 0.01
+
+    pack = np.zeros(CS * tok_elems, dtype=np.float32)
+    for t in range(CS):
+        base = t * tok_elems
+        pack[base:base + S] = q[t]
+        pack[base + S:base + 2 * S] = k[t]
+        if workers == 1:
+            pack[base + 2 * S:base + 2 * S + ROWS] = v[t, :ROWS]
+        else:
+            pack[base + 2 * S:base + 3 * S] = v[t]
+        pack[base + 3 * S] = np.exp(g[t])
+        pack[base + 3 * S + 1] = beta[t]
+
+    state_elems = workers * ROWS * S
+    attn_elems = CS * ROWS * workers
+    tok = iron.tensor((CS * tok_elems,), dtype=np.float32, device="npu")
+    st = iron.tensor((state_elems,), dtype=np.float32, device="npu")
+    out = iron.zeros((attn_elems,), dtype=np.float32, device="npu")
+    tok[:] = pack
+    st[:] = state.reshape(-1)[:state_elems]
+
+    ggml_xdna_gdn(tok, st, out, **_compile_kwargs(opts))
+
+    actual = out.numpy()
+    updated_state = st.numpy()
+    if workers == 1:
+        attn_ref, state_ref = _ref_strip(q, k, v, g, beta, state[:ROWS], S, ROWS, CS, 0)
+        attn = actual.reshape(CS, ROWS)
+        new_state = updated_state.reshape(ROWS, S)
+        assert_pass(attn_ref.reshape(-1), attn.reshape(-1), rtol=2e-3, atol=2e-3,
+                    fail_msg="ggml-xdna GDN attn mismatch")
+        assert_pass(state_ref.reshape(-1), new_state.reshape(-1), rtol=2e-3, atol=2e-3,
+                    fail_msg="ggml-xdna GDN state mismatch")
+    else:
+        attn_ref = np.empty((NS, CS, ROWS), dtype=np.float32)
+        state_ref = np.empty_like(state)
+        for ns in range(NS):
+            a, s = _ref_strip(q, k, v, g, beta, state[ns * ROWS:(ns + 1) * ROWS],
+                              S, ROWS, CS, ns * ROWS)
+            attn_ref[ns] = a
+            state_ref[ns * ROWS:(ns + 1) * ROWS] = s
+        # Host layout: attn strips concatenated as worker-major CS*ROWS blocks.
+        attn = actual.reshape(NS, CS, ROWS)
+        new_state = updated_state.reshape(NS * ROWS, S)
+        if opts.verbose:
+            print(f"attn max abs: {np.max(np.abs(attn_ref - attn)):.6g}")
+            print(f"state max abs: {np.max(np.abs(state_ref - new_state)):.6g}")
+        assert_pass(attn_ref.reshape(-1), attn.reshape(-1), rtol=2e-3, atol=2e-3,
+                    fail_msg="ggml-xdna GDN full attn mismatch")
+        assert_pass(state_ref.reshape(-1), new_state.reshape(-1), rtol=2e-3, atol=2e-3,
+                    fail_msg="ggml-xdna GDN full state mismatch")
+    print(f"PASS: NPU GDN matches NumPy (S={S}, ROWS={ROWS}, CS={CS}, workers={workers})")
+
+
+def _device(opts):
+    from aie.iron.device import from_name
+    # Multi-worker needs one column (and MemTile DMA budget) per strip worker.
+    cols = opts.workers if opts.workers > 1 else 1
+    return from_name(opts.dev, n_cols=cols)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="ggml-xdna-gdn",
+        description="Build/run the ggml-xdna NPU GATED_DELTA_NET kernel",
+    )
+    add_compile_args(parser)
+    parser.add_argument("--S", type=int, default=DEFAULT_S)
+    parser.add_argument("--ROWS", type=int, default=DEFAULT_ROWS)
+    parser.add_argument("--CS", type=int, default=DEFAULT_CS)
+    parser.add_argument("--workers", type=int, default=1,
+                        help="1 = single strip (legacy); S/ROWS = full state in one submit")
+    parser.add_argument("--fuse-pre", type=int, default=0)
+    parser.add_argument("-v", "--verbose", action="store_true")
+    opts = parser.parse_args()
+
+    if opts.S % opts.ROWS:
+        raise SystemExit("--S must be divisible by --ROWS")
+    if opts.workers not in (1, opts.S // opts.ROWS):
+        raise SystemExit(f"--workers must be 1 or {opts.S // opts.ROWS}")
+
+    l1 = 2 * opts.ROWS * opts.S * 4 + 2 * (3 * opts.S + 2) * 4 + opts.CS * opts.ROWS * 4
+    if l1 > L1_BUDGET:
+        raise SystemExit(f"L1 needs {l1} B; reduce --ROWS or --CS")
+
+    run_design_cli(
+        ggml_xdna_gdn,
+        opts,
+        compile_kwargs=_compile_kwargs,
+        run_and_verify=_run_and_verify,
+        device=_device,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ggml/src/ggml-xdna/iron/ggml-xdna-gemm.py
+++ b/ggml/src/ggml-xdna/iron/ggml-xdna-gemm.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+# ggml-xdna-gemm.py -*- Python -*-
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+"""IRON design for the ggml-xdna MUL_MAT kernel.
+
+  run+verify   python3 ggml-xdna-gemm.py --MB 16
+  compile-only python3 ggml-xdna-gemm.py -d npu2 --MB 16 \
+                   --xclbin-path ggml-xdna-gemm-npu2-bf16-8-16.xclbin \
+                   --insts-path  ggml-xdna-gemm-npu2-bf16-8-16.insts.bin
+
+One submit:
+
+    C[MB*GR*M, GC*N] = A[MB*GR*M, KT*K] @ B[KT*K, GC*N]
+
+with KT fixed at 16 (K=1024). The host splits larger K into 1024-chunks and
+accumulates C, and loops over output column blocks of GC*N (NB=1). A K that
+does not fill the last chunk is zero-padded by the host.
+
+B is staged once per column as a single MemTile object (KT*K*N bf16), then
+forwarded to L1 as tile-sized pieces and replayed MB times via set_iter_count.
+Per-tile MemTile depth=KT plus set_iter_count deadlocks; the asymmetric
+chain object is what makes L2 reuse work.
+
+Artifact name: ggml-xdna-gemm-npu2-bf16-<KT>-<MB>
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+import aie.iron as iron
+from aie.iron import CompileTime, In, ObjectFifo, Out, Program, Runtime, Worker
+from aie.iron.controlflow import range_
+from aie.iron.kernels import mm as mm_kernel
+from aie.utils.hostruntime.argparse import add_compile_args
+from aie.helpers.taplib import TensorAccessPattern
+from aie.iron.device import from_name
+from aie.utils.hostruntime.cli import run_design_cli
+from aie.utils.verify import assert_pass
+
+MAC_R, MAC_S, MAC_T = 8, 8, 8
+
+CORES_PER_COL = 4
+MAX_COLS = 8
+MEMTILE_BYTES = 512 * 1024
+
+TILE_M, TILE_K, TILE_N = 32, 64, 64
+# Fixed K depth: 16 tiles = 1024. One MemTile object per column (128 KiB).
+DEFAULT_KT = 16
+
+
+def swizzle_a(a, r=MAC_R, s=MAC_S):
+    M, K = a.shape
+    return a.reshape(M // r, r, K // s, s).transpose(0, 2, 1, 3).reshape(-1)
+
+
+def swizzle_b(b, s=MAC_S, t=MAC_T):
+    K, N = b.shape
+    return b.reshape(K // s, s, N // t, t).transpose(0, 2, 1, 3).reshape(-1)
+
+
+def unswizzle_c(c, M, N, r=MAC_R, t=MAC_T):
+    return c.reshape(M // r, N // t, r, t).transpose(0, 2, 1, 3).reshape(M, N)
+
+
+def _core(of_a, of_b, of_c, zero_fn, matmul_fn, k_tiles):
+    elem_out = of_c.acquire(1)
+    zero_fn(elem_out)
+    for _ in range_(k_tiles):
+        elem_in_a = of_a.acquire(1)
+        elem_in_b = of_b.acquire(1)
+        matmul_fn(elem_in_a, elem_in_b, elem_out)
+        of_a.release(1)
+        of_b.release(1)
+    of_c.release(1)
+
+
+@iron.jit
+def ggml_xdna_gemm(
+    input_a: In,
+    input_b: In,
+    output_c: Out,
+    *,
+    M: CompileTime[int],
+    K: CompileTime[int],
+    N: CompileTime[int],
+    KT: CompileTime[int],
+    MB: CompileTime[int],
+    GR: CompileTime[int],
+    GC: CompileTime[int],
+):
+    matmul = mm_kernel(
+        dim_m=M,
+        dim_k=K,
+        dim_n=N,
+        input_dtype=bfloat16,
+        output_dtype=np.float32,
+        vectorized=True,
+        emulate_bf16_mmul_with_bfp16=True,
+        b_col_maj=False,
+        c_col_maj=False,
+    )
+    zero = matmul.zero
+
+    a_tile_ty = np.ndarray[(M * K,), np.dtype[bfloat16]]
+    b_tile_ty = np.ndarray[(K * N,), np.dtype[bfloat16]]
+    b_chain_ty = np.ndarray[(KT * K * N,), np.dtype[bfloat16]]
+    c_ty = np.ndarray[(M * N,), np.dtype[np.float32]]
+
+    a_ty = np.ndarray[(GR * MB * KT * M * K,), np.dtype[bfloat16]]
+    b_ty = np.ndarray[(GC * KT * K * N,), np.dtype[bfloat16]]
+    c_host_ty = np.ndarray[(GC * MB * GR * M * N,), np.dtype[np.float32]]
+
+    of_a = [ObjectFifo(a_tile_ty, name=f"inA{i}", depth=2) for i in range(GR)]
+
+    of_b_ddr = []
+    of_b_l2 = []
+    for j in range(GC):
+        # One MemTile-resident chain object, split to L1 tiles and replayed MB
+        # times. Per-tile depth=KT + set_iter_count deadlocks; asymmetric chain
+        # + forward(repeat_count=MB) is the working L2-reuse pattern.
+        ddr = ObjectFifo(b_chain_ty, name=f"inB{j}", depth=1)
+        l2 = ddr.cons(depth=1).forward(
+            name=f"inB{j}_l1",
+            obj_type=b_tile_ty,
+            depth=2,
+            repeat_count=MB,
+        )
+        of_b_ddr.append(ddr)
+        of_b_l2.append(l2)
+
+    of_c = []
+    of_c_shim = []
+    for j in range(GC):
+        if GR == 1:
+            f = ObjectFifo(c_ty, name=f"outC{j}", depth=1)
+            of_c.append([f])
+            of_c_shim.append(f)
+            continue
+
+        c_wide_ty = np.ndarray[(GR * M * N,), np.dtype[np.float32]]
+        c_shim = ObjectFifo(c_wide_ty, name=f"outC{j}", depth=1)
+        of_c.append(c_shim.prod().join(
+            offsets=[i * M * N for i in range(GR)],
+            obj_types=[c_ty] * GR,
+            depths=[1] * GR,
+        ))
+        of_c_shim.append(c_shim)
+
+    workers = [Worker(
+        _core,
+        fn_args=[of_a[i].cons(), of_b_l2[j].cons(depth=2), of_c[j][i].prod(),
+                 zero, matmul, KT],
+        while_true=True,
+    ) for j in range(GC) for i in range(GR)]
+
+    def slice_tap(total, offset, count):
+        return TensorAccessPattern([1, total], offset, [1, count], [0, 1])
+
+    a_stride = MB * KT * M * K
+    b_stride = KT * K * N
+    c_stride = MB * GR * M * N
+
+    rt = Runtime()
+    with rt.sequence(a_ty, b_ty, c_host_ty) as (a, b, c):
+        for w in workers:
+            rt.start(w)
+        for i in range(GR):
+            rt.fill(of_a[i].prod(), a,
+                    tap=slice_tap(GR * a_stride, i * a_stride, a_stride))
+        for j in range(GC):
+            rt.fill(of_b_ddr[j].prod(), b,
+                    tap=slice_tap(GC * b_stride, j * b_stride, b_stride))
+            rt.drain(of_c_shim[j].cons(), c,
+                     tap=slice_tap(GC * c_stride, j * c_stride, c_stride),
+                     wait=True)
+
+    return Program(iron.get_current_device(), rt).resolve_program()
+
+
+def _compile_kwargs(opts) -> dict:
+    return {"M": TILE_M, "K": TILE_K, "N": TILE_N,
+            "KT": opts.KT, "MB": opts.MB,
+            "GR": opts.grid[0], "GC": opts.grid[1]}
+
+
+def _validate(opts) -> None:
+    gr, gc = opts.grid
+    if gr < 1 or gc < 1:
+        raise SystemExit("--grid dimensions must be >= 1")
+    if gr > CORES_PER_COL:
+        raise SystemExit(f"grid rows map to cores within a column, so <= {CORES_PER_COL}")
+    if gc > MAX_COLS:
+        raise SystemExit(f"grid columns map to device columns, so <= {MAX_COLS}")
+    if opts.KT < 1 or opts.KT > 16:
+        raise SystemExit("--KT must be in 1..16 (MemTile BD-ID budget for chain+C)")
+    if opts.MB < 1 or opts.MB > 256:
+        raise SystemExit("--MB must be in 1..256")
+
+    l1 = TILE_M * TILE_N * 4 + 2 * 2 * (TILE_M * TILE_K + TILE_K * TILE_N)
+    if l1 > 60 * 1024:
+        raise SystemExit(f"tile needs {l1} B of L1, over budget")
+
+    # One B chain object + C join wide buffer share the MemTile.
+    b_chain = opts.KT * TILE_K * TILE_N * 2
+    c_wide = gr * TILE_M * TILE_N * 4
+    if b_chain + c_wide > MEMTILE_BYTES:
+        raise SystemExit(f"MemTile needs {b_chain + c_wide} B, over budget")
+
+
+def _report(opts) -> None:
+    gr, gc = opts.grid
+    m, k, n, kt, mb = TILE_M, TILE_K, TILE_N, opts.KT, opts.MB
+    macs = gr * gc * mb * kt * m * k * n
+    dma = 2 * (gr * mb * kt * m * k + gc * kt * k * n) + gr * gc * mb * m * n * 4
+    print(f"geometry: C[{mb * gr * m}, {gc * n}] = A[{mb * gr * m}, {kt * k}] @ "
+          f"B[{kt * k}, {gc * n}]")
+    print(f"          B staged as one L2 chain ({kt * k * n * 2 / 1024:.0f} KiB/col), "
+          f"replayed x{mb}")
+    print(f"          {macs / 1e6:.1f} MMAC and {dma / 1024 / 1024:.2f} MiB per submit, "
+          f"{macs / dma:.1f} MAC/byte")
+
+
+def _run_and_verify(opts) -> None:
+    M, K, N, KT, MB = TILE_M, TILE_K, TILE_N, opts.KT, opts.MB
+    GR, GC = opts.grid
+    rng = np.random.default_rng(0)
+
+    a = rng.standard_normal((MB * GR * M, KT * K), dtype=np.float32).astype(bfloat16)
+    b = rng.standard_normal((KT * K, GC * N), dtype=np.float32).astype(bfloat16)
+
+    input_a = iron.tensor((GR * MB * KT * M * K,), dtype=bfloat16, device="npu")
+    input_b = iron.tensor((GC * KT * K * N,), dtype=bfloat16, device="npu")
+    output_c = iron.zeros((GC * MB * GR * M * N,), dtype=np.float32, device="npu")
+
+    a_parts = []
+    for i in range(GR):
+        for mb in range(MB):
+            m0 = (mb * GR + i) * M
+            for kt in range(KT):
+                a_parts.append(swizzle_a(a[m0:m0 + M, kt * K:(kt + 1) * K]))
+    np.copyto(input_a.numpy(), np.concatenate(a_parts))
+
+    b_parts = []
+    for j in range(GC):
+        for kt in range(KT):
+            b_parts.append(swizzle_b(b[kt * K:(kt + 1) * K, j * N:(j + 1) * N]))
+    np.copyto(input_b.numpy(), np.concatenate(b_parts))
+
+    ggml_xdna_gemm(input_a, input_b, output_c, **_compile_kwargs(opts))
+
+    flat_c = output_c.numpy()
+    actual = np.zeros((MB * GR * M, GC * N), dtype=np.float32)
+    w = 0
+    for j in range(GC):
+        for mb in range(MB):
+            for i in range(GR):
+                tile = unswizzle_c(flat_c[w * M * N:(w + 1) * M * N], M, N)
+                m0 = (mb * GR + i) * M
+                actual[m0:m0 + M, j * N:(j + 1) * N] = tile
+                w += 1
+
+    expected = a.astype(np.float32) @ b.astype(np.float32)
+    # bf16/BFP16 matmul noise grows with K and with more row blocks in one submit
+    rtol, atol = 2e-1, 6e-1 * np.sqrt(KT * K / 32.0)
+
+    if opts.verbose:
+        _report(opts)
+
+    assert_pass(expected.reshape(-1), actual.reshape(-1), rtol=rtol, atol=atol,
+                fail_msg="ggml-xdna GEMM mismatch vs NumPy")
+    err = np.abs(actual.reshape(-1) - expected.reshape(-1))
+    print(f"PASS: NPU bf16 GEMM matches NumPy "
+          f"(C[{MB * GR * M}, {GC * N}], K={KT * K}, MB={MB}), "
+          f"max abs err {err.max():.3g}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="ggml-xdna-gemm",
+        description="Build/run the ggml-xdna NPU MUL_MAT kernel",
+    )
+    add_compile_args(parser)
+    parser.add_argument("--KT", type=int, default=DEFAULT_KT,
+                        help="K chunks per submit; K = KT*%d (default: %%(default)s). "
+                             "Host splits larger K." % TILE_K)
+    parser.add_argument("--MB", type=int, default=16,
+                        help="row blocks per submit; M = MB*GR*%d. B is staged "
+                             "in L2 and replayed this many times "
+                             "(default: %%(default)s)" % TILE_M)
+    parser.add_argument("--grid", type=int, nargs=2, default=[4, 8],
+                        metavar=("ROWS", "COLS"),
+                        help="worker grid (default: %(default)s)")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    opts = parser.parse_args()
+
+    def device(o):
+        return from_name(o.dev, n_cols=o.grid[1])
+
+    run_design_cli(
+        ggml_xdna_gemm,
+        opts,
+        compile_kwargs=_compile_kwargs,
+        run_and_verify=_run_and_verify,
+        validate=_validate,
+        device=device,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ggml/src/ggml-xdna/iron/ggml-xdna-mul.py
+++ b/ggml/src/ggml-xdna/iron/ggml-xdna-mul.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# ggml-xdna-mul.py -*- Python -*-
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Derived from Xilinx/mlir-aie programming_examples/basic/vector_vector_add
+#
+"""IRON design for the ggml-xdna MUL kernel.
+
+Two modes:
+
+  run+verify   python3 ggml-xdna-mul.py -n 1024              (JIT, checks vs NumPy)
+  compile-only python3 ggml-xdna-mul.py -n 1024 -d npu2 \
+                   --xclbin-path ggml-xdna-mul-npu2-1024.xclbin \
+                   --insts-path  ggml-xdna-mul-npu2-1024.insts.bin
+
+This builds a second xclbin next to the ADD one. Both stay resident on the NPU
+at the same time, each in its own hw_context, so dispatching between them never
+reloads a design.
+
+``num_elements`` is baked into the artifacts and *is* the host ABI: the backend
+submits exactly this many elements per NPU run and chunks larger tensors.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+
+import aie.iron as iron
+from aie.iron import CompileTime, In, Out
+from aie.iron.algorithms import transform_binary
+from aie.utils.hostruntime.argparse import add_compile_args
+from aie.utils.hostruntime.cli import run_design_cli
+from aie.utils.verify import assert_pass
+
+DTYPES = {
+    "f32": np.float32,
+    "i32": np.int32,
+}
+
+
+@iron.jit
+def ggml_xdna_mul(
+    input0: In,
+    input1: In,
+    output: Out,
+    *,
+    num_elements: CompileTime[int],
+    dtype: CompileTime[type],
+    tile_size: CompileTime[int],
+):
+    """output[i] = input0[i] * input1[i] for a fixed-length vector."""
+    tensor_ty = np.ndarray[(num_elements,), np.dtype[dtype]]
+    return transform_binary(lambda a, b: a * b, tensor_ty, tile_size=tile_size)
+
+
+def _compile_kwargs(opts) -> dict:
+    return {
+        "num_elements": opts.num_elements,
+        "dtype": DTYPES[opts.dtype],
+        "tile_size": opts.tile_size,
+    }
+
+
+def _validate(opts) -> None:
+    if opts.num_elements % opts.tile_size != 0:
+        raise SystemExit(
+            f"--num-elements ({opts.num_elements}) must be a multiple of "
+            f"--tile-size ({opts.tile_size})"
+        )
+
+
+def _run_and_verify(opts) -> None:
+    dtype = DTYPES[opts.dtype]
+    n = opts.num_elements
+
+    if np.issubdtype(dtype, np.integer):
+        input0 = iron.randint(0, 100, (n,), dtype=dtype, device="npu")
+        input1 = iron.randint(0, 100, (n,), dtype=dtype, device="npu")
+    else:
+        input0 = iron.rand(n, dtype=dtype, device="npu")
+        input1 = iron.rand(n, dtype=dtype, device="npu")
+    output = iron.zeros_like(input0)
+
+    ggml_xdna_mul(input0, input1, output, **_compile_kwargs(opts))
+
+    expected = input0.numpy() * input1.numpy()
+    actual = output.numpy()
+
+    if opts.verbose:
+        print(f"{'i':>4}  {'a':>12} * {'b':>12} = {'c':>12}  (ref)")
+        print("-" * 60)
+        for i in range(min(8, n)):
+            print(
+                f"{i:4d}  {input0[i]:12} * {input1[i]:12} = "
+                f"{output[i]:12}  ({expected[i]})"
+            )
+
+    if np.issubdtype(dtype, np.integer):
+        assert_pass(expected, actual, fail_msg="ggml-xdna MUL mismatch vs NumPy")
+    else:
+        # AIE f32 multiply rounds slightly differently than the host FPU (~1 ULP).
+        assert_pass(expected, actual, rtol=1e-6,
+                    fail_msg="ggml-xdna MUL mismatch vs NumPy")
+    print(f"PASS: NPU MUL matches NumPy (n={n}, dtype={opts.dtype})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="ggml-xdna-mul",
+        description="Build/run the ggml-xdna NPU MUL kernel",
+    )
+    add_compile_args(parser)
+    parser.add_argument("-n", "--num-elements", type=int, default=1024,
+                        help="elements per NPU run, baked into the artifacts (default: %(default)s)")
+    parser.add_argument("--tile-size", type=int, default=256,
+                        help="DMA tile size; must divide --num-elements (default: %(default)s)")
+    parser.add_argument("--dtype", choices=sorted(DTYPES), default="f32",
+                        help="element type (default: %(default)s)")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    opts = parser.parse_args()
+
+    run_design_cli(
+        ggml_xdna_mul,
+        opts,
+        compile_kwargs=_compile_kwargs,
+        run_and_verify=_run_and_verify,
+        validate=_validate,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ggml/src/ggml-xdna/iron/ggml-xdna-rms-norm.py
+++ b/ggml/src/ggml-xdna/iron/ggml-xdna-rms-norm.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# ggml-xdna-rms-norm.py -*- Python -*-
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+"""IRON design for the ggml-xdna RMS_NORM kernel.
+
+  run+verify   python3 ggml-xdna-rms-norm.py -n 1024
+  compile-only python3 ggml-xdna-rms-norm.py -n 1024 -d npu2 \
+                   --xclbin-path ggml-xdna-rms-norm-npu2-f32-1024.xclbin \
+                   --insts-path  ggml-xdna-rms-norm-npu2-f32-1024.insts.bin
+
+Unlike ADD and MUL this is not elementwise: the row has to be summed before any
+output can be produced, so it cannot be expressed as a ``transform_binary``
+lambda and needs an AIE kernel with accumulator state.
+
+``num_elements`` is one row (ggml's ne0) and is baked into the artifacts. The
+host ABI is three buffers - x, eps, y - in that order. eps travels in its own
+one-element buffer instead of being a compile-time constant so the same xclbin
+serves any model.
+
+This is a reference implementation: scalar, correct, and not fast. It exists so
+the RMS_NORM op and the ADD+RMS_NORM+MUL fusion path can be exercised end to
+end; replacing it with a vectorised kernel changes nothing above it.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+
+import aie.iron as iron
+from aie.iron import CompileTime, In, ObjectFifo, Out, Program, Runtime, Worker
+from aie.iron.kernel import ExternalFunction
+from aie.iron.kernels._common import _include_dirs
+from aie.utils.hostruntime.argparse import add_compile_args
+from aie.utils.hostruntime.cli import run_design_cli
+from aie.utils.verify import assert_pass
+
+KERNEL_SOURCE = r"""
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+
+// y[i] = x[i] / sqrt(sum(x^2)/n + eps)
+extern "C" void ggml_xdna_rms_norm_f32(const float * x, const float * eps, float * y, int32_t n) {
+    float sum = 0.0f;
+    for (int32_t i = 0; i < n; i++) {
+        sum += x[i] * x[i];
+    }
+
+    // aie::invsqrt is an approximation; exact 1/sqrtf would pull in libm
+    const float scale = aie::invsqrt(sum / (float) n + eps[0]);
+
+    for (int32_t i = 0; i < n; i++) {
+        y[i] = x[i] * scale;
+    }
+}
+"""
+
+
+def _rms_norm_program(num_elements: int):
+    """Whole-row design: one kernel call per submission, three buffers."""
+    row_ty = np.ndarray[(num_elements,), np.dtype[np.float32]]
+    eps_ty = np.ndarray[(1,), np.dtype[np.float32]]
+
+    kernel = ExternalFunction(
+        "ggml_xdna_rms_norm_f32",
+        source_string=KERNEL_SOURCE,
+        arg_types=[row_ty, eps_ty, row_ty, np.int32],
+        include_dirs=_include_dirs(),
+    )
+
+    of_x = ObjectFifo(row_ty, name="x")
+    of_eps = ObjectFifo(eps_ty, name="eps")
+    of_y = ObjectFifo(row_ty, name="y")
+
+    def core_body(of_x, of_eps, of_y, kernel):
+        e = of_eps.acquire(1)
+        x = of_x.acquire(1)
+        y = of_y.acquire(1)
+        kernel(x, e, y, num_elements)
+        of_x.release(1)
+        of_eps.release(1)
+        of_y.release(1)
+
+    worker = Worker(core_body, fn_args=[of_x.cons(), of_eps.cons(), of_y.prod(), kernel])
+
+    rt = Runtime()
+    with rt.sequence(row_ty, eps_ty, row_ty) as (a_x, a_eps, a_y):
+        rt.start(worker)
+        rt.fill(of_x.prod(), a_x)
+        rt.fill(of_eps.prod(), a_eps)
+        rt.drain(of_y.cons(), a_y, wait=True)
+
+    return Program(iron.get_current_device(), rt).resolve_program()
+
+
+@iron.jit
+def ggml_xdna_rms_norm(x: In, eps: In, y: Out, *, num_elements: CompileTime[int]):
+    return _rms_norm_program(num_elements)
+
+
+def _compile_kwargs(opts) -> dict:
+    return {"num_elements": opts.num_elements}
+
+
+def _run_and_verify(opts) -> None:
+    n = opts.num_elements
+
+    x = iron.rand(n, dtype=np.float32, device="npu")
+    eps = iron.zeros(1, dtype=np.float32, device="npu")
+    eps[0] = opts.eps
+    y = iron.zeros_like(x)
+
+    ggml_xdna_rms_norm(x, eps, y, **_compile_kwargs(opts))
+
+    xn = x.numpy().astype(np.float64)
+    expected = (xn / np.sqrt(np.mean(xn * xn) + opts.eps)).astype(np.float32)
+    actual = y.numpy()
+
+    if opts.verbose:
+        print(f"{'i':>4}  {'x':>14}  {'y':>14}  {'ref':>14}")
+        print("-" * 54)
+        for i in range(min(8, n)):
+            print(f"{i:4d}  {x[i]:14.6f}  {actual[i]:14.6f}  {expected[i]:14.6f}")
+
+    assert_pass(expected, actual, rtol=1e-4,
+                fail_msg="ggml-xdna RMS_NORM mismatch vs NumPy")
+    print(f"PASS: NPU RMS_NORM matches NumPy (n={n}, eps={opts.eps})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="ggml-xdna-rms-norm",
+        description="Build/run the ggml-xdna NPU RMS_NORM kernel",
+    )
+    add_compile_args(parser)
+    parser.add_argument("-n", "--num-elements", type=int, default=1024,
+                        help="row length (ggml ne0), baked into the artifacts (default: %(default)s)")
+    parser.add_argument("--eps", type=float, default=1e-6,
+                        help="epsilon used by the verify path only (default: %(default)s)")
+    parser.add_argument("--tile-size", type=int, default=256,
+                        help="accepted for symmetry with the elementwise designs; unused")
+    parser.add_argument("--dtype", choices=["f32"], default="f32")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    opts = parser.parse_args()
+
+    run_design_cli(
+        ggml_xdna_rms_norm,
+        opts,
+        compile_kwargs=_compile_kwargs,
+        run_and_verify=_run_and_verify,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ggml/src/ggml-xdna/xdna-npu.cpp
+++ b/ggml/src/ggml-xdna/xdna-npu.cpp
@@ -1,0 +1,1635 @@
+#include "xdna-npu.h"
+
+#include "ggml-impl.h"
+
+#if defined(__x86_64__) || defined(__i386__)
+#include <immintrin.h>
+#endif
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+const char * ggml_xdna_op_name(enum ggml_xdna_op op) {
+    switch (op) {
+        case GGML_XDNA_OP_GEMM:         return "gemm";
+#if defined(GGML_XDNA_EXPERIMENTAL)
+        case GGML_XDNA_OP_ADD:          return "add";
+        case GGML_XDNA_OP_MUL:          return "mul";
+        case GGML_XDNA_OP_RMS_NORM:     return "rms-norm";
+        case GGML_XDNA_OP_ADD_RMS_MUL:  return "add-rms-mul";
+        case GGML_XDNA_OP_GDN:          return "gdn";
+#endif
+    }
+    return "?";
+}
+
+#if defined(GGML_XDNA_HAS_XRT)
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_hw_context.h"
+#include "xrt/xrt_kernel.h"
+#include "xrt/experimental/xrt_kernel.h"
+#include "xrt/experimental/xrt_xclbin.h"
+
+// Kernel ABI emitted by mlir-aie: MLIR_AIE(opcode, instr, n_instr, bo0, bo1, bo2).
+// Data buffers start at group_id(3); opcode 3 selects the transaction flow.
+static const char * XDNA_KERNEL_NAME = "MLIR_AIE";
+static constexpr uint64_t XDNA_OPCODE_TXN = 3;
+static constexpr int XDNA_ARG_DATA0 = 3;
+
+// One xrt::device for the whole process. Every kernel builds its own
+// hw_context on top of it, which is what lets several xclbins be resident at
+// the same time; opening the device once also avoids handing the driver two
+// unrelated clients for the same NPU.
+struct ggml_xdna_device {
+    xrt::device device;
+    std::string name;
+    bool        ok = false;
+};
+
+static ggml_xdna_device & ggml_xdna_shared_device(void) {
+    static ggml_xdna_device dev;
+    static std::once_flag   once;
+
+    std::call_once(once, [&]() {
+        try {
+            dev.device = xrt::device(0u);
+            dev.name   = dev.device.get_info<xrt::info::device::name>();
+            dev.ok     = true;
+        } catch (const std::exception & e) {
+            GGML_LOG_DEBUG("%s: no XDNA device: %s\n", "ggml-xdna", e.what());
+        } catch (...) {
+            GGML_LOG_DEBUG("%s: no XDNA device (unknown error)\n", "ggml-xdna");
+        }
+    });
+
+    return dev;
+}
+
+struct ggml_xdna_npu {
+    xrt::hw_context  context;
+    xrt::kernel      kernel;
+    xrt::bo          bo_instr;
+    xrt::bo          bo_a;
+    xrt::bo          bo_b;
+    xrt::bo          bo_c;
+    // Optional second A/C bank for pack/submit overlap. Empty when n_banks==1.
+    xrt::bo          bo_a1;
+    xrt::bo          bo_c1;
+    xrt::run         run;
+    // Pre-built runs for runlist batching of K-slices (one per a_views entry).
+    std::vector<xrt::run> runs;
+    xrt::runlist *   runlist = nullptr;
+    int              pending_kb_n = 0;
+    size_t           pending_c_bytes = 0;
+    int              pending_bank = 0;
+    bool             pending_async = false;
+
+    ggml_xdna_op     op = GGML_XDNA_OP_GEMM;
+
+    ggml_xdna_gemm_shape shape{};
+    // One sub-buffer per (weight buffer, offset). Building an xrt::bo view is
+    // not free, and the same weight tensor is submitted once per prefill chunk
+    // for the whole run.
+    std::unordered_map<std::string, xrt::bo> w_views;
+
+    // GEMM operands stay in device-visible memory: the host packs A and reads C
+    // in place, so a submit copies nothing. One view per K-slice, so all slices
+    // of a row block can be packed once and replayed for every column block.
+    std::vector<xrt::bo> a_views;
+    std::vector<xrt::bo> b_views;
+    std::vector<xrt::bo> c_views;
+    std::vector<xrt::bo> a_views1;
+    std::vector<xrt::bo> c_views1;
+    int                  kb_max = 1;
+    int                  n_banks = 1;
+    int                  bank = 0;
+
+    uint32_t         n_instr    = 0;
+    // Manual cache invalidation after bo.sync(FROM_DEVICE). Kept on by default
+    // because the amdxdna path has shown stale CPU reads without it; can be
+    // disabled with GGML_XDNA_CLFLUSH=0 to test whether sync() alone suffices.
+    bool             invalidate = true;
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+    ggml_xdna_gdn_shape gdn{};
+    size_t              tile_elems = 0;
+    size_t              b_elems    = 0;
+    bool                verify     = false;
+    float               verify_atol = 1e-5f;
+    float               verify_rtol = 1e-5f;
+#endif
+
+    ggml_xdna_npu_stats stats{};
+    std::mutex          mutex;
+};
+
+static int ggml_xdna_env_int(const char * name, int def) {
+    const char * val = getenv(name);
+    return val ? atoi(val) : def;
+}
+
+static uint64_t ggml_xdna_now_ns(void) {
+    using clock = std::chrono::steady_clock;
+    return (uint64_t) std::chrono::duration_cast<std::chrono::nanoseconds>(
+        clock::now().time_since_epoch()).count();
+}
+
+static void ggml_xdna_invalidate(const void * addr, size_t bytes) {
+#if defined(__x86_64__) || defined(__i386__)
+    const char * end = (const char *) addr + bytes;
+    const char * p   = (const char *) ((uintptr_t) addr & ~(uintptr_t) 63);
+
+    _mm_mfence();
+    for (; p < end; p += 64) {
+        _mm_clflush(p);
+    }
+    _mm_mfence();
+#else
+    GGML_UNUSED(addr);
+    GGML_UNUSED(bytes);
+#endif
+}
+
+static bool ggml_xdna_read_instr(const char * path, std::vector<uint32_t> & out) {
+    std::ifstream f(path, std::ios::binary | std::ios::ate);
+    if (!f) {
+        return false;
+    }
+
+    const std::streamsize size = f.tellg();
+    if (size <= 0 || (size % sizeof(uint32_t)) != 0) {
+        return false;
+    }
+
+    out.resize((size_t) size / sizeof(uint32_t));
+    f.seekg(0);
+    return (bool) f.read((char *) out.data(), size);
+}
+
+bool ggml_xdna_npu_probe(char * name, size_t name_size) {
+    ggml_xdna_device & dev = ggml_xdna_shared_device();
+    if (name && name_size > 0) {
+        snprintf(name, name_size, "%s", dev.ok ? dev.name.c_str() : "none");
+    }
+    return dev.ok;
+}
+
+
+void ggml_xdna_npu_free(ggml_xdna_npu * npu) {
+    if (npu) {
+        delete npu->runlist;
+        npu->runlist = nullptr;
+    }
+    delete npu;
+}
+
+void ggml_xdna_npu_get_stats(const ggml_xdna_npu * npu, ggml_xdna_npu_stats * stats) {
+    if (!stats) {
+        return;
+    }
+    *stats = npu ? npu->stats : ggml_xdna_npu_stats{};
+}
+
+
+// ** GEMM **
+
+struct ggml_xdna_buf {
+    xrt::bo bo;
+};
+
+static size_t gemm_a_bytes(const ggml_xdna_gemm_shape & s) {
+    return (size_t) s.grid_r * s.mb * s.kt * s.tile_m * s.tile_k * sizeof(uint16_t);
+}
+
+static size_t gemm_b_bytes(const ggml_xdna_gemm_shape & s) {
+    // One column block per submit (nb is always 1 in the artifact).
+    return (size_t) s.grid_c * s.nb * s.kt * s.tile_k * s.tile_n * sizeof(uint16_t);
+}
+
+static size_t gemm_c_bytes(const ggml_xdna_gemm_shape & s) {
+    return (size_t) s.grid_c * s.mb * s.grid_r * s.tile_m * s.tile_n * sizeof(float);
+}
+
+int ggml_xdna_npu_gemm_m(const ggml_xdna_npu * npu) {
+    return npu ? npu->shape.mb * npu->shape.grid_r * npu->shape.tile_m : 0;
+}
+
+int ggml_xdna_npu_gemm_k(const ggml_xdna_npu * npu) {
+    return npu ? npu->shape.kt * npu->shape.tile_k : 0;
+}
+
+int ggml_xdna_npu_gemm_n(const ggml_xdna_npu * npu) {
+    return npu ? npu->shape.nb * npu->shape.grid_c * npu->shape.tile_n : 0;
+}
+
+size_t ggml_xdna_npu_gemm_a_bytes(const ggml_xdna_npu * npu) {
+    return npu ? gemm_a_bytes(npu->shape) : 0;
+}
+
+size_t ggml_xdna_npu_gemm_b_bytes(const ggml_xdna_npu * npu) {
+    return npu ? gemm_b_bytes(npu->shape) : 0;
+}
+
+size_t ggml_xdna_npu_gemm_c_bytes(const ggml_xdna_npu * npu) {
+    return npu ? gemm_c_bytes(npu->shape) : 0;
+}
+
+ggml_xdna_npu * ggml_xdna_npu_gemm_init(const char *                        xclbin_path,
+                                        const char *                        insts_path,
+                                        const struct ggml_xdna_gemm_shape * shape) {
+    if (!xclbin_path || !insts_path || !shape) {
+        return nullptr;
+    }
+    if (shape->tile_m <= 0 || shape->tile_k <= 0 || shape->tile_n <= 0 ||
+        shape->grid_r <= 0 || shape->grid_c <= 0 || shape->kt <= 0 ||
+        shape->nb <= 0 || shape->mb <= 0) {
+        return nullptr;
+    }
+
+    ggml_xdna_device & dev = ggml_xdna_shared_device();
+    if (!dev.ok) {
+        return nullptr;
+    }
+
+    std::vector<uint32_t> instr;
+    if (!ggml_xdna_read_instr(insts_path, instr)) {
+        GGML_LOG_WARN("%s: failed to read instruction stream %s\n", __func__, insts_path);
+        return nullptr;
+    }
+
+    try {
+        std::unique_ptr<ggml_xdna_npu> npu(new ggml_xdna_npu);
+
+        npu->op    = GGML_XDNA_OP_GEMM;
+        npu->shape = *shape;
+
+        xrt::xclbin xclbin_obj{std::string(xclbin_path)};
+        dev.device.register_xclbin(xclbin_obj);
+        npu->context = xrt::hw_context(dev.device, xclbin_obj.get_uuid());
+        npu->kernel  = xrt::kernel(npu->context, XDNA_KERNEL_NAME);
+
+        const size_t instr_bytes = instr.size() * sizeof(uint32_t);
+        const size_t a_bytes     = gemm_a_bytes(*shape);
+        const size_t b_bytes     = gemm_b_bytes(*shape);
+        const size_t c_bytes     = gemm_c_bytes(*shape);
+
+        // Room for every K-slice of one row block, so the host packs A once and
+        // the K-loop is just a submit per slice with no data movement.
+        npu->kb_max = std::max(1, ggml_xdna_env_int("GGML_XDNA_GEMM_KB_MAX", 16));
+        // Production: one B buffer, every K-slice view aliases offset 0 (weights
+        // come from ggml_xdna_buf, not this BO). Experimental act-x-act packs
+        // a distinct B slice per K-block.
+#if defined(GGML_XDNA_EXPERIMENTAL)
+        const size_t b_alloc_bytes = b_bytes * (size_t) npu->kb_max;
+        const bool   b_per_slice   = true;
+#else
+        const size_t b_alloc_bytes = b_bytes;
+        const bool   b_per_slice   = false;
+#endif
+        // Second A/C bank lets the host pack the next M-block while the NPU
+        // runs the current one. Disable with GGML_XDNA_GEMM_BANKS=1.
+        npu->n_banks = std::max(1, std::min(2, ggml_xdna_env_int("GGML_XDNA_GEMM_BANKS", 2)));
+        npu->bank = 0;
+
+        npu->bo_instr = xrt::bo(dev.device, instr_bytes, XCL_BO_FLAGS_CACHEABLE, npu->kernel.group_id(1));
+        npu->bo_a     = xrt::bo(dev.device, a_bytes * npu->kb_max, XRT_BO_FLAGS_HOST_ONLY, npu->kernel.group_id(XDNA_ARG_DATA0 + 0));
+        npu->bo_b     = xrt::bo(dev.device, b_alloc_bytes, XRT_BO_FLAGS_HOST_ONLY, npu->kernel.group_id(XDNA_ARG_DATA0 + 1));
+        npu->bo_c     = xrt::bo(dev.device, c_bytes * npu->kb_max, XRT_BO_FLAGS_HOST_ONLY, npu->kernel.group_id(XDNA_ARG_DATA0 + 2));
+
+        for (int kb = 0; kb < npu->kb_max; kb++) {
+            npu->a_views.emplace_back(npu->bo_a, a_bytes, a_bytes * (size_t) kb);
+            npu->b_views.emplace_back(npu->bo_b, b_bytes, b_per_slice ? b_bytes * (size_t) kb : 0);
+            npu->c_views.emplace_back(npu->bo_c, c_bytes, c_bytes * (size_t) kb);
+        }
+        if (npu->n_banks > 1) {
+            npu->bo_a1 = xrt::bo(dev.device, a_bytes * npu->kb_max, XRT_BO_FLAGS_HOST_ONLY,
+                                 npu->kernel.group_id(XDNA_ARG_DATA0 + 0));
+            npu->bo_c1 = xrt::bo(dev.device, c_bytes * npu->kb_max, XRT_BO_FLAGS_HOST_ONLY,
+                                 npu->kernel.group_id(XDNA_ARG_DATA0 + 2));
+            for (int kb = 0; kb < npu->kb_max; kb++) {
+                npu->a_views1.emplace_back(npu->bo_a1, a_bytes, a_bytes * (size_t) kb);
+                npu->c_views1.emplace_back(npu->bo_c1, c_bytes, c_bytes * (size_t) kb);
+            }
+            memset(npu->bo_a1.map<void *>(), 0, a_bytes * npu->kb_max);
+            memset(npu->bo_c1.map<void *>(), 0, c_bytes * npu->kb_max);
+            npu->bo_a1.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        }
+
+        memcpy(npu->bo_instr.map<void *>(), instr.data(), instr_bytes);
+        npu->bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+        memset(npu->bo_a.map<void *>(), 0, a_bytes * npu->kb_max);
+        memset(npu->bo_b.map<void *>(), 0, b_alloc_bytes);
+        memset(npu->bo_c.map<void *>(), 0, c_bytes * npu->kb_max);
+        npu->bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        npu->bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+        npu->n_instr    = (uint32_t) instr.size();
+        npu->invalidate = ggml_xdna_env_int("GGML_XDNA_CLFLUSH", 1) != 0;
+
+        npu->run = xrt::run(npu->kernel);
+        npu->run.set_arg(0, XDNA_OPCODE_TXN);
+        npu->run.set_arg(1, npu->bo_instr);
+        npu->run.set_arg(2, npu->n_instr);
+        npu->run.set_arg(XDNA_ARG_DATA0 + 0, npu->a_views[0]);
+        npu->run.set_arg(XDNA_ARG_DATA0 + 1, npu->bo_b);
+        npu->run.set_arg(XDNA_ARG_DATA0 + 2, npu->c_views[0]);
+
+        npu->runs.clear();
+        npu->runs.reserve(npu->kb_max);
+        for (int kb = 0; kb < npu->kb_max; kb++) {
+            xrt::run r(npu->kernel);
+            r.set_arg(0, XDNA_OPCODE_TXN);
+            r.set_arg(1, npu->bo_instr);
+            r.set_arg(2, npu->n_instr);
+            r.set_arg(XDNA_ARG_DATA0 + 0, npu->a_views[kb]);
+            r.set_arg(XDNA_ARG_DATA0 + 1, npu->b_views[kb]);
+            r.set_arg(XDNA_ARG_DATA0 + 2, npu->c_views[kb]);
+            npu->runs.push_back(std::move(r));
+        }
+        npu->runlist = new xrt::runlist(npu->context);
+
+        // while_true workers need the ObjectFifo pipeline primed; zeroed
+        // operands are enough for that.
+        const int n_warmup = ggml_xdna_env_int("GGML_XDNA_WARMUP", 4);
+        for (int i = 0; i < n_warmup; ++i) {
+            npu->run.start();
+            if (npu->run.wait() != ERT_CMD_STATE_COMPLETED) {
+                GGML_LOG_WARN("%s: NPU gemm warm-up run %d did not complete\n", "ggml-xdna", i);
+                break;
+            }
+            npu->bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+        }
+
+        GGML_LOG_INFO("%s: NPU gemm ready: %s, C[%d,%d] = A[%d,%d] @ B, grid %dx%d, "
+                      "%.2f MiB per submit, instr=%u words\n",
+                      "ggml-xdna", dev.name.c_str(),
+                      ggml_xdna_npu_gemm_m(npu.get()), ggml_xdna_npu_gemm_n(npu.get()),
+                      ggml_xdna_npu_gemm_m(npu.get()), ggml_xdna_npu_gemm_k(npu.get()),
+                      shape->grid_r, shape->grid_c,
+                      (double) (a_bytes + b_bytes + c_bytes) / (1024.0 * 1024.0),
+                      npu->n_instr);
+
+        return npu.release();
+    } catch (const std::exception & e) {
+        GGML_LOG_WARN("%s: NPU gemm init failed: %s\n", "ggml-xdna", e.what());
+    } catch (...) {
+        GGML_LOG_WARN("%s: NPU gemm init failed (unknown error)\n", "ggml-xdna");
+    }
+
+    return nullptr;
+}
+
+ggml_xdna_buf * ggml_xdna_buf_alloc(ggml_xdna_npu * npu, size_t nbytes) {
+    if (!npu || nbytes == 0) {
+        return nullptr;
+    }
+
+    ggml_xdna_device & dev = ggml_xdna_shared_device();
+    if (!dev.ok) {
+        return nullptr;
+    }
+
+    try {
+        std::unique_ptr<ggml_xdna_buf> buf(new ggml_xdna_buf);
+        buf->bo = xrt::bo(dev.device, nbytes, XRT_BO_FLAGS_HOST_ONLY,
+                          npu->kernel.group_id(XDNA_ARG_DATA0 + 1));
+        memset(buf->bo.map<void *>(), 0, nbytes);
+        return buf.release();
+    } catch (const std::exception & e) {
+        GGML_LOG_WARN("%s: weight buffer of %zu bytes failed: %s\n", "ggml-xdna", nbytes, e.what());
+    } catch (...) {
+        GGML_LOG_WARN("%s: weight buffer of %zu bytes failed\n", "ggml-xdna", nbytes);
+    }
+
+    return nullptr;
+}
+
+void ggml_xdna_buf_free(ggml_xdna_buf * buf) {
+    delete buf;
+}
+
+void * ggml_xdna_buf_host(ggml_xdna_buf * buf) {
+    return buf ? buf->bo.map<void *>() : nullptr;
+}
+
+void ggml_xdna_buf_sync_to_device(ggml_xdna_buf * buf, size_t offset, size_t nbytes) {
+    if (buf && nbytes) {
+        buf->bo.sync(XCL_BO_SYNC_BO_TO_DEVICE, nbytes, offset);
+    }
+}
+
+int ggml_xdna_npu_gemm_kb_max(const ggml_xdna_npu * npu) {
+    return npu ? npu->kb_max : 0;
+}
+
+int ggml_xdna_npu_gemm_n_banks(const ggml_xdna_npu * npu) {
+    return npu ? npu->n_banks : 0;
+}
+
+void ggml_xdna_npu_gemm_set_bank(ggml_xdna_npu * npu, int bank) {
+    if (npu && bank >= 0 && bank < npu->n_banks) {
+        npu->bank = bank;
+    }
+}
+
+static xrt::bo & ggml_xdna_gemm_a_bo(ggml_xdna_npu * npu, int bank) {
+    return (bank == 1 && npu->n_banks > 1) ? npu->bo_a1 : npu->bo_a;
+}
+
+static xrt::bo & ggml_xdna_gemm_c_bo(ggml_xdna_npu * npu, int bank) {
+    return (bank == 1 && npu->n_banks > 1) ? npu->bo_c1 : npu->bo_c;
+}
+
+static std::vector<xrt::bo> & ggml_xdna_gemm_a_views(ggml_xdna_npu * npu, int bank) {
+    return (bank == 1 && npu->n_banks > 1) ? npu->a_views1 : npu->a_views;
+}
+
+static std::vector<xrt::bo> & ggml_xdna_gemm_c_views(ggml_xdna_npu * npu, int bank) {
+    return (bank == 1 && npu->n_banks > 1) ? npu->c_views1 : npu->c_views;
+}
+
+uint16_t * ggml_xdna_npu_gemm_a_slice_bank(ggml_xdna_npu * npu, int bank, int k_block) {
+    if (!npu || k_block < 0 || k_block >= npu->kb_max || bank < 0 || bank >= npu->n_banks) {
+        return nullptr;
+    }
+    return (uint16_t *) (ggml_xdna_gemm_a_bo(npu, bank).map<char *>() +
+                         gemm_a_bytes(npu->shape) * (size_t) k_block);
+}
+
+const float * ggml_xdna_npu_gemm_c_slice_bank(ggml_xdna_npu * npu, int bank, int k_block) {
+    if (!npu || k_block < 0 || k_block >= npu->kb_max || bank < 0 || bank >= npu->n_banks) {
+        return nullptr;
+    }
+    return (const float *) (ggml_xdna_gemm_c_bo(npu, bank).map<char *>() +
+                            gemm_c_bytes(npu->shape) * (size_t) k_block);
+}
+
+uint16_t * ggml_xdna_npu_gemm_a_slice(ggml_xdna_npu * npu, int k_block) {
+    return npu ? ggml_xdna_npu_gemm_a_slice_bank(npu, npu->bank, k_block) : nullptr;
+}
+
+const float * ggml_xdna_npu_gemm_c_slice(ggml_xdna_npu * npu, int k_block) {
+    return npu ? ggml_xdna_npu_gemm_c_slice_bank(npu, npu->bank, k_block) : nullptr;
+}
+
+void ggml_xdna_npu_gemm_acquire(ggml_xdna_npu * npu) {
+    if (npu) {
+        npu->mutex.lock();
+    }
+}
+
+void ggml_xdna_npu_gemm_release(ggml_xdna_npu * npu) {
+    if (npu) {
+        npu->mutex.unlock();
+    }
+}
+
+static bool ggml_xdna_npu_gemm_submit(ggml_xdna_npu * npu,
+                                      ggml_xdna_buf * buf,
+                                      size_t          w_off,
+                                      int             k_block) {
+    if (!npu || !buf || k_block < 0 || k_block >= npu->kb_max) {
+        return false;
+    }
+
+    const size_t b_bytes = gemm_b_bytes(npu->shape);
+    const size_t c_bytes = gemm_c_bytes(npu->shape);
+    const int bank = npu->bank;
+    auto & a_views = ggml_xdna_gemm_a_views(npu, bank);
+    auto & c_views = ggml_xdna_gemm_c_views(npu, bank);
+
+    const uint64_t t_begin = ggml_xdna_now_ns();
+
+    try {
+        char key[64];
+        snprintf(key, sizeof(key), "%p+%zu", (const void *) buf, w_off);
+
+        auto it = npu->w_views.find(key);
+        if (it == npu->w_views.end()) {
+            it = npu->w_views.emplace(key, xrt::bo(buf->bo, b_bytes, w_off)).first;
+        }
+
+        npu->run.set_arg(XDNA_ARG_DATA0 + 0, a_views[k_block]);
+        npu->run.set_arg(XDNA_ARG_DATA0 + 1, it->second);
+        npu->run.set_arg(XDNA_ARG_DATA0 + 2, c_views[k_block]);
+
+        a_views[k_block].sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+        const uint64_t t_submit = ggml_xdna_now_ns();
+        npu->run.start();
+        const ert_cmd_state state = npu->run.wait();
+        npu->stats.ns_submit += ggml_xdna_now_ns() - t_submit;
+        npu->stats.n_runs++;
+
+        if (state != ERT_CMD_STATE_COMPLETED) {
+            GGML_LOG_ERROR("%s: NPU gemm run did not complete\n", "ggml-xdna");
+            return false;
+        }
+
+        c_views[k_block].sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+        if (npu->invalidate) {
+            ggml_xdna_invalidate(ggml_xdna_gemm_c_bo(npu, bank).map<char *>() +
+                                 c_bytes * (size_t) k_block, c_bytes);
+        }
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: NPU gemm failed: %s\n", "ggml-xdna", e.what());
+        return false;
+    }
+
+    npu->stats.ns_total += ggml_xdna_now_ns() - t_begin;
+    npu->stats.n_calls++;
+
+    return true;
+}
+
+bool ggml_xdna_npu_gemm_submit_list_async(ggml_xdna_npu * npu,
+                                          ggml_xdna_buf * buf,
+                                          const size_t *  w_offs,
+                                          int             kb_n) {
+    if (!npu || !buf || !w_offs || kb_n < 1 || kb_n > npu->kb_max) {
+        return false;
+    }
+    if (npu->pending_async) {
+        if (!ggml_xdna_npu_gemm_runlist_wait(npu)) {
+            return false;
+        }
+    }
+    if (kb_n == 1 || !npu->runlist || (int) npu->runs.size() < kb_n) {
+        // Single-slice path is still synchronous.
+        const bool ok = ggml_xdna_npu_gemm_submit(npu, buf, w_offs[0], 0);
+        return ok;
+    }
+
+    const size_t b_bytes = gemm_b_bytes(npu->shape);
+    const size_t c_bytes = gemm_c_bytes(npu->shape);
+    const int bank = npu->bank;
+    auto & a_views = ggml_xdna_gemm_a_views(npu, bank);
+    auto & c_views = ggml_xdna_gemm_c_views(npu, bank);
+    const uint64_t t_begin = ggml_xdna_now_ns();
+
+    try {
+        npu->runlist->reset();
+        for (int kb = 0; kb < kb_n; kb++) {
+            char key[64];
+            snprintf(key, sizeof(key), "%p+%zu", (const void *) buf, w_offs[kb]);
+            auto it = npu->w_views.find(key);
+            if (it == npu->w_views.end()) {
+                it = npu->w_views.emplace(key, xrt::bo(buf->bo, b_bytes, w_offs[kb])).first;
+            }
+            npu->runs[kb].set_arg(XDNA_ARG_DATA0 + 0, a_views[kb]);
+            npu->runs[kb].set_arg(XDNA_ARG_DATA0 + 1, it->second);
+            npu->runs[kb].set_arg(XDNA_ARG_DATA0 + 2, c_views[kb]);
+            a_views[kb].sync(XCL_BO_SYNC_BO_TO_DEVICE);
+            npu->runlist->add(npu->runs[kb]);
+        }
+
+        const uint64_t t_submit = ggml_xdna_now_ns();
+        npu->runlist->execute();
+        // Wait time is attributed in runlist_wait; execute() itself is cheap.
+        npu->stats.n_runs += (uint64_t) kb_n;
+        npu->pending_kb_n = kb_n;
+        npu->pending_c_bytes = c_bytes;
+        npu->pending_bank = bank;
+        npu->pending_async = true;
+        npu->stats.ns_total += ggml_xdna_now_ns() - t_begin;
+        npu->stats.n_calls++;
+        GGML_UNUSED(t_submit);
+        return true;
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: NPU gemm runlist async failed: %s\n", "ggml-xdna", e.what());
+        return false;
+    }
+}
+
+bool ggml_xdna_npu_gemm_runlist_wait(ggml_xdna_npu * npu) {
+    if (!npu || !npu->pending_async) {
+        return true;
+    }
+    const uint64_t t0 = ggml_xdna_now_ns();
+    try {
+        npu->runlist->wait();
+        const uint64_t t_waited = ggml_xdna_now_ns();
+        npu->stats.ns_submit += t_waited - t0;
+        auto & c_views = ggml_xdna_gemm_c_views(npu, npu->pending_bank);
+        auto & c_bo = ggml_xdna_gemm_c_bo(npu, npu->pending_bank);
+        for (int kb = 0; kb < npu->pending_kb_n; kb++) {
+            c_views[kb].sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+            if (npu->invalidate) {
+                ggml_xdna_invalidate(c_bo.map<char *>() +
+                                     npu->pending_c_bytes * (size_t) kb,
+                                     npu->pending_c_bytes);
+            }
+        }
+        const uint64_t t_end = ggml_xdna_now_ns();
+        npu->stats.ns_sync  += t_end - t_waited;
+        npu->stats.ns_total += t_end - t0;
+        npu->pending_async = false;
+        npu->pending_kb_n = 0;
+        return true;
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: NPU gemm runlist wait failed: %s\n", "ggml-xdna", e.what());
+        npu->pending_async = false;
+        return false;
+    }
+}
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+static float ggml_xdna_env_float(const char * name, float def) {
+    const char * val = getenv(name);
+    return val ? (float) atof(val) : def;
+}
+
+static float ggml_xdna_apply(ggml_xdna_op op, float a, float b) {
+    return op == GGML_XDNA_OP_MUL ? a * b : a + b;
+}
+
+ggml_xdna_npu * ggml_xdna_npu_init(enum ggml_xdna_op op,
+                                   const char *      xclbin_path,
+                                   const char *      insts_path,
+                                   size_t            tile_elems) {
+    if (!xclbin_path || !insts_path || tile_elems == 0) {
+        return nullptr;
+    }
+
+    ggml_xdna_device & dev = ggml_xdna_shared_device();
+    if (!dev.ok) {
+        return nullptr;
+    }
+
+    const size_t b_elems    = (op == GGML_XDNA_OP_RMS_NORM) ? 1 : tile_elems;
+    const size_t data_bytes = tile_elems * sizeof(float);
+    const size_t b_bytes    = b_elems * sizeof(float);
+    const bool   is_fused   = op == GGML_XDNA_OP_ADD_RMS_MUL;
+    const size_t ab_bytes   = is_fused ? (2 * tile_elems + 1) * sizeof(float) : 0;
+    const size_t out_bytes  = is_fused ? 2 * data_bytes : data_bytes;
+
+    std::vector<uint32_t> instr;
+    if (!ggml_xdna_read_instr(insts_path, instr)) {
+        GGML_LOG_WARN("%s: failed to read instruction stream %s\n", __func__, insts_path);
+        return nullptr;
+    }
+
+    try {
+        // RAII: the unique_ptr frees the partially constructed NPU (and its
+        // XRT resources) if any step below throws. Ownership is released to
+        // the caller only on the success path.
+        std::unique_ptr<ggml_xdna_npu> npu(new ggml_xdna_npu);
+
+        npu->op = op;
+
+        xrt::xclbin xclbin_obj{std::string(xclbin_path)};
+        dev.device.register_xclbin(xclbin_obj);
+        npu->context = xrt::hw_context(dev.device, xclbin_obj.get_uuid());
+        npu->kernel  = xrt::kernel(npu->context, XDNA_KERNEL_NAME);
+
+        const size_t instr_bytes = instr.size() * sizeof(uint32_t);
+
+        npu->bo_instr = xrt::bo(dev.device, instr_bytes, XCL_BO_FLAGS_CACHEABLE, npu->kernel.group_id(1));
+        if (is_fused) {
+            npu->bo_a = xrt::bo(dev.device, ab_bytes,   XRT_BO_FLAGS_HOST_ONLY, npu->kernel.group_id(XDNA_ARG_DATA0 + 0));
+            npu->bo_b = xrt::bo(dev.device, data_bytes, XRT_BO_FLAGS_HOST_ONLY, npu->kernel.group_id(XDNA_ARG_DATA0 + 1));
+            npu->bo_c = xrt::bo(dev.device, out_bytes,  XRT_BO_FLAGS_HOST_ONLY, npu->kernel.group_id(XDNA_ARG_DATA0 + 2));
+        } else {
+            npu->bo_a = xrt::bo(dev.device, data_bytes, XRT_BO_FLAGS_HOST_ONLY, npu->kernel.group_id(XDNA_ARG_DATA0 + 0));
+            npu->bo_b = xrt::bo(dev.device, b_bytes,    XRT_BO_FLAGS_HOST_ONLY, npu->kernel.group_id(XDNA_ARG_DATA0 + 1));
+            npu->bo_c = xrt::bo(dev.device, data_bytes, XRT_BO_FLAGS_HOST_ONLY, npu->kernel.group_id(XDNA_ARG_DATA0 + 2));
+        }
+
+        memcpy(npu->bo_instr.map<void *>(), instr.data(), instr_bytes);
+        npu->bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+        memset(npu->bo_a.map<void *>(), 0, is_fused ? ab_bytes : data_bytes);
+        if (!is_fused) {
+            memset(npu->bo_b.map<void *>(), 0, b_bytes);
+        } else {
+            memset(npu->bo_b.map<void *>(), 0, data_bytes);
+        }
+        memset(npu->bo_c.map<void *>(), 0, is_fused ? out_bytes : data_bytes);
+
+        npu->n_instr    = (uint32_t) instr.size();
+        npu->tile_elems = tile_elems;
+        npu->b_elems    = b_elems;
+
+        const char * verify_env = getenv("GGML_XDNA_VERIFY");
+        npu->verify      = verify_env && atoi(verify_env) != 0;
+        npu->verify_atol = ggml_xdna_env_float("GGML_XDNA_VERIFY_ATOL", 1e-5f);
+        npu->verify_rtol = ggml_xdna_env_float("GGML_XDNA_VERIFY_RTOL", 1e-5f);
+        npu->invalidate  = ggml_xdna_env_int("GGML_XDNA_CLFLUSH", 1) != 0;
+
+        npu->run = xrt::run(npu->kernel);
+        npu->run.set_arg(0, XDNA_OPCODE_TXN);
+        npu->run.set_arg(1, npu->bo_instr);
+        npu->run.set_arg(2, npu->n_instr);
+        npu->run.set_arg(XDNA_ARG_DATA0 + 0, npu->bo_a);
+        npu->run.set_arg(XDNA_ARG_DATA0 + 1, npu->bo_b);
+        npu->run.set_arg(XDNA_ARG_DATA0 + 2, npu->bo_c);
+
+        // The design keeps its worker alive across submissions (while_true),
+        // so the ObjectFifo pipeline has to be primed.
+        const int n_warmup = ggml_xdna_env_int("GGML_XDNA_WARMUP", 4);
+        if (op == GGML_XDNA_OP_RMS_NORM) {
+            npu->bo_b.map<float *>()[0] = 1.0f;
+        } else if (is_fused) {
+            npu->bo_a.map<float *>()[2 * tile_elems] = 1.0f;
+        }
+        npu->bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        npu->bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        for (int i = 0; i < n_warmup; ++i) {
+            npu->run.start();
+            if (npu->run.wait() != ERT_CMD_STATE_COMPLETED) {
+                GGML_LOG_WARN("%s: NPU %s warm-up run %d did not complete\n",
+                              "ggml-xdna", ggml_xdna_op_name(op), i);
+                break;
+            }
+            npu->bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+        }
+
+        GGML_LOG_INFO("%s: NPU %s ready: %s, kernel=%s, tile=%zu f32, instr=%u words\n",
+                      "ggml-xdna", ggml_xdna_op_name(op), dev.name.c_str(),
+                      XDNA_KERNEL_NAME, tile_elems, npu->n_instr);
+        return npu.release();
+    } catch (const std::exception & e) {
+        GGML_LOG_WARN("%s: NPU %s init failed: %s\n", "ggml-xdna", ggml_xdna_op_name(op), e.what());
+        return nullptr;
+    } catch (...) {
+        GGML_LOG_WARN("%s: NPU %s init failed (unknown error)\n", "ggml-xdna", ggml_xdna_op_name(op));
+        return nullptr;
+    }
+}
+
+bool ggml_xdna_npu_binary_f32(ggml_xdna_npu * npu, const float * a, const float * b, float * dst, size_t n) {
+    if (!npu || !a || !b || !dst) {
+        return false;
+    }
+
+    const size_t tile = npu->tile_elems;
+
+    std::lock_guard<std::mutex> lock(npu->mutex);
+
+    float * ha = npu->bo_a.map<float *>();
+    float * hb = npu->bo_b.map<float *>();
+    float * hc = npu->bo_c.map<float *>();
+
+    const uint64_t t_begin = ggml_xdna_now_ns();
+
+    try {
+        for (size_t off = 0; off < n; off += tile) {
+            const size_t cur = std::min(tile, n - off);
+
+            memcpy(ha, a + off, cur * sizeof(float));
+            memcpy(hb, b + off, cur * sizeof(float));
+            if (cur < tile) {
+                memset(ha + cur, 0, (tile - cur) * sizeof(float));
+                memset(hb + cur, 0, (tile - cur) * sizeof(float));
+            }
+
+            npu->bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+            npu->bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+            const uint64_t t_submit = ggml_xdna_now_ns();
+            npu->run.start();
+            const ert_cmd_state state = npu->run.wait();
+            npu->stats.ns_submit += ggml_xdna_now_ns() - t_submit;
+
+            if (state != ERT_CMD_STATE_COMPLETED) {
+                GGML_LOG_ERROR("%s: NPU %s run did not complete\n",
+                               "ggml-xdna", ggml_xdna_op_name(npu->op));
+                return false;
+            }
+
+            npu->bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+            if (npu->invalidate) {
+                ggml_xdna_invalidate(hc, cur * sizeof(float));
+            }
+            memcpy(dst + off, hc, cur * sizeof(float));
+
+            npu->stats.n_runs++;
+
+            if (npu->verify) {
+                size_t n_bad     = 0;
+                size_t first_bad = 0;
+                for (size_t i = 0; i < cur; i++) {
+                    const float want = ggml_xdna_apply(npu->op, ha[i], hb[i]);
+                    // Combined absolute + relative tolerance (atol + rtol*|want|),
+                    // matching ggml's test-backend-ops convention.
+                    const float tol = npu->verify_atol + npu->verify_rtol * std::fabs(want);
+                    if (std::fabs(dst[off + i] - want) > tol) {
+                        if (n_bad == 0) {
+                            first_bad = i;
+                        }
+                        n_bad++;
+                    }
+                }
+                if (n_bad) {
+                    GGML_LOG_ERROR("%s: verify %s: offset %zu: %zu/%zu differ, first %zu (got %.9g, want %.9g)\n",
+                                   "ggml-xdna", ggml_xdna_op_name(npu->op), off, n_bad, cur, first_bad,
+                                   dst[off + first_bad],
+                                   ggml_xdna_apply(npu->op, ha[first_bad], hb[first_bad]));
+                }
+            }
+        }
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: NPU %s failed: %s\n", "ggml-xdna", ggml_xdna_op_name(npu->op), e.what());
+        return false;
+    }
+
+    npu->stats.ns_total += ggml_xdna_now_ns() - t_begin;
+    npu->stats.n_calls++;
+
+    return true;
+}
+
+bool ggml_xdna_npu_rms_norm_f32(ggml_xdna_npu * npu, const float * x, float * dst, int64_t n_rows, float eps) {
+    if (!npu || !x || !dst || n_rows <= 0) {
+        return false;
+    }
+
+    const size_t ne0 = npu->tile_elems;
+
+    std::lock_guard<std::mutex> lock(npu->mutex);
+
+    float * hx = npu->bo_a.map<float *>();
+    float * he = npu->bo_b.map<float *>();
+    float * hy = npu->bo_c.map<float *>();
+
+    const uint64_t t_begin = ggml_xdna_now_ns();
+
+    try {
+        if (he[0] != eps) {
+            he[0] = eps;
+            npu->bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        }
+
+        for (int64_t r = 0; r < n_rows; r++) {
+            const float * row_in  = x   + (size_t) r * ne0;
+            float *       row_out = dst + (size_t) r * ne0;
+
+            memcpy(hx, row_in, ne0 * sizeof(float));
+            npu->bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+            const uint64_t t_submit = ggml_xdna_now_ns();
+            npu->run.start();
+            const ert_cmd_state state = npu->run.wait();
+            npu->stats.ns_submit += ggml_xdna_now_ns() - t_submit;
+
+            if (state != ERT_CMD_STATE_COMPLETED) {
+                GGML_LOG_ERROR("%s: NPU %s run did not complete\n",
+                               "ggml-xdna", ggml_xdna_op_name(npu->op));
+                return false;
+            }
+
+            npu->bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+            if (npu->invalidate) {
+                ggml_xdna_invalidate(hy, ne0 * sizeof(float));
+            }
+            memcpy(row_out, hy, ne0 * sizeof(float));
+
+            npu->stats.n_runs++;
+
+            if (npu->verify) {
+                double sum = 0.0;
+                for (size_t i = 0; i < ne0; i++) {
+                    sum += (double) hx[i] * (double) hx[i];
+                }
+                const float scale = 1.0f / std::sqrt((float) (sum / (double) ne0) + eps);
+
+                size_t n_bad     = 0;
+                size_t first_bad = 0;
+                for (size_t i = 0; i < ne0; i++) {
+                    const float want = hx[i] * scale;
+                    const float tol  = npu->verify_atol + npu->verify_rtol * std::fabs(want);
+                    if (std::fabs(row_out[i] - want) > tol) {
+                        if (n_bad == 0) {
+                            first_bad = i;
+                        }
+                        n_bad++;
+                    }
+                }
+                if (n_bad) {
+                    GGML_LOG_ERROR("%s: verify %s: row %lld: %zu/%zu differ, first %zu (got %.9g, want %.9g)\n",
+                                   "ggml-xdna", ggml_xdna_op_name(npu->op), (long long) r, n_bad, ne0, first_bad,
+                                   row_out[first_bad], hx[first_bad] * scale);
+                }
+            }
+        }
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: NPU %s failed: %s\n", "ggml-xdna", ggml_xdna_op_name(npu->op), e.what());
+        return false;
+    }
+
+    npu->stats.ns_total += ggml_xdna_now_ns() - t_begin;
+    npu->stats.n_calls++;
+
+    return true;
+}
+
+bool ggml_xdna_npu_add_rms_mul_f32(ggml_xdna_npu * npu,
+                                   const float *  a,
+                                   const float *  b,
+                                   const float *  weight,
+                                   float *        add_dst,
+                                   float *        mul_dst,
+                                   int64_t        n_rows,
+                                   int64_t        weight_n_rows,
+                                   float          eps) {
+    if (!npu || !a || !b || !weight || !add_dst || !mul_dst || n_rows <= 0) {
+        return false;
+    }
+
+    const size_t ne0 = npu->tile_elems;
+    const bool   w_broadcast = weight_n_rows <= 1;
+
+    std::lock_guard<std::mutex> lock(npu->mutex);
+
+    float * hab  = npu->bo_a.map<float *>();
+    float * hw   = npu->bo_b.map<float *>();
+    float * hout = npu->bo_c.map<float *>();
+
+    const uint64_t t_begin = ggml_xdna_now_ns();
+
+    try {
+        float cached_eps = std::numeric_limits<float>::quiet_NaN();
+
+        for (int64_t r = 0; r < n_rows; r++) {
+            const float * row_a  = a        + (size_t) r * ne0;
+            const float * row_b  = b        + (size_t) r * ne0;
+            const float * row_w  = w_broadcast ? weight : weight + (size_t) r * ne0;
+            float *       row_add = add_dst + (size_t) r * ne0;
+            float *       row_mul = mul_dst + (size_t) r * ne0;
+
+            memcpy(hab, row_a, ne0 * sizeof(float));
+            memcpy(hab + ne0, row_b, ne0 * sizeof(float));
+            if (cached_eps != eps) {
+                hab[2 * ne0] = eps;
+                cached_eps   = eps;
+            }
+            memcpy(hw, row_w, ne0 * sizeof(float));
+            npu->bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+            npu->bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+            const uint64_t t_submit = ggml_xdna_now_ns();
+            npu->run.start();
+            const ert_cmd_state state = npu->run.wait();
+            npu->stats.ns_submit += ggml_xdna_now_ns() - t_submit;
+
+            if (state != ERT_CMD_STATE_COMPLETED) {
+                GGML_LOG_ERROR("%s: NPU %s run did not complete\n",
+                               "ggml-xdna", ggml_xdna_op_name(npu->op));
+                return false;
+            }
+
+            npu->bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+            if (npu->invalidate) {
+                ggml_xdna_invalidate(hout, 2 * ne0 * sizeof(float));
+            }
+            memcpy(row_add, hout, ne0 * sizeof(float));
+            memcpy(row_mul, hout + ne0, ne0 * sizeof(float));
+
+            npu->stats.n_runs++;
+
+            if (npu->verify) {
+                double sum = 0.0;
+                for (size_t i = 0; i < ne0; i++) {
+                    const float s = row_a[i] + row_b[i];
+                    sum += (double) s * (double) s;
+                }
+                const float scale = 1.0f / std::sqrt((float) (sum / (double) ne0) + eps);
+
+                size_t n_bad_add = 0;
+                size_t n_bad_mul = 0;
+                for (size_t i = 0; i < ne0; i++) {
+                    const float want_add = row_a[i] + row_b[i];
+                    const float want_mul = want_add * scale * row_w[i];
+                    const float tol_add  = npu->verify_atol + npu->verify_rtol * std::fabs(want_add);
+                    const float tol_mul  = npu->verify_atol + npu->verify_rtol * std::fabs(want_mul);
+                    if (std::fabs(row_add[i] - want_add) > tol_add) {
+                        n_bad_add++;
+                    }
+                    if (std::fabs(row_mul[i] - want_mul) > tol_mul) {
+                        n_bad_mul++;
+                    }
+                }
+                if (n_bad_add) {
+                    GGML_LOG_ERROR("%s: verify %s: row %lld add: %zu/%zu differ\n",
+                                   "ggml-xdna", ggml_xdna_op_name(npu->op),
+                                   (long long) r, n_bad_add, ne0);
+                }
+                if (n_bad_mul) {
+                    GGML_LOG_ERROR("%s: verify %s: row %lld mul: %zu/%zu differ\n",
+                                   "ggml-xdna", ggml_xdna_op_name(npu->op),
+                                   (long long) r, n_bad_mul, ne0);
+                }
+            }
+        }
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: NPU %s failed: %s\n", "ggml-xdna", ggml_xdna_op_name(npu->op), e.what());
+        return false;
+    }
+
+    npu->stats.ns_total += ggml_xdna_now_ns() - t_begin;
+    npu->stats.n_calls++;
+
+    return true;
+}
+
+bool ggml_xdna_npu_gemm_submit_ab_list(ggml_xdna_npu * npu, int kb_n) {
+    if (!npu || kb_n < 1 || kb_n > npu->kb_max) {
+        return false;
+    }
+    if (kb_n == 1 || !npu->runlist || (int) npu->runs.size() < kb_n ||
+        (int) npu->b_views.size() < kb_n) {
+        for (int kb = 0; kb < kb_n; kb++) {
+            if (!ggml_xdna_npu_gemm_submit_ab(npu, kb)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    const size_t c_bytes = gemm_c_bytes(npu->shape);
+    const int bank = npu->bank;
+    auto & a_views = ggml_xdna_gemm_a_views(npu, bank);
+    auto & c_views = ggml_xdna_gemm_c_views(npu, bank);
+    const uint64_t t_begin = ggml_xdna_now_ns();
+
+    try {
+        npu->runlist->reset();
+        for (int kb = 0; kb < kb_n; kb++) {
+            npu->runs[kb].set_arg(XDNA_ARG_DATA0 + 0, a_views[kb]);
+            npu->runs[kb].set_arg(XDNA_ARG_DATA0 + 1, npu->b_views[kb]);
+            npu->runs[kb].set_arg(XDNA_ARG_DATA0 + 2, c_views[kb]);
+            a_views[kb].sync(XCL_BO_SYNC_BO_TO_DEVICE);
+            npu->b_views[kb].sync(XCL_BO_SYNC_BO_TO_DEVICE);
+            npu->runlist->add(npu->runs[kb]);
+        }
+        const uint64_t t_submit = ggml_xdna_now_ns();
+        npu->runlist->execute();
+        npu->runlist->wait();
+        const uint64_t t_waited = ggml_xdna_now_ns();
+        npu->stats.ns_submit += t_waited - t_submit;
+        npu->stats.n_runs += (uint64_t) kb_n;
+        for (int kb = 0; kb < kb_n; kb++) {
+            c_views[kb].sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+            if (npu->invalidate) {
+                ggml_xdna_invalidate(ggml_xdna_gemm_c_bo(npu, bank).map<char *>() +
+                                     c_bytes * (size_t) kb, c_bytes);
+            }
+        }
+        npu->stats.ns_sync += ggml_xdna_now_ns() - t_waited;
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: NPU gemm_ab runlist failed: %s\n", "ggml-xdna", e.what());
+        return false;
+    }
+    npu->stats.ns_total += ggml_xdna_now_ns() - t_begin;
+    npu->stats.n_calls++;
+    return true;
+}
+
+uint16_t * ggml_xdna_npu_gemm_b_slice(ggml_xdna_npu * npu, int k_block) {
+    if (!npu || k_block < 0 || k_block >= npu->kb_max ||
+        k_block >= (int) npu->b_views.size()) {
+        return nullptr;
+    }
+    return (uint16_t *) npu->b_views[k_block].map<void *>();
+}
+
+uint16_t * ggml_xdna_npu_gemm_b_host(ggml_xdna_npu * npu) {
+    return ggml_xdna_npu_gemm_b_slice(npu, 0);
+}
+
+bool ggml_xdna_npu_gemm_submit_ab(ggml_xdna_npu * npu, int k_block) {
+    if (!npu || k_block < 0 || k_block >= npu->kb_max ||
+        k_block >= (int) npu->b_views.size()) {
+        return false;
+    }
+
+    const size_t c_bytes = gemm_c_bytes(npu->shape);
+    const uint64_t t_begin = ggml_xdna_now_ns();
+
+    try {
+        npu->run.set_arg(XDNA_ARG_DATA0 + 0, npu->a_views[k_block]);
+        npu->run.set_arg(XDNA_ARG_DATA0 + 1, npu->b_views[k_block]);
+        npu->run.set_arg(XDNA_ARG_DATA0 + 2, npu->c_views[k_block]);
+
+        npu->a_views[k_block].sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        npu->b_views[k_block].sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+        const uint64_t t_submit = ggml_xdna_now_ns();
+        npu->run.start();
+        const ert_cmd_state state = npu->run.wait();
+        npu->stats.ns_submit += ggml_xdna_now_ns() - t_submit;
+        npu->stats.n_runs++;
+
+        if (state != ERT_CMD_STATE_COMPLETED) {
+            GGML_LOG_ERROR("%s: NPU gemm_ab run did not complete\n", "ggml-xdna");
+            return false;
+        }
+
+        npu->c_views[k_block].sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+        if (npu->invalidate) {
+            ggml_xdna_invalidate(npu->bo_c.map<char *>() + c_bytes * (size_t) k_block, c_bytes);
+        }
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: NPU gemm_ab failed: %s\n", "ggml-xdna", e.what());
+        return false;
+    }
+
+    npu->stats.ns_total += ggml_xdna_now_ns() - t_begin;
+    npu->stats.n_calls++;
+
+    return true;
+}
+
+ggml_xdna_npu * ggml_xdna_npu_gdn_init(const char * xclbin_path,
+                                       const char * insts_path,
+                                       const struct ggml_xdna_gdn_shape * shape) {
+    if (!xclbin_path || !insts_path || !shape ||
+        shape->S <= 0 || shape->ROWS <= 0 || shape->CS <= 0) {
+        return nullptr;
+    }
+
+    ggml_xdna_device & dev = ggml_xdna_shared_device();
+    if (!dev.ok) {
+        return nullptr;
+    }
+
+    const int S = shape->S;
+    const int ROWS = shape->ROWS;
+    const int CS = shape->CS;
+    const int workers = shape->workers > 0 ? shape->workers : 1;
+    const size_t tok_elems = (size_t) CS * (size_t) (3 * S + 2);
+    const size_t strip_elems = (size_t) ROWS * (size_t) S;
+    const size_t state_elems = (size_t) workers * strip_elems;
+    const size_t attn_elems = (size_t) CS * (size_t) ROWS * (size_t) workers;
+
+    std::vector<uint32_t> instr;
+    if (!ggml_xdna_read_instr(insts_path, instr)) {
+        GGML_LOG_WARN("%s: failed to read instruction stream %s\n", __func__, insts_path);
+        return nullptr;
+    }
+
+    try {
+        std::unique_ptr<ggml_xdna_npu> npu(new ggml_xdna_npu);
+        npu->op = GGML_XDNA_OP_GDN;
+        npu->gdn = *shape;
+        if (npu->gdn.workers <= 0) {
+            npu->gdn.workers = workers;
+        }
+
+        xrt::xclbin xclbin_obj{std::string(xclbin_path)};
+        dev.device.register_xclbin(xclbin_obj);
+        npu->context = xrt::hw_context(dev.device, xclbin_obj.get_uuid());
+        npu->kernel  = xrt::kernel(npu->context, XDNA_KERNEL_NAME);
+
+        const size_t instr_bytes = instr.size() * sizeof(uint32_t);
+        const size_t tok_bytes = tok_elems * sizeof(float);
+        const size_t strip_bytes = state_elems * sizeof(float);
+        const size_t out_bytes = attn_elems * sizeof(float);
+
+        npu->bo_instr = xrt::bo(dev.device, instr_bytes, XCL_BO_FLAGS_CACHEABLE, npu->kernel.group_id(1));
+        npu->bo_a = xrt::bo(dev.device, tok_bytes, XRT_BO_FLAGS_HOST_ONLY, npu->kernel.group_id(XDNA_ARG_DATA0 + 0));
+        npu->bo_b = xrt::bo(dev.device, strip_bytes, XRT_BO_FLAGS_HOST_ONLY, npu->kernel.group_id(XDNA_ARG_DATA0 + 1));
+        npu->bo_c = xrt::bo(dev.device, out_bytes, XRT_BO_FLAGS_HOST_ONLY, npu->kernel.group_id(XDNA_ARG_DATA0 + 2));
+
+        memcpy(npu->bo_instr.map<void *>(), instr.data(), instr_bytes);
+        npu->bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        memset(npu->bo_a.map<void *>(), 0, tok_bytes);
+        memset(npu->bo_b.map<void *>(), 0, strip_bytes);
+        memset(npu->bo_c.map<void *>(), 0, out_bytes);
+
+        npu->n_instr = (uint32_t) instr.size();
+        npu->tile_elems = strip_elems;
+        npu->invalidate = ggml_xdna_env_int("GGML_XDNA_CLFLUSH", 1) != 0;
+
+        npu->run = xrt::run(npu->kernel);
+        npu->run.set_arg(0, XDNA_OPCODE_TXN);
+        npu->run.set_arg(1, npu->bo_instr);
+        npu->run.set_arg(2, npu->n_instr);
+        npu->run.set_arg(XDNA_ARG_DATA0 + 0, npu->bo_a);
+        npu->run.set_arg(XDNA_ARG_DATA0 + 1, npu->bo_b);
+        npu->run.set_arg(XDNA_ARG_DATA0 + 2, npu->bo_c);
+
+        const int n_warmup = ggml_xdna_env_int("GGML_XDNA_WARMUP", 2);
+        npu->bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        npu->bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        for (int i = 0; i < n_warmup; ++i) {
+            npu->run.start();
+            if (npu->run.wait() != ERT_CMD_STATE_COMPLETED) {
+                GGML_LOG_WARN("%s: NPU gdn warm-up run %d did not complete\n", "ggml-xdna", i);
+                break;
+            }
+            npu->bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+        }
+
+        GGML_LOG_INFO("%s: NPU gdn ready: %s, S=%d ROWS=%d CS=%d workers=%d, instr=%u words\n",
+                      "ggml-xdna", dev.name.c_str(), S, ROWS, CS, npu->gdn.workers, npu->n_instr);
+        return npu.release();
+    } catch (const std::exception & e) {
+        GGML_LOG_WARN("%s: NPU gdn init failed: %s\n", "ggml-xdna", e.what());
+        return nullptr;
+    } catch (...) {
+        GGML_LOG_WARN("%s: NPU gdn init failed (unknown error)\n", "ggml-xdna");
+        return nullptr;
+    }
+}
+
+bool ggml_xdna_npu_gdn_submit(ggml_xdna_npu * npu,
+                              const float *   tok,
+                              const float *   state_strip,
+                              float *         attn_strip,
+                              float *         new_state_strip) {
+    if (!npu || npu->op != GGML_XDNA_OP_GDN || !tok || !state_strip ||
+        !attn_strip || !new_state_strip) {
+        return false;
+    }
+    if (npu->gdn.workers > 1) {
+        return false;
+    }
+
+    const int S = npu->gdn.S;
+    const int ROWS = npu->gdn.ROWS;
+    const int CS = npu->gdn.CS;
+    const size_t tok_elems = (size_t) CS * (size_t) (3 * S + 2);
+    const size_t strip_elems = (size_t) ROWS * (size_t) S;
+    const size_t attn_elems = (size_t) CS * (size_t) ROWS;
+
+    std::lock_guard<std::mutex> lock(npu->mutex);
+    const uint64_t t_begin = ggml_xdna_now_ns();
+
+    try {
+        float * ha = npu->bo_a.map<float *>();
+        float * hb = npu->bo_b.map<float *>();
+        float * hc = npu->bo_c.map<float *>();
+
+        memcpy(ha, tok, tok_elems * sizeof(float));
+        memcpy(hb, state_strip, strip_elems * sizeof(float));
+
+        npu->bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        npu->bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+        const uint64_t t_submit = ggml_xdna_now_ns();
+        npu->run.start();
+        const ert_cmd_state state = npu->run.wait();
+        npu->stats.ns_submit += ggml_xdna_now_ns() - t_submit;
+        npu->stats.n_runs++;
+
+        if (state != ERT_CMD_STATE_COMPLETED) {
+            GGML_LOG_ERROR("%s: NPU gdn run did not complete\n", "ggml-xdna");
+            return false;
+        }
+
+        npu->bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+        npu->bo_b.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+        if (npu->invalidate) {
+            ggml_xdna_invalidate(hc, attn_elems * sizeof(float));
+            ggml_xdna_invalidate(hb, strip_elems * sizeof(float));
+        }
+
+        memcpy(attn_strip, hc, attn_elems * sizeof(float));
+        memcpy(new_state_strip, hb, strip_elems * sizeof(float));
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: NPU gdn failed: %s\n", "ggml-xdna", e.what());
+        return false;
+    }
+
+    npu->stats.ns_total += ggml_xdna_now_ns() - t_begin;
+    npu->stats.n_calls++;
+    return true;
+}
+
+bool ggml_xdna_npu_gdn_submit_full(ggml_xdna_npu * npu,
+                                   const float *   tok,
+                                   const float *   state,
+                                   float *         attn,
+                                   float *         new_state) {
+    return ggml_xdna_npu_gdn_submit_full_chunks(npu, tok, 1, state, attn, new_state);
+}
+
+bool ggml_xdna_npu_gdn_submit_full_chunks(ggml_xdna_npu * npu,
+                                          const float *   tok_chunks,
+                                          int             n_chunks,
+                                          const float *   state,
+                                          float *         attn_chunks,
+                                          float *         new_state) {
+    if (!npu || npu->op != GGML_XDNA_OP_GDN || !tok_chunks || n_chunks < 1 ||
+        !state || !attn_chunks || !new_state) {
+        return false;
+    }
+
+    const int S = npu->gdn.S;
+    const int ROWS = npu->gdn.ROWS;
+    const int CS = npu->gdn.CS;
+    const int workers = npu->gdn.workers > 0 ? npu->gdn.workers : 1;
+    if (workers <= 1) {
+        return false;
+    }
+    const size_t tok_elems = (size_t) CS * (size_t) (3 * S + 2);
+    const size_t strip_elems = (size_t) ROWS * (size_t) S;
+    const size_t state_elems = (size_t) workers * strip_elems;
+    const size_t attn_elems = (size_t) CS * (size_t) ROWS * (size_t) workers;
+
+    std::lock_guard<std::mutex> lock(npu->mutex);
+    const uint64_t t_begin = ggml_xdna_now_ns();
+
+    try {
+        float * ha = npu->bo_a.map<float *>();
+        float * hb = npu->bo_b.map<float *>();
+        float * hc = npu->bo_c.map<float *>();
+
+        memcpy(hb, state, state_elems * sizeof(float));
+        npu->bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+        for (int chunk = 0; chunk < n_chunks; chunk++) {
+            memcpy(ha, tok_chunks + (size_t) chunk * tok_elems, tok_elems * sizeof(float));
+            npu->bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+            const uint64_t t_submit = ggml_xdna_now_ns();
+            npu->run.start();
+            const ert_cmd_state state_cmd = npu->run.wait();
+            npu->stats.ns_submit += ggml_xdna_now_ns() - t_submit;
+            npu->stats.n_runs++;
+
+            if (state_cmd != ERT_CMD_STATE_COMPLETED) {
+                GGML_LOG_ERROR("%s: NPU gdn full run did not complete\n", "ggml-xdna");
+                return false;
+            }
+
+            npu->bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+            if (npu->invalidate) {
+                ggml_xdna_invalidate(hc, attn_elems * sizeof(float));
+            }
+            memcpy(attn_chunks + (size_t) chunk * attn_elems,
+                   hc, attn_elems * sizeof(float));
+        }
+
+        npu->bo_b.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+        if (npu->invalidate) {
+            ggml_xdna_invalidate(hb, state_elems * sizeof(float));
+        }
+        memcpy(new_state, hb, state_elems * sizeof(float));
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: NPU gdn full failed: %s\n", "ggml-xdna", e.what());
+        return false;
+    }
+
+    npu->stats.ns_total += ggml_xdna_now_ns() - t_begin;
+    npu->stats.n_calls++;
+    return true;
+}
+#endif
+
+#else // !GGML_XDNA_HAS_XRT
+
+bool ggml_xdna_npu_probe(char * name, size_t name_size) {
+    if (name && name_size > 0) {
+        snprintf(name, name_size, "none");
+    }
+    return false;
+}
+
+void ggml_xdna_npu_free(ggml_xdna_npu * npu) {
+    GGML_UNUSED(npu);
+}
+
+void ggml_xdna_npu_get_stats(const ggml_xdna_npu * npu, ggml_xdna_npu_stats * stats) {
+    GGML_UNUSED(npu);
+    if (stats) {
+        *stats = ggml_xdna_npu_stats{};
+    }
+}
+
+ggml_xdna_npu * ggml_xdna_npu_gemm_init(const char *                        xclbin_path,
+                                        const char *                        insts_path,
+                                        const struct ggml_xdna_gemm_shape * shape) {
+    GGML_UNUSED(xclbin_path);
+    GGML_UNUSED(insts_path);
+    GGML_UNUSED(shape);
+    return nullptr;
+}
+
+int ggml_xdna_npu_gemm_m(const ggml_xdna_npu * npu) { GGML_UNUSED(npu); return 0; }
+int ggml_xdna_npu_gemm_k(const ggml_xdna_npu * npu) { GGML_UNUSED(npu); return 0; }
+int ggml_xdna_npu_gemm_n(const ggml_xdna_npu * npu) { GGML_UNUSED(npu); return 0; }
+
+size_t ggml_xdna_npu_gemm_a_bytes(const ggml_xdna_npu * npu) { GGML_UNUSED(npu); return 0; }
+size_t ggml_xdna_npu_gemm_b_bytes(const ggml_xdna_npu * npu) { GGML_UNUSED(npu); return 0; }
+size_t ggml_xdna_npu_gemm_c_bytes(const ggml_xdna_npu * npu) { GGML_UNUSED(npu); return 0; }
+
+ggml_xdna_buf * ggml_xdna_buf_alloc(ggml_xdna_npu * npu, size_t nbytes) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(nbytes);
+    return nullptr;
+}
+
+void   ggml_xdna_buf_free(ggml_xdna_buf * buf)            { GGML_UNUSED(buf); }
+void * ggml_xdna_buf_host(ggml_xdna_buf * buf)            { GGML_UNUSED(buf); return nullptr; }
+void   ggml_xdna_buf_sync_to_device(ggml_xdna_buf * buf, size_t offset, size_t nbytes) {
+    GGML_UNUSED(buf);
+    GGML_UNUSED(offset);
+    GGML_UNUSED(nbytes);
+}
+
+int ggml_xdna_npu_gemm_kb_max(const ggml_xdna_npu * npu) {
+    GGML_UNUSED(npu);
+    return 0;
+}
+
+uint16_t * ggml_xdna_npu_gemm_a_slice(ggml_xdna_npu * npu, int k_block) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(k_block);
+    return nullptr;
+}
+
+const float * ggml_xdna_npu_gemm_c_slice(ggml_xdna_npu * npu, int k_block) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(k_block);
+    return nullptr;
+}
+
+void ggml_xdna_npu_gemm_acquire(ggml_xdna_npu * npu) {
+    GGML_UNUSED(npu);
+}
+
+void ggml_xdna_npu_gemm_release(ggml_xdna_npu * npu) {
+    GGML_UNUSED(npu);
+}
+
+bool ggml_xdna_npu_gemm_runlist_wait(ggml_xdna_npu * npu) {
+    GGML_UNUSED(npu);
+    return false;
+}
+
+bool ggml_xdna_npu_gemm_submit_list_async(ggml_xdna_npu * npu,
+                                          ggml_xdna_buf * buf,
+                                          const size_t *  w_offs,
+                                          int             kb_n) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(buf);
+    GGML_UNUSED(w_offs);
+    GGML_UNUSED(kb_n);
+    return false;
+}
+
+int ggml_xdna_npu_gemm_n_banks(const ggml_xdna_npu * npu) {
+    GGML_UNUSED(npu);
+    return 0;
+}
+
+void ggml_xdna_npu_gemm_set_bank(ggml_xdna_npu * npu, int bank) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(bank);
+}
+
+uint16_t * ggml_xdna_npu_gemm_a_slice_bank(ggml_xdna_npu * npu, int bank, int k_block) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(bank);
+    GGML_UNUSED(k_block);
+    return nullptr;
+}
+
+const float * ggml_xdna_npu_gemm_c_slice_bank(ggml_xdna_npu * npu, int bank, int k_block) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(bank);
+    GGML_UNUSED(k_block);
+    return nullptr;
+}
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+ggml_xdna_npu * ggml_xdna_npu_init(enum ggml_xdna_op op,
+                                   const char *      xclbin_path,
+                                   const char *      insts_path,
+                                   size_t            tile_elems) {
+    GGML_UNUSED(op);
+    GGML_UNUSED(xclbin_path);
+    GGML_UNUSED(insts_path);
+    GGML_UNUSED(tile_elems);
+    return nullptr;
+}
+
+bool ggml_xdna_npu_binary_f32(ggml_xdna_npu * npu, const float * a, const float * b, float * dst, size_t n) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(a);
+    GGML_UNUSED(b);
+    GGML_UNUSED(dst);
+    GGML_UNUSED(n);
+    return false;
+}
+
+bool ggml_xdna_npu_rms_norm_f32(ggml_xdna_npu * npu, const float * x, float * dst, int64_t n_rows, float eps) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(x);
+    GGML_UNUSED(dst);
+    GGML_UNUSED(n_rows);
+    GGML_UNUSED(eps);
+    return false;
+}
+
+bool ggml_xdna_npu_add_rms_mul_f32(ggml_xdna_npu * npu,
+                                   const float *  a,
+                                   const float *  b,
+                                   const float *  weight,
+                                   float *        add_dst,
+                                   float *        mul_dst,
+                                   int64_t        n_rows,
+                                   int64_t        weight_n_rows,
+                                   float          eps) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(a);
+    GGML_UNUSED(b);
+    GGML_UNUSED(weight);
+    GGML_UNUSED(add_dst);
+    GGML_UNUSED(mul_dst);
+    GGML_UNUSED(n_rows);
+    GGML_UNUSED(weight_n_rows);
+    GGML_UNUSED(eps);
+    return false;
+}
+
+bool ggml_xdna_npu_gemm_submit_ab_list(ggml_xdna_npu * npu, int kb_n) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(kb_n);
+    return false;
+}
+
+uint16_t * ggml_xdna_npu_gemm_b_host(ggml_xdna_npu * npu) {
+    GGML_UNUSED(npu);
+    return nullptr;
+}
+
+uint16_t * ggml_xdna_npu_gemm_b_slice(ggml_xdna_npu * npu, int k_block) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(k_block);
+    return nullptr;
+}
+
+bool ggml_xdna_npu_gemm_submit_ab(ggml_xdna_npu * npu, int k_block) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(k_block);
+    return false;
+}
+
+ggml_xdna_npu * ggml_xdna_npu_gdn_init(const char * xclbin_path,
+                                       const char * insts_path,
+                                       const struct ggml_xdna_gdn_shape * shape) {
+    GGML_UNUSED(xclbin_path);
+    GGML_UNUSED(insts_path);
+    GGML_UNUSED(shape);
+    return nullptr;
+}
+
+bool ggml_xdna_npu_gdn_submit(ggml_xdna_npu * npu,
+                              const float *   tok,
+                              const float *   state_strip,
+                              float *         attn_strip,
+                              float *         new_state_strip) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(tok);
+    GGML_UNUSED(state_strip);
+    GGML_UNUSED(attn_strip);
+    GGML_UNUSED(new_state_strip);
+    return false;
+}
+
+bool ggml_xdna_npu_gdn_submit_full(ggml_xdna_npu * npu,
+                                   const float *   tok,
+                                   const float *   state,
+                                   float *         attn,
+                                   float *         new_state) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(tok);
+    GGML_UNUSED(state);
+    GGML_UNUSED(attn);
+    GGML_UNUSED(new_state);
+    return false;
+}
+
+bool ggml_xdna_npu_gdn_submit_full_chunks(ggml_xdna_npu * npu,
+                                          const float *   tok_chunks,
+                                          int             n_chunks,
+                                          const float *   state,
+                                          float *         attn_chunks,
+                                          float *         new_state) {
+    GGML_UNUSED(npu);
+    GGML_UNUSED(tok_chunks);
+    GGML_UNUSED(n_chunks);
+    GGML_UNUSED(state);
+    GGML_UNUSED(attn_chunks);
+    GGML_UNUSED(new_state);
+    return false;
+}
+#endif
+
+#endif // GGML_XDNA_HAS_XRT

--- a/ggml/src/ggml-xdna/xdna-npu.h
+++ b/ggml/src/ggml-xdna/xdna-npu.h
@@ -1,0 +1,172 @@
+#pragma once
+
+// Thin wrapper around the XRT/XDNA runtime. Keeps XRT types out of the ggml
+// backend layer so ggml-xdna.cpp stays readable when XRT is not available.
+
+#include <cstddef>
+#include <cstdint>
+
+struct ggml_xdna_npu;
+
+enum ggml_xdna_op {
+    GGML_XDNA_OP_GEMM,
+#if defined(GGML_XDNA_EXPERIMENTAL)
+    GGML_XDNA_OP_ADD,
+    GGML_XDNA_OP_MUL,
+    GGML_XDNA_OP_RMS_NORM,
+    GGML_XDNA_OP_ADD_RMS_MUL,
+    GGML_XDNA_OP_GDN,
+#endif
+};
+
+// Geometry of one GEMM artifact. The per-worker tile and the worker grid are
+// baked into the xclbin; kt and mb enter the instruction stream through the
+// operand sizes. nb is always 1 in the artifact: the host loops over output
+// column blocks of grid_c*tile_n.
+//
+//   C[mb*grid_r*tile_m, grid_c*tile_n] = A[mb*grid_r*tile_m, kt*tile_k]
+//                                      @ B[kt*tile_k, grid_c*tile_n]
+//
+// B is staged once in MemTile and replayed mb times, so a long prefill does
+// not re-read weights for every row block.
+struct ggml_xdna_gemm_shape {
+    int tile_m, tile_k, tile_n;
+    int grid_r, grid_c;
+    int kt, nb, mb;
+};
+
+struct ggml_xdna_npu_stats {
+    uint64_t n_calls;    // ggml ops dispatched
+    uint64_t n_runs;     // kernel submissions (one per tile)
+    uint64_t ns_total;   // wall time inside the submit path, incl. host copies
+    uint64_t ns_submit;  // wall time in run.start() + run.wait() only
+    // Result readback and its cache maintenance. Kept apart from ns_submit
+    // because it is host work that happens after the NPU is already idle.
+    uint64_t ns_sync;
+};
+
+// Opens NPU device 0 and reports its name. Does not load any kernel.
+// Returns false when no XDNA device is usable (or XRT was not compiled in).
+bool ggml_xdna_npu_probe(char * name, size_t name_size);
+
+void ggml_xdna_npu_free(ggml_xdna_npu * npu);
+
+void ggml_xdna_npu_get_stats(const ggml_xdna_npu * npu, struct ggml_xdna_npu_stats * stats);
+
+const char * ggml_xdna_op_name(enum ggml_xdna_op op);
+
+// Loads a GEMM artifact. The shape must match what the artifact was built with;
+// it decides the BO sizes and is not discoverable from the xclbin.
+ggml_xdna_npu * ggml_xdna_npu_gemm_init(const char * xclbin_path,
+                                        const char * insts_path,
+                                        const struct ggml_xdna_gemm_shape * shape);
+
+int ggml_xdna_npu_gemm_m(const ggml_xdna_npu * npu);
+int ggml_xdna_npu_gemm_k(const ggml_xdna_npu * npu);
+int ggml_xdna_npu_gemm_n(const ggml_xdna_npu * npu);
+
+// Byte size of the swizzled operand/result streams one submit moves.
+size_t ggml_xdna_npu_gemm_a_bytes(const ggml_xdna_npu * npu);
+size_t ggml_xdna_npu_gemm_b_bytes(const ggml_xdna_npu * npu);
+size_t ggml_xdna_npu_gemm_c_bytes(const ggml_xdna_npu * npu);
+
+// Device-visible memory for repacked weights. Weights are written once at model
+// load and read by every submit, so they live here rather than being copied into
+// an operand BO per call - at 7 MiB a tensor that copy would cost more than the
+// matmul.
+struct ggml_xdna_buf;
+
+ggml_xdna_buf * ggml_xdna_buf_alloc(ggml_xdna_npu * npu, size_t nbytes);
+void            ggml_xdna_buf_free(ggml_xdna_buf * buf);
+void *          ggml_xdna_buf_host(ggml_xdna_buf * buf);
+void            ggml_xdna_buf_sync_to_device(ggml_xdna_buf * buf, size_t offset, size_t nbytes);
+
+// GEMM operands live in device-visible memory: the caller packs A into the
+// slice it is about to submit and reads C back from the matching slice, so a
+// submit moves nothing between host buffers.
+//
+// The buffers are shared per device, so a caller holds acquire/release around
+// the whole pack -> submit -> read sequence.
+int            ggml_xdna_npu_gemm_kb_max (const ggml_xdna_npu * npu);
+uint16_t *     ggml_xdna_npu_gemm_a_slice(ggml_xdna_npu * npu, int k_block);
+const float *  ggml_xdna_npu_gemm_c_slice(ggml_xdna_npu * npu, int k_block);
+
+void ggml_xdna_npu_gemm_acquire(ggml_xdna_npu * npu);
+void ggml_xdna_npu_gemm_release(ggml_xdna_npu * npu);
+
+// Wait for the outstanding runlist from submit_list_async, then
+// sync C views back to the host. No-op when nothing is pending.
+bool ggml_xdna_npu_gemm_runlist_wait(ggml_xdna_npu * npu);
+
+// Like submit_list but returns after execute() without wait/C-sync so the host
+// can pack the next A block while the NPU runs. Must call runlist_wait next.
+bool ggml_xdna_npu_gemm_submit_list_async(ggml_xdna_npu * npu,
+                                          ggml_xdna_buf * buf,
+                                          const size_t *  w_offs,
+                                          int             kb_n);
+
+// Double-buffered A/C: ping-pong bank in {0,1}. Pack into bank, submit from
+// bank, wait/scatter the other. Default bank 0 preserves single-buffer callers.
+int  ggml_xdna_npu_gemm_n_banks(const ggml_xdna_npu * npu);
+void ggml_xdna_npu_gemm_set_bank(ggml_xdna_npu * npu, int bank);
+uint16_t *    ggml_xdna_npu_gemm_a_slice_bank(ggml_xdna_npu * npu, int bank, int k_block);
+const float * ggml_xdna_npu_gemm_c_slice_bank(ggml_xdna_npu * npu, int bank, int k_block);
+
+#if defined(GGML_XDNA_EXPERIMENTAL)
+// Elementwise / fused / GDN kernels and act-x-act GEMM. Production builds
+// compile none of this.
+
+ggml_xdna_npu * ggml_xdna_npu_init(enum ggml_xdna_op op,
+                                   const char *      xclbin_path,
+                                   const char *      insts_path,
+                                   size_t            tile_elems);
+
+bool ggml_xdna_npu_binary_f32(ggml_xdna_npu * npu, const float * a, const float * b, float * dst, size_t n);
+
+bool ggml_xdna_npu_rms_norm_f32(ggml_xdna_npu * npu, const float * x, float * dst, int64_t n_rows, float eps);
+
+bool ggml_xdna_npu_add_rms_mul_f32(ggml_xdna_npu * npu,
+                                   const float *  a,
+                                   const float *  b,
+                                   const float *  weight,
+                                   float *        add_dst,
+                                   float *        mul_dst,
+                                   int64_t        n_rows,
+                                   int64_t        weight_n_rows,
+                                   float          eps);
+
+bool ggml_xdna_npu_gemm_submit_ab_list(ggml_xdna_npu * npu, int kb_n);
+uint16_t * ggml_xdna_npu_gemm_b_host(ggml_xdna_npu * npu);
+uint16_t * ggml_xdna_npu_gemm_b_slice(ggml_xdna_npu * npu, int k_block);
+bool ggml_xdna_npu_gemm_submit_ab(ggml_xdna_npu * npu, int k_block);
+
+struct ggml_xdna_gdn_shape {
+    int S;
+    int ROWS;
+    int CS;
+    int workers; // 1 or S/ROWS
+};
+
+ggml_xdna_npu * ggml_xdna_npu_gdn_init(const char * xclbin_path,
+                                       const char * insts_path,
+                                       const struct ggml_xdna_gdn_shape * shape);
+
+bool ggml_xdna_npu_gdn_submit(ggml_xdna_npu * npu,
+                              const float *   tok,
+                              const float *   state_strip,
+                              float *         attn_strip,
+                              float *         new_state_strip);
+
+bool ggml_xdna_npu_gdn_submit_full(ggml_xdna_npu * npu,
+                                   const float *   tok,
+                                   const float *   state,
+                                   float *         attn,
+                                   float *         new_state);
+
+bool ggml_xdna_npu_gdn_submit_full_chunks(ggml_xdna_npu * npu,
+                                          const float *   tok_chunks,
+                                          int             n_chunks,
+                                          const float *   state,
+                                          float *         attn_chunks,
+                                          float *         new_state);
+#endif

--- a/ggml/src/ggml-xdna/xdna-probe.cpp
+++ b/ggml/src/ggml-xdna/xdna-probe.cpp
@@ -1,0 +1,1043 @@
+// xdna-probe - standalone diagnostic for XDNA/XRT kernel residency and the cost
+// of changing what the NPU is running.
+//
+// Separates four costs that are easy to conflate, and reports each on its own:
+//
+//   instruction/module rotation - several sequences bound to ONE context
+//   same-xclbin context switch  - several contexts of the SAME design
+//   different-xclbin switch     - contexts of DIFFERENT designs (fabric changes)
+//   eviction/recreation         - no free context slot, so one must be destroyed
+//
+// The different-xclbin figure is computed the way it has to be, against both
+// homogeneous baselines rather than against one of them:
+//
+//   overhead = mean(AMAM) - (mean(AAAA) + mean(MMMM)) / 2
+//
+// Every submit is timed in three parts (start, wait, sync) so a difference can
+// be attributed rather than guessed at, every scenario is verified against the
+// CPU, and every sample is written to CSV so several process runs can be pooled.
+//
+// Deliberately does not link ggml: only XRT is involved, so nothing about the
+// result depends on the backend.
+//
+// SPDX-License-Identifier: MIT
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_hw_context.h"
+#include "xrt/xrt_kernel.h"
+#include "xrt/experimental/xrt_kernel.h"
+#include "xrt/experimental/xrt_xclbin.h"
+
+#ifdef XDNA_PROBE_HAS_AIEBU
+#include "xrt/experimental/xrt_elf.h"
+#include "xrt/experimental/xrt_ext.h"
+#include "xrt/experimental/xrt_module.h"
+
+#include "aiebu/aiebu_assembler.h"
+#endif
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+static const char * KERNEL_NAME = "MLIR_AIE";
+static constexpr uint64_t OPCODE_TXN = 3;
+static constexpr int ARG_DATA0 = 3;
+
+static double now_us(void) {
+    using clock = std::chrono::steady_clock;
+    return std::chrono::duration<double, std::micro>(clock::now().time_since_epoch()).count();
+}
+
+static double now_ms(void) {
+    return now_us() / 1e3;
+}
+
+// ---------------------------------------------------------------------------
+// samples and statistics
+// ---------------------------------------------------------------------------
+
+struct sample {
+    double start_us;
+    double wait_us;
+    double sync_us;
+    double total_us;
+};
+
+struct stats {
+    size_t n;
+    double mean_us;
+    double p50_us;
+    double p95_us;
+    double p99_us;
+};
+
+static double percentile(std::vector<double> & sorted, double q) {
+    if (sorted.empty()) {
+        return 0.0;
+    }
+    const size_t i = (size_t) ((double) (sorted.size() - 1) * q);
+    return sorted[i];
+}
+
+// Which field of the sample to summarize.
+enum class field { start, wait, sync, total };
+
+static stats summarize(const std::vector<sample> & samples, field f = field::total) {
+    std::vector<double> v;
+    v.reserve(samples.size());
+    for (const sample & s : samples) {
+        switch (f) {
+            case field::start: v.push_back(s.start_us); break;
+            case field::wait:  v.push_back(s.wait_us);  break;
+            case field::sync:  v.push_back(s.sync_us);  break;
+            case field::total: v.push_back(s.total_us); break;
+        }
+    }
+    std::sort(v.begin(), v.end());
+
+    double sum = 0;
+    for (double x : v) {
+        sum += x;
+    }
+
+    stats s;
+    s.n       = v.size();
+    s.mean_us = v.empty() ? 0.0 : sum / (double) v.size();
+    s.p50_us  = percentile(v, 0.50);
+    s.p95_us  = percentile(v, 0.95);
+    s.p99_us  = percentile(v, 0.99);
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// artifacts
+// ---------------------------------------------------------------------------
+
+struct instr_blob {
+    std::vector<uint32_t> words;
+};
+
+static bool read_instr(const std::string & path, instr_blob & out) {
+    FILE * f = fopen(path.c_str(), "rb");
+    if (!f) {
+        return false;
+    }
+    fseek(f, 0, SEEK_END);
+    const long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (size <= 0 || (size % 4) != 0) {
+        fclose(f);
+        return false;
+    }
+    out.words.resize((size_t) size / 4);
+    const size_t n = fread(out.words.data(), 1, (size_t) size, f);
+    fclose(f);
+    return n == (size_t) size;
+}
+
+// Which elementwise operation an artifact implements, taken from its name. Used
+// only to check the result against the CPU.
+enum class op_kind { add, mul, unknown };
+
+static op_kind op_of(const std::string & path) {
+    const std::string name = fs::path(path).filename().string();
+    if (name.find("-add-") != std::string::npos) {
+        return op_kind::add;
+    }
+    if (name.find("-mul-") != std::string::npos) {
+        return op_kind::mul;
+    }
+    return op_kind::unknown;
+}
+
+struct design {
+    std::string path;
+    xrt::uuid   uuid;
+    instr_blob  instr;
+    op_kind     op;
+    int         id;   // probe-assigned, so CSV rows can be grouped
+};
+
+// ---------------------------------------------------------------------------
+// the two ways of driving a design
+// ---------------------------------------------------------------------------
+
+// Cost of putting one handle together, broken into the steps the caller pays
+// separately. Kept next to the handle because that is where it is produced.
+struct build_cost {
+    double ctx_ms    = 0;
+    double kernel_ms = 0;
+    double module_ms = 0;
+    double bo_ms     = 0;
+    double asm_ms    = 0;
+};
+
+// Instruction stream handed to the driver in a buffer on every submit. This is
+// what the backend does today.
+struct live_kernel {
+    xrt::hw_context context;
+    xrt::kernel     kernel;
+    xrt::bo         bo_instr;
+    xrt::bo         bo_a;
+    xrt::bo         bo_b;
+    xrt::bo         bo_c;
+    xrt::run        run;
+    uint32_t        instr_words = 0;
+    int             design_id = -1;
+    int             ctx_id    = -1;
+    int             mod_id    = -1;   // no module on this path
+};
+
+static int g_next_ctx_id = 0;
+
+static std::unique_ptr<live_kernel> make_kernel(xrt::device &  dev,
+                                               const design & d,
+                                               size_t         tile_elems,
+                                               build_cost *   cost = nullptr) {
+    auto lk = std::make_unique<live_kernel>();
+    build_cost c;
+
+    double t0 = now_ms();
+    lk->context = xrt::hw_context(dev, d.uuid);
+    c.ctx_ms    = now_ms() - t0;
+
+    t0           = now_ms();
+    lk->kernel   = xrt::kernel(lk->context, KERNEL_NAME);
+    c.kernel_ms  = now_ms() - t0;
+
+    const size_t instr_bytes = d.instr.words.size() * sizeof(uint32_t);
+    const size_t data_bytes  = tile_elems * sizeof(float);
+
+    t0 = now_ms();
+    lk->bo_instr = xrt::bo(dev, instr_bytes, XCL_BO_FLAGS_CACHEABLE, lk->kernel.group_id(1));
+    lk->bo_a = xrt::bo(dev, data_bytes, XRT_BO_FLAGS_HOST_ONLY, lk->kernel.group_id(ARG_DATA0 + 0));
+    lk->bo_b = xrt::bo(dev, data_bytes, XRT_BO_FLAGS_HOST_ONLY, lk->kernel.group_id(ARG_DATA0 + 1));
+    lk->bo_c = xrt::bo(dev, data_bytes, XRT_BO_FLAGS_HOST_ONLY, lk->kernel.group_id(ARG_DATA0 + 2));
+    c.bo_ms  = now_ms() - t0;
+
+    memcpy(lk->bo_instr.map<void *>(), d.instr.words.data(), instr_bytes);
+    lk->bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    memset(lk->bo_c.map<void *>(), 0, data_bytes);
+
+    lk->run = xrt::run(lk->kernel);
+    lk->run.set_arg(0, OPCODE_TXN);
+    lk->run.set_arg(1, lk->bo_instr);
+    lk->run.set_arg(2, (uint32_t) d.instr.words.size());
+    lk->run.set_arg(ARG_DATA0 + 0, lk->bo_a);
+    lk->run.set_arg(ARG_DATA0 + 1, lk->bo_b);
+    lk->run.set_arg(ARG_DATA0 + 2, lk->bo_c);
+
+    lk->instr_words = (uint32_t) d.instr.words.size();
+    lk->design_id   = d.id;
+    lk->ctx_id      = g_next_ctx_id++;
+
+    if (cost) {
+        *cost = c;
+    }
+    return lk;
+}
+
+#ifdef XDNA_PROBE_HAS_AIEBU
+// Instruction stream assembled into an ELF and bound to the context as a module.
+// Several of these can share one context, which is the point of this path.
+struct live_module {
+    xrt::hw_context                   context;
+    std::unique_ptr<xrt::elf>         elf;
+    std::unique_ptr<xrt::module>      mod;
+    std::unique_ptr<xrt::ext::kernel> kernel;
+    xrt::bo                           bo_a;
+    xrt::bo                           bo_b;
+    xrt::bo                           bo_c;
+    xrt::run                          run;
+    int                               design_id = -1;
+    int                               ctx_id    = -1;
+    int                               mod_id    = -1;
+};
+
+static int g_next_mod_id = 0;
+
+static std::vector<char> assemble_elf(const instr_blob & instr) {
+    const char * p = reinterpret_cast<const char *>(instr.words.data());
+    const std::vector<char> txn(p, p + instr.words.size() * sizeof(uint32_t));
+
+    aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::blob_instr_transaction, txn);
+    return as.get_elf();
+}
+
+// Takes the context by value so several modules can share one and the same
+// context: the xclbin fixes the fabric, the module carries the shape.
+static std::unique_ptr<live_module> make_module_kernel(const xrt::hw_context & ctx,
+                                                      const design &          d,
+                                                      size_t                  tile_elems,
+                                                      int                     ctx_id,
+                                                      build_cost *            cost = nullptr) {
+    auto lm = std::make_unique<live_module>();
+    build_cost c;
+
+    double t0 = now_ms();
+    std::vector<char> elf_data = assemble_elf(d.instr);
+    c.asm_ms = now_ms() - t0;
+
+    lm->context = ctx;
+
+    t0          = now_ms();
+    lm->elf     = std::make_unique<xrt::elf>(elf_data.data(), elf_data.size());
+    lm->mod     = std::make_unique<xrt::module>(*lm->elf);
+    c.module_ms = now_ms() - t0;
+
+    t0          = now_ms();
+    lm->kernel  = std::make_unique<xrt::ext::kernel>(lm->context, *lm->mod, KERNEL_NAME);
+    c.kernel_ms = now_ms() - t0;
+
+    const size_t data_bytes = tile_elems * sizeof(float);
+
+    t0       = now_ms();
+    lm->bo_a = xrt::ext::bo(lm->context, data_bytes);
+    lm->bo_b = xrt::ext::bo(lm->context, data_bytes);
+    lm->bo_c = xrt::ext::bo(lm->context, data_bytes);
+    c.bo_ms  = now_ms() - t0;
+
+    memset(lm->bo_c.map<void *>(), 0, data_bytes);
+
+    lm->run = xrt::run(*lm->kernel);
+    lm->run.set_arg(0, OPCODE_TXN);
+    lm->run.set_arg(1, 0);
+    lm->run.set_arg(2, 0);
+    lm->run.set_arg(ARG_DATA0 + 0, lm->bo_a);
+    lm->run.set_arg(ARG_DATA0 + 1, lm->bo_b);
+    lm->run.set_arg(ARG_DATA0 + 2, lm->bo_c);
+
+    lm->design_id = d.id;
+    lm->ctx_id    = ctx_id;
+    lm->mod_id    = g_next_mod_id++;
+
+    if (cost) {
+        *cost = c;
+    }
+    return lm;
+}
+#endif // XDNA_PROBE_HAS_AIEBU
+
+// ---------------------------------------------------------------------------
+// submit, inputs, verification
+// ---------------------------------------------------------------------------
+
+template <typename T> static sample submit_timed(T & lk) {
+    const double t0 = now_us();
+    lk.run.start();
+    const double t1 = now_us();
+    lk.run.wait();
+    const double t2 = now_us();
+    lk.bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+    const double t3 = now_us();
+
+    sample s;
+    s.start_us = t1 - t0;
+    s.wait_us  = t2 - t1;
+    s.sync_us  = t3 - t2;
+    s.total_us = t3 - t0;
+    return s;
+}
+
+// One graph is hundreds of nodes, so whether the per-submit round trip is paid
+// per node or per submission decides whether offloading a graph can pay off at
+// all. xrt::runlist submits several runs as one command, which is what
+// ggml-hexagon does with its op batch (opt_opbatch is 1024 nodes per queue
+// write). Both halves below do the same amount of device work.
+struct batch_result {
+    double seq_us  = 0;   // per op, one start/wait each
+    double list_us = 0;   // per op, one execute/wait for the whole list
+};
+
+static xrt::run clone_run(const live_kernel & lk) {
+    xrt::run r(lk.kernel);
+    r.set_arg(0, OPCODE_TXN);
+    r.set_arg(1, lk.bo_instr);
+    r.set_arg(2, lk.instr_words);
+    r.set_arg(ARG_DATA0 + 0, lk.bo_a);
+    r.set_arg(ARG_DATA0 + 1, lk.bo_b);
+    r.set_arg(ARG_DATA0 + 2, lk.bo_c);
+    return r;
+}
+
+static batch_result run_batch(live_kernel & lk, int batch, int iters, int n_warm) {
+    std::vector<xrt::run> runs;
+    runs.reserve(batch);
+    for (int i = 0; i < batch; i++) {
+        runs.push_back(clone_run(lk));
+    }
+
+    xrt::runlist list(lk.context);
+    for (auto & r : runs) {
+        list.add(r);
+    }
+
+    for (int i = 0; i < n_warm; i++) {
+        lk.run.start();
+        lk.run.wait();
+        list.execute();
+        list.wait();
+    }
+
+    batch_result out;
+
+    double acc = 0;
+    for (int i = 0; i < iters; i++) {
+        const double t0 = now_us();
+        for (int j = 0; j < batch; j++) {
+            lk.run.start();
+            lk.run.wait();
+        }
+        acc += now_us() - t0;
+    }
+    out.seq_us = acc / (iters * batch);
+
+    acc = 0;
+    for (int i = 0; i < iters; i++) {
+        const double t0 = now_us();
+        list.execute();
+        list.wait();
+        acc += now_us() - t0;
+    }
+    out.list_us = acc / (iters * batch);
+
+    return out;
+}
+
+// Same inputs everywhere, so outputs are comparable across paths and scenarios.
+static float in_a(size_t i) { return 1.0f + 0.001f * (float) (i % 977); }
+static float in_b(size_t i) { return 2.0f - 0.002f * (float) (i % 641); }
+
+template <typename T> static void fill_inputs(T & lk, size_t tile_elems) {
+    float * a = lk.bo_a.template map<float *>();
+    float * b = lk.bo_b.template map<float *>();
+    for (size_t i = 0; i < tile_elems; i++) {
+        a[i] = in_a(i);
+        b[i] = in_b(i);
+    }
+    lk.bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    lk.bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+}
+
+// How many submits a freshly built handle needs before its output matches the
+// CPU. Anything above 1 means a newly created context cannot be trusted on its
+// first use, which is a correctness constraint on the backend rather than a
+// performance one.
+template <typename T>
+static int submits_until_correct(T & lk, size_t tile_elems, op_kind op, int max_tries);
+
+// Returns the largest absolute deviation from what the CPU computes, or -1 when
+// the artifact is not one whose operation we can predict from its name.
+template <typename T> static double verify_cpu(T & lk, size_t tile_elems, op_kind op) {
+    if (op == op_kind::unknown) {
+        return -1.0;
+    }
+    const float * c = lk.bo_c.template map<const float *>();
+    double max_delta = 0;
+    for (size_t i = 0; i < tile_elems; i++) {
+        const double want = (op == op_kind::add) ? (double) in_a(i) + (double) in_b(i)
+                                                 : (double) in_a(i) * (double) in_b(i);
+        max_delta = std::max(max_delta, std::abs((double) c[i] - want));
+    }
+    return max_delta;
+}
+
+template <typename T>
+static int submits_until_correct(T & lk, size_t tile_elems, op_kind op, int max_tries) {
+    if (op == op_kind::unknown) {
+        return -1;
+    }
+    for (int i = 1; i <= max_tries; i++) {
+        submit_timed(lk);
+        if (verify_cpu(lk, tile_elems, op) < 1e-5) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+// ---------------------------------------------------------------------------
+// CSV
+// ---------------------------------------------------------------------------
+
+struct csv_writer {
+    FILE * f      = nullptr;
+    int    run_id = 0;
+
+    void open(const std::string & path, int run) {
+        run_id = run;
+        const bool exists = fs::exists(path) && fs::file_size(path) > 0;
+        f = fopen(path.c_str(), "a");
+        if (f && !exists) {
+            fprintf(f, "run_id,scenario,iter,xclbin,uuid,design_id,ctx_id,mod_id,"
+                       "start_us,wait_us,sync_us,total_us\n");
+        }
+    }
+
+    void write(const char * scenario, int iter, const design & d,
+               int ctx_id, int mod_id, const sample & s) {
+        if (!f) {
+            return;
+        }
+        fprintf(f, "%d,%s,%d,%s,%s,%d,%d,%d,%.3f,%.3f,%.3f,%.3f\n",
+                run_id, scenario, iter,
+                fs::path(d.path).filename().string().c_str(),
+                d.uuid.to_string().c_str(),
+                d.id, ctx_id, mod_id,
+                s.start_us, s.wait_us, s.sync_us, s.total_us);
+    }
+
+    ~csv_writer() {
+        if (f) {
+            fclose(f);
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// scenario runner
+// ---------------------------------------------------------------------------
+
+// Runs `rotation` round-robin. A rotation of one handle is a homogeneous
+// baseline; a rotation of two is a switch on every submit.
+template <typename T>
+static std::vector<sample> run_scenario(const char *               name,
+                                        const std::vector<T *> &   rotation,
+                                        const std::vector<design>& designs,
+                                        int                        n_warm,
+                                        int                        n_iter,
+                                        csv_writer &               csv) {
+    for (int i = 0; i < n_warm; i++) {
+        submit_timed(*rotation[i % rotation.size()]);
+    }
+
+    std::vector<sample> out;
+    out.reserve(n_iter);
+    for (int i = 0; i < n_iter; i++) {
+        T & h = *rotation[i % rotation.size()];
+        const sample s = submit_timed(h);
+        out.push_back(s);
+        csv.write(name, i, designs[h.design_id], h.ctx_id, h.mod_id, s);
+    }
+    return out;
+}
+
+static void print_row(const char * label, const std::vector<sample> & s) {
+    const stats t  = summarize(s, field::total);
+    const stats st = summarize(s, field::start);
+    const stats w  = summarize(s, field::wait);
+    const stats sy = summarize(s, field::sync);
+    printf("   %-34s %6zu %9.1f %9.1f %9.1f %9.1f | %8.1f %8.1f %8.1f\n",
+           label, t.n, t.mean_us, t.p50_us, t.p95_us, t.p99_us,
+           st.mean_us, w.mean_us, sy.mean_us);
+}
+
+static void print_header(void) {
+    printf("   %-34s %6s %9s %9s %9s %9s | %8s %8s %8s\n",
+           "scenario", "n", "mean us", "p50", "p95", "p99", "start", "wait", "sync");
+}
+
+static fs::path exe_dir(void) {
+    std::error_code ec;
+    fs::path p = fs::read_symlink("/proc/self/exe", ec);
+    return ec ? fs::current_path() : p.parent_path();
+}
+
+// ---------------------------------------------------------------------------
+
+int main(int argc, char ** argv) {
+    size_t      tile    = 16384;
+    int         n_iter  = 1000;
+    int         n_warm  = 32;
+    int         max_ctx = 24;
+    int         run_id  = 0;
+    int         big_bo_mib = 0;
+    int         batch   = 0;
+    bool        run_smi = false;
+    std::string csv_path;
+    std::vector<std::pair<std::string, std::string>> artifacts;
+
+    for (int i = 1; i < argc; i++) {
+        const std::string a = argv[i];
+        if (a == "--tile" && i + 1 < argc) {
+            tile = (size_t) atoll(argv[++i]);
+        } else if (a == "--iter" && i + 1 < argc) {
+            n_iter = atoi(argv[++i]);
+        } else if (a == "--warmup" && i + 1 < argc) {
+            n_warm = atoi(argv[++i]);
+        } else if (a == "--max-contexts" && i + 1 < argc) {
+            max_ctx = atoi(argv[++i]);
+        } else if (a == "--run-id" && i + 1 < argc) {
+            run_id = atoi(argv[++i]);
+        } else if (a == "--big-bo-mib" && i + 1 < argc) {
+            big_bo_mib = atoi(argv[++i]);
+        } else if (a == "--batch" && i + 1 < argc) {
+            batch = atoi(argv[++i]);
+        } else if (a == "--csv" && i + 1 < argc) {
+            csv_path = argv[++i];
+        } else if (a == "--smi") {
+            run_smi = true;
+        } else if (a == "--kernel" && i + 2 < argc) {
+            artifacts.emplace_back(argv[i + 1], argv[i + 2]);
+            i += 2;
+        } else {
+            fprintf(stderr,
+                    "usage: %s [--tile N] [--iter N] [--warmup N] [--max-contexts N]\n"
+                    "          [--run-id N] [--csv <path>] [--smi] [--big-bo-mib N]\n"
+                    "          [--batch N] [--kernel <xclbin> <insts.bin>]...\n"
+                    "\n"
+                    "  --batch submits N runs as one xrt::runlist and compares that\n"
+                    "  against N separate start/wait pairs, which says whether the\n"
+                    "  per-submit round trip is paid per node or per submission.\n"
+                    "\n"
+                    "  --big-bo-mib makes the residency test give every context a buffer of\n"
+                    "  that size, which shows whether the cap is a count of slots or a\n"
+                    "  memory budget.\n"
+                    "\n"
+                    "  Two designs are needed for the different-xclbin figure; by default\n"
+                    "  the add and mul artifacts for the given tile are picked up from the\n"
+                    "  directory of this executable.\n", argv[0]);
+            return 2;
+        }
+    }
+
+    if (artifacts.empty()) {
+        const fs::path dir = exe_dir();
+        for (const char * op : { "add", "mul" }) {
+            char stem[128];
+            snprintf(stem, sizeof(stem), "ggml-xdna-%s-npu2-f32-%zu", op, tile);
+            const fs::path x = dir / (std::string(stem) + ".xclbin");
+            const fs::path b = dir / (std::string(stem) + ".insts.bin");
+            if (fs::exists(x) && fs::exists(b)) {
+                artifacts.emplace_back(x.string(), b.string());
+            }
+        }
+    }
+
+    if (artifacts.empty()) {
+        fprintf(stderr, "xdna-probe: no kernel artifacts found for tile=%zu; pass --kernel\n", tile);
+        return 1;
+    }
+
+    csv_writer csv;
+    if (!csv_path.empty()) {
+        csv.open(csv_path, run_id);
+    }
+
+    try {
+        printf("xdna-probe: run_id=%d tile=%zu warmup=%d iters=%d designs=%zu\n\n",
+               run_id, tile, n_warm, n_iter, artifacts.size());
+
+        // --- 1. device -----------------------------------------------------
+        double t0 = now_ms();
+        xrt::device dev(0u);
+        const double t_dev = now_ms() - t0;
+        printf("1. device\n");
+        printf("   name                 : %s\n", dev.get_info<xrt::info::device::name>().c_str());
+        printf("   xrt::device(0)       : %8.3f ms\n\n", t_dev);
+
+        // --- 2. one-time cost, per component -------------------------------
+        printf("2. one-time cost of putting a design on the NPU, per component\n");
+        printf("   %-30s %8s %8s %8s %8s %8s\n",
+               "design", "parse", "regxcl", "hwctx", "kernel", "BOs");
+
+        std::vector<design> designs;
+        for (const auto & art : artifacts) {
+            design d;
+            d.path = art.first;
+            d.op   = op_of(art.first);
+            d.id   = (int) designs.size();
+            if (!read_instr(art.second, d.instr)) {
+                fprintf(stderr, "xdna-probe: cannot read %s\n", art.second.c_str());
+                return 1;
+            }
+
+            t0 = now_ms();
+            xrt::xclbin xclbin{art.first};
+            const double t_parse = now_ms() - t0;
+
+            t0 = now_ms();
+            dev.register_xclbin(xclbin);
+            const double t_reg = now_ms() - t0;
+
+            d.uuid = xclbin.get_uuid();
+
+            build_cost c;
+            auto probe_handle = make_kernel(dev, d, tile, &c);
+            (void) probe_handle;
+
+            printf("   %-30s %8.3f %8.3f %8.3f %8.3f %8.3f\n",
+                   fs::path(art.first).filename().string().c_str(),
+                   t_parse, t_reg, c.ctx_ms, c.kernel_ms, c.bo_ms);
+
+            designs.push_back(std::move(d));
+        }
+        printf("   (all values in ms, paid once at init)\n\n");
+
+        // --- 3. how many contexts stay resident ----------------------------
+        printf("3. how many hw_contexts the driver lets us hold at once\n");
+        std::vector<std::unique_ptr<live_kernel>> pool;
+        std::string limit_reason = "(hit the --max-contexts cap, not a driver limit)";
+        for (int i = 0; i < max_ctx; i++) {
+            try {
+                pool.push_back(make_kernel(dev, designs[i % designs.size()], tile));
+            } catch (const std::exception & e) {
+                limit_reason = std::string("driver refused #") + std::to_string(i + 1) + ": " + e.what();
+                break;
+            }
+        }
+        const size_t n_max_ctx = pool.size();
+        printf("   resident contexts    : %zu\n", n_max_ctx);
+        printf("   stopped because      : %s\n", limit_reason.c_str());
+
+        if (pool.empty()) {
+            fprintf(stderr, "xdna-probe: could not create a single context\n");
+            return 1;
+        }
+
+        // Whether the cap is a count of context slots or a budget that large
+        // buffers eat into. Same loop, but every context also holds a big buffer;
+        // context creation and buffer allocation are reported separately so a
+        // refusal can be attributed to one or the other.
+        if (big_bo_mib > 0) {
+            printf("   with an extra %d MiB buffer per context:\n", big_bo_mib);
+            struct fat_ctx {
+                xrt::hw_context ctx;
+                xrt::kernel     krn;
+                xrt::bo         bo;
+            };
+            std::vector<std::unique_ptr<fat_ctx>> fat;
+            std::string          fat_reason = "(reached the same cap)";
+            const size_t         bo_bytes   = (size_t) big_bo_mib * 1024 * 1024;
+            {
+                // The pool holds every slot, so it has to go before this runs.
+                pool.clear();
+
+                for (int i = 0; i < max_ctx; i++) {
+                    auto f = std::make_unique<fat_ctx>();
+                    try {
+                        f->ctx = xrt::hw_context(dev, designs[i % designs.size()].uuid);
+                        f->krn = xrt::kernel(f->ctx, KERNEL_NAME);
+                    } catch (const std::exception & e) {
+                        fat_reason = std::string("hw_context #") + std::to_string(i + 1)
+                                     + " refused: " + e.what();
+                        break;
+                    }
+                    try {
+                        f->bo = xrt::bo(dev, bo_bytes, XRT_BO_FLAGS_HOST_ONLY,
+                                        f->krn.group_id(ARG_DATA0));
+                        memset(f->bo.map<void *>(), 0, bo_bytes);
+                    } catch (const std::exception & e) {
+                        fat_reason = std::string("buffer #") + std::to_string(i + 1)
+                                     + " refused: " + e.what();
+                        break;
+                    }
+                    fat.push_back(std::move(f));
+                }
+                printf("     contexts holding %4d MiB each : %zu  (%zu MiB pinned in total)\n",
+                       big_bo_mib, fat.size(), fat.size() * (size_t) big_bo_mib);
+                printf("     stopped because              : %s\n", fat_reason.c_str());
+            }
+
+            // Rebuild the pool the later sections expect. The fat contexts are
+            // still holding every slot, so they have to be released first.
+            fat.clear();
+            for (int i = 0; i < (int) n_max_ctx; i++) {
+                pool.push_back(make_kernel(dev, designs[i % designs.size()], tile));
+            }
+            printf("     pool rebuilt to %zu contexts\n", pool.size());
+        }
+        printf("\n");
+
+        if (run_smi) {
+            printf("4. the driver's own view, taken while those contexts are held\n");
+            fflush(stdout);
+            if (system("/opt/xilinx/xrt/bin/xrt-smi examine -r aie-partitions 2>/dev/null"
+                       " | sed 's/^/   /'") != 0) {
+                printf("   (xrt-smi unavailable)\n");
+            }
+            printf("\n");
+        }
+
+        // --- 5. eviction: no free slot, so a context must be destroyed ------
+        // Two cases, and the difference between them is the whole point. Warm:
+        // the design being brought back still has other contexts, so its PDI is
+        // already on the array. Cold: every context of that design was dropped
+        // first, so the fabric has to be programmed again - the real cache miss.
+        printf("5. eviction with a full pool: destroy a context, create another\n");
+        double ms_evict_warm = 0;
+        double ms_evict_cold = 0;
+        double us_first_warm = 0;
+        double us_steady_warm = 0;
+        double us_first_cold = 0;
+        int    ok_warm_n     = 0;
+        int    ok_cold_n     = 0;
+        {
+            // Warm: drop one context, bring back a design that is still resident.
+            const int victim_design = pool.back()->design_id;
+            t0 = now_ms();
+            pool.pop_back();
+            const double ms_destroy_warm = now_ms() - t0;
+
+            build_cost c;
+            t0 = now_ms();
+            auto fresh = make_kernel(dev, designs[0], tile, &c);
+            const double ms_create_warm = now_ms() - t0;
+            ms_evict_warm = ms_destroy_warm + ms_create_warm;
+
+            fill_inputs(*fresh, tile);
+            const sample first = submit_timed(*fresh);
+            us_first_warm      = first.total_us;
+            csv.write("evict_warm_first", 0, designs[0], fresh->ctx_id, -1, first);
+
+            const double d_warm  = verify_cpu(*fresh, tile, designs[0].op);
+            const int    ok_warm = d_warm < 1e-5
+                                       ? 1
+                                       : 1 + submits_until_correct(*fresh, tile, designs[0].op, 8);
+            ok_warm_n = ok_warm;
+
+            std::vector<live_kernel *> rot{ fresh.get() };
+            const auto after = run_scenario("evict_warm_steady", rot, designs, n_warm,
+                                            std::min(n_iter, 200), csv);
+            us_steady_warm = summarize(after).mean_us;
+
+            printf("   WARM  design still resident elsewhere (evicted design %d)\n", victim_design);
+            printf("     destroy one context           : %8.3f ms\n", ms_destroy_warm);
+            printf("     hw_context+kernel+BOs again   : %8.3f ms  (hwctx %.3f, kernel %.3f, BOs %.3f)\n",
+                   ms_create_warm, c.ctx_ms, c.kernel_ms, c.bo_ms);
+            printf("     first invocation / steady     : %8.1f us / %.1f us\n", us_first_warm, us_steady_warm);
+            printf("     submits until output correct  : %8d  (delta after the 1st: %.3g)\n",
+                   ok_warm, d_warm);
+            printf("     eviction+recreation           : %8.3f ms\n", ms_evict_warm);
+
+            pool.push_back(std::move(fresh));
+
+            // Cold: drop every context of one design, then bring it back. Only
+            // meaningful when there is a second design to evict entirely.
+            if (designs.size() > 1) {
+                const int cold = 1;
+                t0 = now_ms();
+                pool.erase(std::remove_if(pool.begin(), pool.end(),
+                                          [&](const std::unique_ptr<live_kernel> & k) {
+                                              return k->design_id == cold;
+                                          }),
+                           pool.end());
+                const double ms_destroy_cold = now_ms() - t0;
+
+                build_cost cc;
+                t0 = now_ms();
+                auto revived = make_kernel(dev, designs[cold], tile, &cc);
+                const double ms_create_cold = now_ms() - t0;
+                ms_evict_cold = ms_destroy_cold + ms_create_cold;
+
+                fill_inputs(*revived, tile);
+                const sample fc = submit_timed(*revived);
+                us_first_cold   = fc.total_us;
+                csv.write("evict_cold_first", 0, designs[cold], revived->ctx_id, -1, fc);
+
+                const double d_cold  = verify_cpu(*revived, tile, designs[cold].op);
+                const int    ok_cold = d_cold < 1e-5
+                                           ? 1
+                                           : 1 + submits_until_correct(*revived, tile, designs[cold].op, 8);
+                ok_cold_n = ok_cold;
+
+                printf("   COLD  design fully evicted first (design %d)\n", cold);
+                printf("     destroy all its contexts      : %8.3f ms\n", ms_destroy_cold);
+                printf("     hw_context+kernel+BOs again   : %8.3f ms  (hwctx %.3f, kernel %.3f, BOs %.3f)\n",
+                       ms_create_cold, cc.ctx_ms, cc.kernel_ms, cc.bo_ms);
+                printf("     first invocation              : %8.1f us\n", us_first_cold);
+                printf("     submits until output correct  : %8d  (delta after the 1st: %.3g)\n",
+                       ok_cold, d_cold);
+                printf("     eviction+recreation           : %8.3f ms\n", ms_evict_cold);
+            }
+            printf("\n");
+        }
+
+        // The scenario suite needs free slots, and the pool is holding every one
+        // the driver will give out.
+        pool.clear();
+
+        // --- 6. the scenario suite -----------------------------------------
+        printf("6. scenarios: what changes between consecutive submits\n");
+        print_header();
+
+        std::vector<sample> s_aaaa;
+        std::vector<sample> s_mmmm;
+        std::vector<sample> s_amam;
+        std::vector<sample> s_a1a2;
+
+        {
+            auto a1 = make_kernel(dev, designs[0], tile);
+            fill_inputs(*a1, tile);
+
+            std::vector<live_kernel *> rot_a{ a1.get() };
+            s_aaaa = run_scenario("AAAA", rot_a, designs, n_warm, n_iter, csv);
+            const double d_a = verify_cpu(*a1, tile, designs[0].op);
+            print_row("AAAA  one context", s_aaaa);
+
+            if (batch > 1) {
+                const batch_result br =
+                    run_batch(*a1, batch, std::max(n_iter / batch, 20), std::min(n_warm, 8));
+                printf("   BATCH %d runs, one context           per op: "
+                       "%8.2f us separate / %.2f us as one runlist  (%.1fx)\n",
+                       batch, br.seq_us, br.list_us,
+                       br.list_us > 0 ? br.seq_us / br.list_us : 0.0);
+            }
+
+            // Same design, a second context of it: isolates the context switch
+            // from the fabric change.
+            auto a2 = make_kernel(dev, designs[0], tile);
+            fill_inputs(*a2, tile);
+            std::vector<live_kernel *> rot_a1a2{ a1.get(), a2.get() };
+            s_a1a2 = run_scenario("A1A2", rot_a1a2, designs, n_warm, n_iter, csv);
+            print_row("A1A2  two contexts, same xclbin", s_a1a2);
+
+            double d_m = -1;
+            if (designs.size() > 1) {
+                auto m1 = make_kernel(dev, designs[1], tile);
+                fill_inputs(*m1, tile);
+
+                std::vector<live_kernel *> rot_m{ m1.get() };
+                s_mmmm = run_scenario("MMMM", rot_m, designs, n_warm, n_iter, csv);
+                d_m    = verify_cpu(*m1, tile, designs[1].op);
+                print_row("MMMM  one context", s_mmmm);
+
+                std::vector<live_kernel *> rot_am{ a1.get(), m1.get() };
+                s_amam = run_scenario("AMAM", rot_am, designs, n_warm, n_iter, csv);
+                print_row("AMAM  two contexts, diff xclbin", s_amam);
+            }
+
+            printf("   cpu check                          A: %.3g %s   M: %.3g %s\n",
+                   d_a, d_a < 0 ? "(n/a)" : (d_a < 1e-5 ? "ok" : "FAILED"),
+                   d_m, d_m < 0 ? "(n/a)" : (d_m < 1e-5 ? "ok" : "FAILED"));
+        }
+
+        // --- 7. several sequences on one context ---------------------------
+        double us_mod_one    = 0;
+        double us_mod_rotate = 0;
+#ifdef XDNA_PROBE_HAS_AIEBU
+        printf("\n7. several instruction streams bound to ONE context\n");
+        print_header();
+        {
+            xrt::hw_context shared(dev, designs[0].uuid);
+            const int       shared_ctx_id = g_next_ctx_id++;
+
+            build_cost c;
+            std::vector<std::unique_ptr<live_module>> mods;
+            for (int i = 0; i < 8; i++) {
+                try {
+                    auto m = make_module_kernel(shared, designs[0], tile, shared_ctx_id,
+                                                i == 0 ? &c : nullptr);
+                    fill_inputs(*m, tile);
+                    mods.push_back(std::move(m));
+                } catch (const std::exception & e) {
+                    printf("   stopped at %zu modules: %s\n", mods.size(), e.what());
+                    break;
+                }
+            }
+
+            if (!mods.empty()) {
+                printf("   aiebu assemble, elf+module, kernel, BOs : %.3f, %.3f, %.3f, %.3f ms\n",
+                       c.asm_ms, c.module_ms, c.kernel_ms, c.bo_ms);
+
+                std::vector<live_module *> rot_one{ mods[0].get() };
+                const auto one = run_scenario("MOD1", rot_one, designs, n_warm, n_iter, csv);
+                us_mod_one     = summarize(one).mean_us;
+                print_row("one module", one);
+
+                const double d = verify_cpu(*mods[0], tile, designs[0].op);
+
+                if (mods.size() > 1) {
+                    std::vector<live_module *> rot_all;
+                    for (auto & m : mods) {
+                        rot_all.push_back(m.get());
+                    }
+                    const auto all  = run_scenario("MODN", rot_all, designs, n_warm, n_iter, csv);
+                    us_mod_rotate   = summarize(all).mean_us;
+                    char label[64];
+                    snprintf(label, sizeof(label), "rotating %zu modules", mods.size());
+                    print_row(label, all);
+                }
+                printf("   cpu check                          : %.3g %s\n",
+                       d, d < 0 ? "(n/a)" : (d < 1e-5 ? "ok" : "FAILED"));
+            }
+        }
+#else
+        printf("\n7. (built without aiebu - module path not compiled in)\n");
+#endif
+
+        // --- 8. the four numbers -------------------------------------------
+        const double m_aaaa = summarize(s_aaaa).mean_us;
+        const double m_mmmm = s_mmmm.empty() ? 0 : summarize(s_mmmm).mean_us;
+        const double m_amam = s_amam.empty() ? 0 : summarize(s_amam).mean_us;
+        const double m_a1a2 = summarize(s_a1a2).mean_us;
+
+        const double ov_mod  = (us_mod_one > 0 && us_mod_rotate > 0) ? us_mod_rotate - us_mod_one : 0;
+        const double ov_same = m_a1a2 - m_aaaa;
+        const double ov_diff = s_amam.empty() ? 0 : m_amam - (m_aaaa + m_mmmm) / 2.0;
+
+        printf("\nresults (run_id=%d)\n", run_id);
+        printf("   instruction/module rotation overhead: %8.1f us", ov_mod);
+        if (us_mod_one > 0) {
+            printf("   (%.1f -> %.1f)\n", us_mod_one, us_mod_rotate);
+        } else {
+            printf("   (not measured)\n");
+        }
+        printf("   same-XCLBIN context switch overhead: %8.1f us   (%.1f -> %.1f)\n",
+               ov_same, m_aaaa, m_a1a2);
+        if (!s_amam.empty()) {
+            printf("   different-XCLBIN switch overhead   : %8.1f us   (AMAM %.1f vs baseline %.1f)\n",
+                   ov_diff, m_amam, (m_aaaa + m_mmmm) / 2.0);
+        } else {
+            printf("   different-XCLBIN switch overhead   : (needs two designs)\n");
+        }
+        printf("   context eviction/recreation cost   : %8.3f ms  (design still resident: %.1f us first invoke)\n",
+               ms_evict_warm, us_first_warm);
+        if (ms_evict_cold > 0) {
+            printf("   same, design fully evicted first   : %8.3f ms  (%.1f us first invoke)\n",
+                   ms_evict_cold, us_first_cold);
+        }
+        printf("\n");
+
+        // One row per process run, so several runs can be pooled without having
+        // to re-derive the headline numbers from the per-sample rows.
+        if (!csv_path.empty()) {
+            const fs::path sp = fs::path(csv_path).replace_extension(".summary.csv");
+            const bool     ex = fs::exists(sp) && fs::file_size(sp) > 0;
+            FILE *         sf = fopen(sp.string().c_str(), "a");
+            if (sf) {
+                if (!ex) {
+                    fprintf(sf, "run_id,tile,n_iter,n_max_ctx,mean_aaaa_us,mean_mmmm_us,mean_amam_us,"
+                                "mean_a1a2_us,mean_mod1_us,mean_modn_us,ov_module_us,ov_same_xclbin_us,"
+                                "ov_diff_xclbin_us,ms_evict_warm,ms_evict_cold,us_first_warm,us_first_cold,"
+                                "us_steady_warm,submits_ok_warm,submits_ok_cold\n");
+                }
+                fprintf(sf, "%d,%zu,%d,%zu,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,"
+                            "%.4f,%.4f,%.2f,%.2f,%.2f,%d,%d\n",
+                        run_id, tile, n_iter, n_max_ctx,
+                        m_aaaa, m_mmmm, m_amam, m_a1a2, us_mod_one, us_mod_rotate,
+                        ov_mod, ov_same, ov_diff,
+                        ms_evict_warm, ms_evict_cold, us_first_warm, us_first_cold,
+                        us_steady_warm, ok_warm_n, ok_cold_n);
+                fclose(sf);
+            }
+        }
+
+    } catch (const std::exception & e) {
+        fprintf(stderr, "xdna-probe: failed: %s\n", e.what());
+        return 1;
+    }
+
+    return 0;
+}

--- a/scripts/run_llm_query.py
+++ b/scripts/run_llm_query.py
@@ -1,0 +1,971 @@
+#!/usr/bin/env python3
+"""Run a local llama.cpp completion and print the answer + performance metrics.
+
+Wraps ``llama-completion`` (CPU-friendly defaults for Qwen3.5). Parses stderr for
+device/buffer lines and ``common_perf_print`` timings.
+
+Each run writes under ``runs/{id}/``:
+
+  raw/         verbatim qvac / llama / ggml output (stdout, stderr, llama.log)
+  processed/   post-processed summary, layer-trace, result.json
+
+Example:
+  python3 scripts/run_llm_query.py "Explain what an NPU is in two sentences."
+  python3 scripts/run_llm_query.py -n 128 --json "Hello"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BIN = REPO_ROOT / "build" / "bin" / "llama-completion"
+DEFAULT_MODEL = REPO_ROOT / "models" / "weights" / "Qwen3.5-0.8B-Q4_K_M.gguf"
+DEFAULT_RUNS_DIR = REPO_ROOT / "runs"
+
+
+@dataclass
+class PerfMetrics:
+    sampling_ms: Optional[float] = None
+    samplers_ms: Optional[float] = None
+    samplers_tokens: Optional[int] = None
+    load_ms: Optional[float] = None
+    prompt_eval_ms: Optional[float] = None
+    prompt_tokens: Optional[int] = None
+    prompt_ms_per_token: Optional[float] = None
+    prompt_tokens_per_sec: Optional[float] = None
+    eval_ms: Optional[float] = None
+    eval_runs: Optional[int] = None
+    eval_ms_per_token: Optional[float] = None
+    eval_tokens_per_sec: Optional[float] = None
+    total_ms: Optional[float] = None
+    total_tokens: Optional[int] = None
+    unaccounted_ms: Optional[float] = None
+    unaccounted_pct: Optional[float] = None
+    graphs_reused: Optional[int] = None
+
+
+@dataclass
+class DeviceInfo:
+    arch: Optional[str] = None
+    system_info: Optional[str] = None
+    n_threads: Optional[int] = None
+    buffers: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    selected_backend: Optional[str] = None
+    xdna_selected: bool = False
+    xdna_messages: list[str] = field(default_factory=list)
+    graph_compute_lines: list[str] = field(default_factory=list)
+    device_info_lines: list[str] = field(default_factory=list)
+    supports_op_lines: list[str] = field(default_factory=list)
+    sched_split_lines: list[str] = field(default_factory=list)
+    sched_node_lines: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RunPaths:
+    """Layout of one ``runs/{id}/`` directory."""
+    run_id: str
+    run_dir: Path
+    raw_dir: Path
+    processed_dir: Path
+    stdout_path: Path
+    stderr_path: Path
+    llama_log_path: Path
+    command_path: Path
+    env_path: Path
+    summary_path: Path
+    layer_trace_path: Path
+    result_json_path: Path
+    meta_path: Path
+
+
+@dataclass
+class RunResult:
+    prompt: str
+    response: str
+    thinking: Optional[str]
+    wall_sec: float
+    exit_code: int
+    command: list[str]
+    perf: PerfMetrics
+    device: DeviceInfo
+    log_path: Optional[str]
+    raw_stdout: str
+    raw_stderr: str  # process stderr only
+    combined_log: str = ""  # preferred parse source (llama.log and/or stderr)
+    layer_trace: list["LayerStep"] = field(default_factory=list)
+    run_paths: Optional[RunPaths] = None
+
+
+_PERF_LINE = re.compile(
+    r"common_perf_print:\s*(?P<label>.+?)\s*=\s*(?P<body>.+)$"
+)
+_NUM = re.compile(r"([-+]?(?:\d+\.\d+|\d+)(?:[eE][-+]?\d+)?)")
+_ARCH = re.compile(r"print_info:\s*arch\s*=\s*(\S+)")
+_SYS = re.compile(r"system_info:\s*(.+)$")
+_THREADS = re.compile(r"n_threads\s*=\s*(\d+)")
+_BUFFER = re.compile(
+    r"(?:print_backend_buffers_info|llama_context|llama_kv_cache|"
+    r"llama_memory_recurrent|sched_reserve):\s*(.+)$"
+)
+_DEVICE_INFO_LINE = re.compile(r"^\s*-\s+(\S+)\s*:\s*(.+)$")
+_XDNA_MSG = re.compile(r"(ggml_backend_xdna\w*|XDNA)", re.IGNORECASE)
+# Scheduler assignment dump (GGML_SCHED_DEBUG>=1, needs -lv 5). Format from
+# ggml_backend_sched_print_assignments in ggml/src/ggml-backend.cpp:
+#   ## SPLIT #<n>: <backend> # <k> inputs
+#   node #<i> (<op>): <name> (<size>) [<backend> <cause>] use=<u>,c=<c>:
+_SCHED_SPLIT = re.compile(r"##\s*SPLIT\s*#(\d+):\s*(\S+)\s*#\s*(\d+)\s*inputs")
+_SCHED_NODE = re.compile(
+    r"node\s*#\s*(\d+)\s*\((.*?)\):\s*(.*?)\s*\(\s*(\S+)\s*\)\s*\[(.*?)\]"
+    r"(?:\s*use=(\d+),c=(\d+))?"
+)
+_THINK = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE)
+_ASSISTANT = re.compile(
+    r"(?:^|\n)assistant\s*\n(?P<body>.*)$",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _f(nums: list[float], idx: int = 0) -> Optional[float]:
+    return nums[idx] if len(nums) > idx else None
+
+
+def _i(nums: list[float], idx: int = 0) -> Optional[int]:
+    v = _f(nums, idx)
+    return int(v) if v is not None else None
+
+
+def parse_perf(stderr: str) -> PerfMetrics:
+    perf = PerfMetrics()
+    for raw in stderr.splitlines():
+        line = re.sub(r"\x1b\[[0-9;]*m", "", raw).strip()
+        m = _PERF_LINE.search(line)
+        if not m:
+            continue
+        label = m.group("label").strip()
+        body = m.group("body").strip()
+        nums = [float(x) for x in _NUM.findall(body)]
+        if label == "sampling time":
+            perf.sampling_ms = _f(nums)
+        elif label == "samplers time":
+            perf.samplers_ms = _f(nums, 0)
+            perf.samplers_tokens = _i(nums, 1)
+        elif label == "load time":
+            perf.load_ms = _f(nums)
+        elif label == "prompt eval time":
+            perf.prompt_eval_ms = _f(nums, 0)
+            perf.prompt_tokens = _i(nums, 1)
+            perf.prompt_ms_per_token = _f(nums, 2)
+            perf.prompt_tokens_per_sec = _f(nums, 3)
+        elif label == "eval time":
+            perf.eval_ms = _f(nums, 0)
+            perf.eval_runs = _i(nums, 1)
+            perf.eval_ms_per_token = _f(nums, 2)
+            perf.eval_tokens_per_sec = _f(nums, 3)
+        elif label == "total time":
+            perf.total_ms = _f(nums, 0)
+            perf.total_tokens = _i(nums, 1)
+        elif label == "unaccounted time":
+            perf.unaccounted_ms = _f(nums, 0)
+            perf.unaccounted_pct = _f(nums, 1)
+        elif label == "graphs reused":
+            perf.graphs_reused = _i(nums, 0)
+    return perf
+
+
+def parse_device(stderr: str, requested_device: Optional[str] = None) -> DeviceInfo:
+    info = DeviceInfo()
+    in_device_info = False
+    for raw in stderr.splitlines():
+        line = re.sub(r"\x1b\[[0-9;]*m", "", raw).rstrip()
+        stripped = line.strip()
+        if "warning:" in stripped.lower():
+            info.warnings.append(stripped)
+        if "device_info:" in stripped:
+            in_device_info = True
+            continue
+        if in_device_info:
+            dm = _DEVICE_INFO_LINE.match(line)
+            if dm:
+                info.device_info_lines.append(f"{dm.group(1)}: {dm.group(2).strip()}")
+                continue
+            if stripped and not stripped.startswith("-"):
+                in_device_info = False
+        if "xdna" in stripped.lower() and (
+            "selected backend" in stripped.lower()
+            or "initializing xdna" in stripped.lower()
+            or "ggml_backend_xdna" in stripped.lower()
+        ):
+            if stripped not in info.xdna_messages:
+                info.xdna_messages.append(stripped)
+            info.xdna_selected = True
+        if "ggml-xdna:" in stripped or "supports_op(" in stripped:
+            if "supports_op" in stripped or "supports_op stats" in stripped or "graph scheduling debug" in stripped:
+                if stripped not in info.supports_op_lines:
+                    info.supports_op_lines.append(stripped)
+                info.xdna_selected = True
+            if "graph_compute" in stripped:
+                if len(info.graph_compute_lines) < 24 and stripped not in info.graph_compute_lines:
+                    info.graph_compute_lines.append(stripped)
+                info.xdna_selected = True
+        if stripped.startswith("## SPLIT") or "SPLIT #" in stripped:
+            if stripped not in info.sched_split_lines:
+                info.sched_split_lines.append(stripped)
+        if stripped.startswith("node #") and ("[" in stripped):
+            # Keep a small sample of scheduler node→backend assignments
+            if len(info.sched_node_lines) < 40 and stripped not in info.sched_node_lines:
+                info.sched_node_lines.append(stripped)
+        m = _ARCH.search(line)
+        if m:
+            info.arch = m.group(1)
+        m = _SYS.search(line)
+        if m:
+            info.system_info = m.group(1).strip()
+            tm = _THREADS.search(info.system_info)
+            if tm:
+                info.n_threads = int(tm.group(1))
+        m = _BUFFER.search(line)
+        if m and ("buffer" in m.group(1).lower() or "CPU" in m.group(1) or "Metal" in m.group(1) or "XDNA" in m.group(1)):
+            info.buffers.append(m.group(1).strip())
+
+    if requested_device:
+        info.selected_backend = requested_device
+        if requested_device.upper() == "XDNA":
+            info.xdna_selected = True
+    elif info.xdna_selected:
+        info.selected_backend = "XDNA"
+    elif any("XDNA" in x for x in info.device_info_lines):
+        info.selected_backend = "XDNA"
+        info.xdna_selected = True
+    return info
+
+
+@dataclass
+class LayerStep:
+    idx: int
+    op: str
+    name: str
+    size: str
+    backend: str
+    cause: str
+    compute: bool
+    split: int
+    split_backend: str
+
+
+def parse_layer_trace(text: str) -> list[LayerStep]:
+    """Extract one graph's ordered op→backend assignments.
+
+    The scheduler reprints the assignment on every (re)split, so several
+    identical blocks can appear. We keep the *first* complete block (node #0
+    up to the last node before node #0 shows up again) — that is the prompt
+    graph and contains every layer in execution order.
+    """
+    steps: list[LayerStep] = []
+    cur_split = -1
+    cur_split_backend = "?"
+    started = False
+    for raw in text.splitlines():
+        line = re.sub(r"\x1b\[[0-9;]*m", "", raw).strip()
+
+        sm = _SCHED_SPLIT.search(line)
+        if sm:
+            cur_split = int(sm.group(1))
+            cur_split_backend = sm.group(2)
+            continue
+
+        nm = _SCHED_NODE.search(line)
+        if not nm:
+            continue
+
+        idx = int(nm.group(1))
+        # A second node #0 means the next graph eval started — stop after the
+        # first full block so the trace is a single, complete layer sequence.
+        if idx == 0 and started and steps:
+            break
+        started = True
+
+        bracket = nm.group(5).split()
+        backend = bracket[0] if bracket else "?"
+        cause = " ".join(bracket[1:]) if len(bracket) > 1 else ""
+        compute = nm.group(7) is None or nm.group(7) == "1"
+
+        steps.append(LayerStep(
+            idx=idx,
+            op=nm.group(2).strip(),
+            name=nm.group(3).strip(),
+            size=nm.group(4).strip(),
+            backend=backend,
+            cause=cause,
+            compute=compute,
+            split=cur_split,
+            split_backend=cur_split_backend,
+        ))
+    return steps
+
+
+def write_layer_trace(path: Path, result: "RunResult") -> int:
+    """Write the per-node execution trace (op → device) to ``path``.
+
+    Returns the number of compute nodes written. One line per node in graph
+    order: index, op, tensor name, size, and the backend that ran it.
+    """
+    steps = result.layer_trace
+    counts: dict[str, int] = {}
+    for s in steps:
+        if s.compute:
+            counts[s.backend] = counts.get(s.backend, 0) + 1
+
+    lines: list[str] = []
+    lines.append(f"# layer/op execution trace (op -> device), graph order")
+    lines.append(f"# prompt: {result.prompt!r}")
+    lines.append(f"# command: {' '.join(result.command)}")
+    if counts:
+        summary = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+        lines.append(f"# compute nodes by backend: {summary}")
+    lines.append(f"# total nodes: {len(steps)}")
+    lines.append("#")
+    lines.append(f"# {'idx':>4}  {'split':>5}  {'op':<12}  {'device':<6}  {'compute':<7}  {'size':>7}  name  [cause]")
+
+    last_split = None
+    for s in steps:
+        if s.split != last_split:
+            lines.append(f"# --- SPLIT #{s.split} -> {s.split_backend} ---")
+            last_split = s.split
+        flag = "run" if s.compute else "-"
+        cause = f"  [{s.cause}]" if s.cause else ""
+        lines.append(
+            f"  {s.idx:>4}  {s.split:>5}  {s.op:<12}  {s.backend:<6}  {flag:<7}  {s.size:>7}  {s.name}{cause}"
+        )
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return sum(counts.values())
+
+
+def extract_response(stdout: str) -> tuple[str, Optional[str]]:
+    text = stdout.strip()
+    # Drop ggml/llama debug lines that sometimes leak onto stdout at high -lv.
+    cleaned: list[str] = []
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("ggml-xdna:") or s.startswith("ggml_") or s.startswith("llama_"):
+            continue
+        if s.startswith("common_perf_print:") or s.startswith("## SPLIT"):
+            continue
+        cleaned.append(line)
+    text = "\n".join(cleaned).strip()
+
+    m = _ASSISTANT.search(text)
+    body = m.group("body").strip() if m else text
+
+    thinking: Optional[str] = None
+    tm = _THINK.search(body)
+    if tm:
+        thinking = tm.group(1).strip() or None
+        body = _THINK.sub("", body).strip()
+    else:
+        # Truncated generation often leaves an unclosed <think>… block.
+        open_m = re.search(r"<think>(.*)$", body, re.DOTALL | re.IGNORECASE)
+        if open_m:
+            thinking = open_m.group(1).strip() or None
+            body = body[: open_m.start()].strip()
+
+    # Drop trailing interactive markers if any
+    for marker in ("> EOF by user", "Exiting...", "[end of text]"):
+        if marker in body:
+            body = body.split(marker, 1)[0].strip()
+
+    return body, thinking
+
+
+def _xdna_mode_summary(d: DeviceInfo) -> str:
+    """Human-readable XDNA mode from init / graph_compute lines."""
+    init = next((m for m in d.xdna_messages if "XDNA backend init" in m), "")
+    bits: list[str] = []
+    if "ADD=NPU" in init:
+        bits.append("ADD on NPU")
+    elif "ADD=host" in init:
+        bits.append("ADD on host")
+    if "MUL_MAT=NPU" in init:
+        bits.append("MUL_MAT on NPU")
+    elif "GEMM_NPU=0" in init or "MUL_MAT=host" in init:
+        bits.append("MUL_MAT on CPU backend (not claimed)")
+    if any("on=NPU" in m and "MUL_MAT" in m for m in d.graph_compute_lines):
+        bits.append("saw NPU MUL_MAT runs")
+    if any("on=NPU" in m and "ADD" in m for m in d.graph_compute_lines):
+        bits.append("saw NPU ADD runs")
+    if bits:
+        return "; ".join(bits)
+    if d.xdna_selected:
+        return "XDNA device selected (see init / supports_op)"
+    return "n/a"
+
+
+def make_run_id(explicit: Optional[str] = None) -> str:
+    if explicit:
+        return explicit
+    return datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def allocate_run_dir(runs_dir: Path, run_id: str) -> Path:
+    """Create ``runs_dir/run_id``, appending -2, -3, … on collision."""
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    candidate = runs_dir / run_id
+    if not candidate.exists():
+        candidate.mkdir(parents=True)
+        return candidate
+    n = 2
+    while True:
+        alt = runs_dir / f"{run_id}-{n}"
+        if not alt.exists():
+            alt.mkdir(parents=True)
+            return alt
+        n += 1
+
+
+def prepare_run_paths(runs_dir: Path, run_id: Optional[str] = None) -> RunPaths:
+    rid = make_run_id(run_id)
+    run_dir = allocate_run_dir(runs_dir, rid)
+    raw_dir = run_dir / "raw"
+    processed_dir = run_dir / "processed"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    processed_dir.mkdir(parents=True, exist_ok=True)
+    return RunPaths(
+        run_id=run_dir.name,
+        run_dir=run_dir,
+        raw_dir=raw_dir,
+        processed_dir=processed_dir,
+        stdout_path=raw_dir / "stdout.txt",
+        stderr_path=raw_dir / "stderr.txt",
+        llama_log_path=raw_dir / "llama.log",
+        command_path=raw_dir / "command.txt",
+        env_path=raw_dir / "env.txt",
+        summary_path=processed_dir / "summary.txt",
+        layer_trace_path=processed_dir / "layer-trace.txt",
+        result_json_path=processed_dir / "result.json",
+        meta_path=run_dir / "meta.json",
+    )
+
+
+def write_raw_artifacts(
+    paths: RunPaths,
+    cmd: list[str],
+    env: dict[str, str],
+    stdout: str,
+    stderr: str,
+) -> None:
+    paths.command_path.write_text(" ".join(cmd) + "\n", encoding="utf-8")
+    interesting = sorted(
+        k for k in env
+        if k.startswith("GGML_") or k.startswith("XDNA") or k in ("XILINX_XRT", "LD_LIBRARY_PATH")
+    )
+    env_lines = [f"{k}={env.get(k, '')}" for k in interesting]
+    paths.env_path.write_text("\n".join(env_lines) + ("\n" if env_lines else ""), encoding="utf-8")
+    paths.stdout_path.write_text(stdout, encoding="utf-8", errors="replace")
+    paths.stderr_path.write_text(stderr, encoding="utf-8", errors="replace")
+    # llama.log is filled by llama-completion via --log-file; leave a stub if empty.
+    if not paths.llama_log_path.exists():
+        paths.llama_log_path.write_text("", encoding="utf-8")
+
+
+def write_processed_artifacts(
+    paths: RunPaths,
+    result: RunResult,
+    summary_text: str,
+    layers_written: int,
+) -> None:
+    paths.summary_path.write_text(summary_text, encoding="utf-8")
+    if result.layer_trace:
+        write_layer_trace(paths.layer_trace_path, result)
+    else:
+        paths.layer_trace_path.write_text(
+            "# no scheduler assignment lines captured — need GGML_SCHED_DEBUG=2 and -lv >= 5\n",
+            encoding="utf-8",
+        )
+    payload = {
+        "run_id": paths.run_id,
+        "prompt": result.prompt,
+        "response": result.response,
+        "thinking": result.thinking,
+        "wall_sec": result.wall_sec,
+        "exit_code": result.exit_code,
+        "command": result.command,
+        "perf": asdict(result.perf),
+        "device": asdict(result.device),
+        "layer_trace": [asdict(s) for s in result.layer_trace],
+        "layer_trace_compute_nodes": layers_written,
+    }
+    paths.result_json_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    meta = {
+        "run_id": paths.run_id,
+        "created_at": datetime.now().isoformat(timespec="seconds"),
+        "exit_code": result.exit_code,
+        "prompt": result.prompt,
+        "raw": {
+            "stdout": str(paths.stdout_path.relative_to(paths.run_dir)),
+            "stderr": str(paths.stderr_path.relative_to(paths.run_dir)),
+            "llama_log": str(paths.llama_log_path.relative_to(paths.run_dir)),
+            "command": str(paths.command_path.relative_to(paths.run_dir)),
+            "env": str(paths.env_path.relative_to(paths.run_dir)),
+        },
+        "processed": {
+            "summary": str(paths.summary_path.relative_to(paths.run_dir)),
+            "layer_trace": str(paths.layer_trace_path.relative_to(paths.run_dir)),
+            "result_json": str(paths.result_json_path.relative_to(paths.run_dir)),
+        },
+    }
+    paths.meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def default_threads() -> int:
+    # Prefer portable os.cpu_count(); fall back to platform helpers.
+    n = os.cpu_count()
+    if n and n > 0:
+        return n
+    try:
+        out = subprocess.check_output(["nproc"], text=True).strip()
+        return max(1, int(out))
+    except (OSError, ValueError, subprocess.CalledProcessError):
+        pass
+    try:
+        # macOS
+        out = subprocess.check_output(["sysctl", "-n", "hw.ncpu"], text=True).strip()
+        return max(1, int(out))
+    except (OSError, ValueError, subprocess.CalledProcessError):
+        return 4
+
+
+def build_cmd(args: argparse.Namespace) -> list[str]:
+    cmd = [
+        str(args.bin),
+        "-m", str(args.model),
+        "-ngl", str(args.ngl),
+        "-c", str(args.ctx),
+        "-n", str(args.n_predict),
+        "-t", str(args.threads),
+        "-lv", str(args.verbosity),
+        "--perf",
+        "--single-turn",
+        "-fit", "off",
+        "-p", args.prompt,
+    ]
+    if args.device:
+        cmd.extend(["-dev", args.device])
+    if args.no_warmup:
+        cmd.append("--no-warmup")
+    if args.log_file:
+        cmd.extend(["--log-file", str(args.log_file)])
+    if args.extra:
+        cmd.extend(args.extra)
+    return cmd
+
+
+def run_query(args: argparse.Namespace) -> RunResult:
+    if not Path(args.bin).is_file():
+        raise FileNotFoundError(f"Binary not found: {args.bin}")
+    if not Path(args.model).is_file():
+        raise FileNotFoundError(f"Model not found: {args.model}")
+
+    run_paths: Optional[RunPaths] = None
+    if args.runs_dir is not None:
+        run_paths = prepare_run_paths(Path(args.runs_dir), args.run_id)
+        print(f"run_llm_query: run dir {run_paths.run_dir}", file=sys.stderr, flush=True)
+
+    if args.log_file is not None:
+        log_path = Path(args.log_file)
+    elif run_paths is not None:
+        log_path = run_paths.llama_log_path
+    else:
+        log_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"llm-query-{os.getpid()}.log"
+
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    # Point llama --log-file at the raw llama log before building the command.
+    args.log_file = log_path
+
+    cmd = build_cmd(args)
+    if "--log-file" not in cmd:
+        cmd.extend(["--log-file", str(log_path)])
+
+    if args.device:
+        print(
+            f"run_llm_query: selecting backend device '{args.device}'",
+            file=sys.stderr,
+            flush=True,
+        )
+
+    env = os.environ.copy()
+    if args.xdna_debug is not None:
+        env["GGML_XDNA_DEBUG"] = str(args.xdna_debug)
+    elif args.device and str(args.device).upper() == "XDNA":
+        env.setdefault("GGML_XDNA_DEBUG", "1")
+    if args.sched_debug is not None:
+        env["GGML_SCHED_DEBUG"] = str(args.sched_debug)
+
+    print(
+        f"run_llm_query: GGML_XDNA_DEBUG={env.get('GGML_XDNA_DEBUG', '0')} "
+        f"GGML_SCHED_DEBUG={env.get('GGML_SCHED_DEBUG', '0')}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+    t0 = time.perf_counter()
+    proc = subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    wall = time.perf_counter() - t0
+
+    stdout = proc.stdout or ""
+    stderr = proc.stderr or ""
+    log_text = ""
+    try:
+        log_text = Path(log_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        pass
+
+    if run_paths is not None:
+        write_raw_artifacts(run_paths, cmd, env, stdout, stderr)
+        # Ensure llama.log exists even if the binary wrote elsewhere / nothing.
+        if not run_paths.llama_log_path.exists() or run_paths.llama_log_path.stat().st_size == 0:
+            if log_text:
+                run_paths.llama_log_path.write_text(log_text, encoding="utf-8", errors="replace")
+            elif log_path.resolve() != run_paths.llama_log_path.resolve() and Path(log_path).is_file():
+                run_paths.llama_log_path.write_text(
+                    Path(log_path).read_text(encoding="utf-8", errors="replace"),
+                    encoding="utf-8",
+                    errors="replace",
+                )
+
+    # Prefer the log file when it has the verbose load dump; else stderr.
+    if "common_perf_print" in log_text or "print_backend_buffers_info" in log_text:
+        combined = log_text
+        if stderr and "warning:" in stderr.lower() and "warning:" not in log_text.lower():
+            combined = stderr + "\n" + log_text
+    else:
+        combined = stderr or log_text
+
+    device = parse_device(combined, requested_device=args.device)
+    seen: set[str] = set()
+    unique_buffers: list[str] = []
+    for b in device.buffers:
+        if b not in seen:
+            seen.add(b)
+            unique_buffers.append(b)
+    device.buffers = unique_buffers
+
+    response, thinking = extract_response(stdout)
+    return RunResult(
+        prompt=args.prompt,
+        response=response,
+        thinking=thinking,
+        wall_sec=wall,
+        exit_code=proc.returncode,
+        command=cmd,
+        perf=parse_perf(combined),
+        device=device,
+        log_path=str(log_path),
+        raw_stdout=stdout,
+        raw_stderr=stderr,
+        combined_log=combined,
+        layer_trace=parse_layer_trace(combined),
+        run_paths=run_paths,
+    )
+
+
+def format_human(result: RunResult, show_thinking: bool, show_raw: bool) -> str:
+    p = result.perf
+    d = result.device
+    out: list[str] = []
+
+    def w(line: str = "") -> None:
+        out.append(line)
+
+    w("=" * 72)
+    w("BACKEND")
+    w("=" * 72)
+    if d.xdna_selected or (d.selected_backend and d.selected_backend.upper() == "XDNA"):
+        w("selected:    XDNA")
+        w(f"mode:        {_xdna_mode_summary(d)}")
+    else:
+        w(f"selected:    {d.selected_backend or 'default / CPU'}")
+    if d.xdna_messages:
+        w("xdna logs:")
+        for msg in d.xdna_messages:
+            w(f"  - {msg}")
+    elif d.xdna_selected:
+        w("xdna logs:   (requested via -dev XDNA; see device_info below)")
+    if d.supports_op_lines:
+        w("supports_op:")
+        uniq = [m for m in d.supports_op_lines if "supports_op(" in m or "graph scheduling debug" in m]
+        stats = [m for m in d.supports_op_lines if "supports_op stats" in m]
+        for msg in uniq:
+            w(f"  - {msg}")
+        if stats:
+            w(f"  - {stats[-1]}")
+        w(f"  ({len(uniq)} lines; set --xdna-debug 2 for denser stats)")
+    if d.graph_compute_lines:
+        w("graph_compute sample (proof XDNA ran the op):")
+        for msg in d.graph_compute_lines[:12]:
+            w(f"  - {msg}")
+        if len(d.graph_compute_lines) > 12:
+            w(f"  - ... ({len(d.graph_compute_lines)} unique lines captured)")
+    if d.sched_split_lines or d.sched_node_lines:
+        w("scheduler graph splits:")
+        for msg in d.sched_split_lines[:20]:
+            w(f"  - {msg}")
+        if d.sched_node_lines:
+            w("scheduler node sample (op → backend):")
+            for msg in d.sched_node_lines[:20]:
+                w(f"  - {msg}")
+            if len(d.sched_node_lines) >= 40:
+                w("  - ... (truncated; full dump is in raw/llama.log)")
+    if d.device_info_lines:
+        w("device_info:")
+        for line in d.device_info_lines:
+            w(f"  - {line}")
+    w()
+
+    w("=" * 72)
+    w("PROMPT")
+    w("=" * 72)
+    w(result.prompt)
+    w()
+
+    show_think = show_thinking or (bool(result.thinking) and not result.response)
+    if show_think and result.thinking:
+        w("=" * 72)
+        w("THINKING" + ("" if result.response else " (truncated — raise -n for a final answer)"))
+        w("=" * 72)
+        w(result.thinking)
+        w()
+
+    w("=" * 72)
+    w("RESPONSE")
+    w("=" * 72)
+    if result.response:
+        w(result.response)
+    elif result.thinking:
+        w("(empty — all -n tokens went into <think>; try -n 128 or --thinking)")
+    else:
+        w("(empty)")
+    w()
+
+    w("=" * 72)
+    w("DEVICE / BUFFERS")
+    w("=" * 72)
+    w(f"arch:        {d.arch or 'n/a'}")
+    w(f"n_threads:   {d.n_threads or 'n/a'}")
+    w(f"system_info: {d.system_info or 'n/a'}")
+    if d.buffers:
+        w("buffers:")
+        for b in d.buffers:
+            w(f"  - {b}")
+    else:
+        w("buffers:     (none parsed — try -lv 4)")
+    if d.warnings:
+        w("warnings:")
+        for warn in d.warnings[:8]:
+            w(f"  - {warn}")
+    w()
+
+    w("=" * 72)
+    w("PERFORMANCE")
+    w("=" * 72)
+    w(f"wall clock:           {result.wall_sec * 1000:.2f} ms")
+    w(f"load time:            {fmt_ms(p.load_ms)}")
+    w(f"prompt eval:          {fmt_ms(p.prompt_eval_ms)} / {fmt_int(p.prompt_tokens)} tok"
+      f"  ({fmt_ms(p.prompt_ms_per_token)}/tok, {fmt_tps(p.prompt_tokens_per_sec)})")
+    w(f"generation (eval):    {fmt_ms(p.eval_ms)} / {fmt_int(p.eval_runs)} tok"
+      f"  ({fmt_ms(p.eval_ms_per_token)}/tok, {fmt_tps(p.eval_tokens_per_sec)})")
+    w(f"sampling:             {fmt_ms(p.sampling_ms)}")
+    w(f"total (libllama):     {fmt_ms(p.total_ms)} / {fmt_int(p.total_tokens)} tok")
+    w(f"unaccounted:          {fmt_ms(p.unaccounted_ms)} ({fmt_pct(p.unaccounted_pct)})")
+    w(f"graphs reused:        {fmt_int(p.graphs_reused)}")
+    w(f"exit code:            {result.exit_code}")
+    if result.run_paths is not None:
+        w(f"run dir:              {result.run_paths.run_dir}")
+        w(f"raw llama log:        {result.run_paths.llama_log_path}")
+    else:
+        w(f"log file:             {result.log_path}")
+    w()
+
+    if show_raw:
+        w("=" * 72)
+        w("RAW COMBINED LOG (tail)")
+        w("=" * 72)
+        lines = (result.combined_log or result.raw_stderr).strip().splitlines()
+        w("\n".join(lines[-40:]))
+
+    return "\n".join(out) + "\n"
+
+
+def print_human(result: RunResult, show_thinking: bool, show_raw: bool) -> str:
+    text = format_human(result, show_thinking=show_thinking, show_raw=show_raw)
+    sys.stdout.write(text)
+    return text
+
+
+def fmt_ms(v: Optional[float]) -> str:
+    return "n/a" if v is None else f"{v:.2f} ms"
+
+
+def fmt_tps(v: Optional[float]) -> str:
+    if v is None:
+        return "n/a"
+    if v != v or v == float("inf"):  # NaN or inf
+        return "n/a"
+    return f"{v:.2f} t/s"
+
+
+def fmt_pct(v: Optional[float]) -> str:
+    return "n/a" if v is None else f"{v:.1f} %"
+
+
+def fmt_int(v: Optional[int]) -> str:
+    return "n/a" if v is None else str(v)
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Run local LLM via llama-completion and print answer + metrics.",
+    )
+    p.add_argument("prompt", nargs="?", help="User prompt / question")
+    p.add_argument("-m", "--model", type=Path, default=DEFAULT_MODEL, help="GGUF model path")
+    p.add_argument("--bin", type=Path, default=DEFAULT_BIN, help="llama-completion binary")
+    p.add_argument("-n", "--n-predict", type=int, default=128, help="Max tokens to generate")
+    p.add_argument("-c", "--ctx", type=int, default=2048, help="Context size")
+    p.add_argument("-t", "--threads", type=int, default=0, help="CPU threads (0 = auto)")
+    p.add_argument("-ngl", type=int, default=0, help="GPU layers (0 = keep model weights on CPU)")
+    p.add_argument("-dev", "--device", default="XDNA",
+                   help="Offload device to select (default: XDNA). Use 'none' to disable.")
+    p.add_argument("--xdna-debug", type=int, default=None, metavar="N",
+                   help="Set GGML_XDNA_DEBUG (default 1 when -dev XDNA). "
+                        "1=unique supports_op fallbacks, 2=verbose per-call")
+    p.add_argument("--sched-debug", type=int, default=2, metavar="N",
+                   help="Set GGML_SCHED_DEBUG (default 2). "
+                        "1=graph split lines only, 2=per-node op->backend assignment "
+                        "(needed for the layer-trace file). Requires -lv >= 5 (auto-raised when >0).")
+    p.add_argument("-lv", "--verbosity", type=int, default=4, help="Log verbosity (3=info, 4=trace, 5=debug)")
+    p.add_argument("--runs-dir", type=Path, default=DEFAULT_RUNS_DIR,
+                   help=f"Root directory for per-run artifacts (default: {DEFAULT_RUNS_DIR})")
+    p.add_argument("--no-runs-dir", dest="runs_dir", action="store_const", const=None,
+                   help="Do not create a runs/{{id}} directory")
+    p.add_argument("--run-id", default=None,
+                   help="Run id under --runs-dir (default: YYYYMMDD-HHMMSS)")
+    p.add_argument("--log-file", type=Path, default=None,
+                   help="Override path for raw llama --log-file "
+                        "(default: runs/{{id}}/raw/llama.log)")
+    p.add_argument("--layers-file", type=Path, default=None, metavar="PATH",
+                   help="Also write layer-trace to this path "
+                        "(always written to runs/{{id}}/processed/layer-trace.txt when --runs-dir is set)")
+    p.add_argument("--no-layers-file", dest="layers_file", action="store_const", const=False,
+                   help="Do not write an extra layer-trace copy outside the run dir")
+    p.add_argument("--warmup", dest="no_warmup", action="store_false", default=True,
+                   help="Enable model warmup (default: disabled)")
+    p.add_argument("--thinking", action="store_true", help="Print model thinking block")
+    p.add_argument("--raw", action="store_true", help="Print tail of raw logs")
+    p.add_argument("--json", action="store_true", help="Emit machine-readable JSON to stdout")
+    p.add_argument("--extra", nargs=argparse.REMAINDER, default=[],
+                   help="Extra args after -- passed to llama-completion")
+    args = p.parse_args(argv)
+    if not args.prompt:
+        p.error("prompt is required")
+    if args.threads <= 0:
+        args.threads = default_threads()
+    if args.device and args.device.lower() == "none":
+        args.device = "none"
+    # GGML_LOG_DEBUG (scheduler splits/nodes) maps to common LOG_LEVEL_DEBUG=5
+    if args.sched_debug and args.sched_debug > 0 and args.verbosity < 5:
+        args.verbosity = 5
+    # argparse.REMAINDER keeps leading '--' if present
+    if args.extra and args.extra[0] == "--":
+        args.extra = args.extra[1:]
+    # layers_file: None → default copy to cwd only if no runs dir;
+    # False → disabled; Path → explicit extra copy.
+    if args.layers_file is None and args.runs_dir is None:
+        args.layers_file = REPO_ROOT / "layer-trace.txt"
+    return args
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = run_query(args)
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    layers_written = 0
+    if result.layer_trace:
+        layers_written = sum(1 for s in result.layer_trace if s.compute)
+
+    # Extra layer-trace copy outside the run dir (legacy / convenience).
+    if args.layers_file not in (None, False) and isinstance(args.layers_file, Path):
+        if result.layer_trace:
+            write_layer_trace(args.layers_file, result)
+        else:
+            args.layers_file.write_text(
+                "# no scheduler assignment lines captured — need GGML_SCHED_DEBUG=2 and -lv >= 5\n",
+                encoding="utf-8",
+            )
+
+    summary_text = format_human(result, show_thinking=args.thinking, show_raw=args.raw)
+
+    if result.run_paths is not None:
+        write_processed_artifacts(
+            result.run_paths, result, summary_text, layers_written=layers_written,
+        )
+
+    if args.json:
+        payload: dict[str, Any] = {
+            "prompt": result.prompt,
+            "response": result.response,
+            "thinking": result.thinking,
+            "wall_sec": result.wall_sec,
+            "exit_code": result.exit_code,
+            "command": result.command,
+            "log_path": result.log_path,
+            "run_dir": str(result.run_paths.run_dir) if result.run_paths else None,
+            "run_id": result.run_paths.run_id if result.run_paths else None,
+            "perf": asdict(result.perf),
+            "device": asdict(result.device),
+            "layer_trace": [asdict(s) for s in result.layer_trace],
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        sys.stdout.write(summary_text)
+        if result.run_paths is not None:
+            print("=" * 72)
+            print("RUN ARTIFACTS")
+            print("=" * 72)
+            print(f"run dir:     {result.run_paths.run_dir}")
+            print(f"raw:         {result.run_paths.raw_dir}")
+            print(f"processed:   {result.run_paths.processed_dir}")
+            print(f"layer-trace: {result.run_paths.layer_trace_path} "
+                  f"({len(result.layer_trace)} nodes, {layers_written} compute)")
+            print()
+
+    return 0 if result.exit_code == 0 else result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -872,7 +872,7 @@ llm_ffn_op_type llm_ffn_op_type_from_string(const std::string & name, llm_ffn_op
 static buft_list_t make_cpu_buft_list(const std::vector<llama_device> & devices, bool use_extra_bufts, bool no_host) {
     buft_list_t buft_list;
 
-    // add ACCEL buffer types
+    // add ACCEL buffer types, and their extra buffer types (repacked weights)
     for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
         ggml_backend_dev_t dev = ggml_backend_dev_get(i);
         if (ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_ACCEL) {
@@ -880,6 +880,21 @@ static buft_list_t make_cpu_buft_list(const std::vector<llama_device> & devices,
             // skip
             if (buft != ggml_backend_cpu_buffer_type()) {
                 buft_list.emplace_back(dev, buft);
+            }
+
+            if (use_extra_bufts) {
+                auto * reg = ggml_backend_dev_backend_reg(dev);
+                auto ggml_backend_dev_get_extra_bufts_fn = (ggml_backend_dev_get_extra_bufts_t)
+                    ggml_backend_reg_get_proc_address(reg, "ggml_backend_dev_get_extra_bufts");
+                if (ggml_backend_dev_get_extra_bufts_fn) {
+                    ggml_backend_buffer_type_t * extra_bufts = ggml_backend_dev_get_extra_bufts_fn(dev);
+                    while (extra_bufts && *extra_bufts) {
+                        if (*extra_bufts != buft) {
+                            buft_list.emplace_back(dev, *extra_bufts);
+                        }
+                        ++extra_bufts;
+                    }
+                }
             }
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -248,6 +248,32 @@ endif()
 llama_build_and_test(test-gguf.cpp)
 llama_build_and_test(test-backend-ops.cpp)
 
+if (GGML_XDNA)
+    llama_build(test-xdna-production.cpp)
+    target_link_libraries(test-xdna-production PRIVATE ggml-xdna)
+
+    add_test(NAME test-xdna-production-micro
+        COMMAND ${CMAKE_COMMAND} -E env
+            GGML_XDNA_NPU=1
+            GGML_XDNA_OWN_GRAPH=1
+            $<TARGET_FILE:test-xdna-production> micro)
+    add_test(NAME test-xdna-production-fallback
+        COMMAND ${CMAKE_COMMAND} -E env
+            GGML_XDNA_NPU=1
+            GGML_XDNA_OWN_GRAPH=1
+            $<TARGET_FILE:test-xdna-production> fallback)
+    add_test(NAME test-xdna-production-no-npu
+        COMMAND ${CMAKE_COMMAND} -E env
+            GGML_XDNA_NPU=0
+            GGML_XDNA_OWN_GRAPH=1
+            $<TARGET_FILE:test-xdna-production> no-npu)
+    set_tests_properties(
+        test-xdna-production-micro
+        test-xdna-production-fallback
+        test-xdna-production-no-npu
+        PROPERTIES LABELS "xdna" SKIP_RETURN_CODE 77)
+endif()
+
 # Vulkan TBQ/PQ copy-to-quant subgroup-size sweep. Spawns itself with different
 # GGML_VK_TBQ_COPY_SG_SIZE values to exercise the shader's cross-subgroup stitch
 # path on hardware that only exposes one native subgroup size. Auto-skips when no

--- a/tests/test-xdna-production.cpp
+++ b/tests/test-xdna-production.cpp
@@ -1,0 +1,281 @@
+#include "ggml.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "ggml-xdna.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using backend_ptr = std::unique_ptr<ggml_backend, decltype(&ggml_backend_free)>;
+using buffer_ptr  = std::unique_ptr<ggml_backend_buffer, decltype(&ggml_backend_buffer_free)>;
+using context_ptr = std::unique_ptr<ggml_context, decltype(&ggml_free)>;
+
+using get_npu_call_count_fn = uint64_t (*)(ggml_backend_t backend);
+
+static constexpr int SKIP = 77;
+
+struct matrix_data {
+    std::vector<uint8_t> weights;
+    std::vector<float>   activations;
+};
+
+static matrix_data make_data(ggml_type type, int64_t k, int64_t n, int64_t m) {
+    std::vector<float> weights_f32((size_t) k * n);
+    std::vector<float> activations((size_t) k * m);
+
+    for (size_t i = 0; i < weights_f32.size(); ++i) {
+        weights_f32[i] = 0.125f * std::sin((float) (i % 251) * 0.071f);
+    }
+    for (size_t i = 0; i < activations.size(); ++i) {
+        activations[i] = 0.25f * std::cos((float) (i % 127) * 0.053f);
+    }
+
+    std::vector<uint8_t> weights(ggml_row_size(type, k) * n);
+    if (type == GGML_TYPE_F32) {
+        std::memcpy(weights.data(), weights_f32.data(), weights.size());
+    } else {
+        const size_t written = ggml_quantize_chunk(
+            type, weights_f32.data(), weights.data(), 0, n, k, nullptr);
+        if (written != weights.size()) {
+            throw std::runtime_error("weight quantization size mismatch");
+        }
+    }
+
+    return { std::move(weights), std::move(activations) };
+}
+
+static std::vector<float> run_standard(
+        ggml_backend_t backend, ggml_type type,
+        int64_t k, int64_t n, int64_t m, const matrix_data & data,
+        bool * supported = nullptr) {
+    context_ptr ctx(ggml_init({
+        /* .mem_size   = */ 1024 * 1024,
+        /* .mem_buffer = */ nullptr,
+        /* .no_alloc   = */ true,
+    }), ggml_free);
+    if (!ctx) {
+        throw std::runtime_error("ggml_init failed");
+    }
+
+    ggml_tensor * weights = ggml_new_tensor_2d(ctx.get(), type, k, n);
+    ggml_tensor * acts    = ggml_new_tensor_2d(ctx.get(), GGML_TYPE_F32, k, m);
+    ggml_tensor * output  = ggml_mul_mat(ctx.get(), weights, acts);
+    ggml_cgraph * graph   = ggml_new_graph(ctx.get());
+    ggml_build_forward_expand(graph, output);
+
+    buffer_ptr buffer(ggml_backend_alloc_ctx_tensors(ctx.get(), backend), ggml_backend_buffer_free);
+    if (!buffer) {
+        throw std::runtime_error("standard tensor allocation failed");
+    }
+
+    ggml_backend_tensor_set(weights, data.weights.data(), 0, data.weights.size());
+    ggml_backend_tensor_set(acts, data.activations.data(), 0, data.activations.size() * sizeof(float));
+    if (supported) {
+        *supported = ggml_backend_supports_op(backend, output);
+    }
+
+    const ggml_status status = ggml_backend_graph_compute(backend, graph);
+    if (status != GGML_STATUS_SUCCESS) {
+        throw std::runtime_error("standard graph compute failed");
+    }
+
+    std::vector<float> result(ggml_nelements(output));
+    ggml_backend_tensor_get(output, result.data(), 0, result.size() * sizeof(float));
+    return result;
+}
+
+static std::vector<float> run_repacked(
+        ggml_backend_t backend, ggml_backend_buffer_type_t repack_buft,
+        int64_t k, int64_t n, int64_t m, const matrix_data & data) {
+    context_ptr ctx(ggml_init({
+        /* .mem_size   = */ 1024 * 1024,
+        /* .mem_buffer = */ nullptr,
+        /* .no_alloc   = */ true,
+    }), ggml_free);
+    if (!ctx) {
+        throw std::runtime_error("ggml_init failed");
+    }
+
+    ggml_tensor * weights = ggml_new_tensor_2d(ctx.get(), GGML_TYPE_Q4_K, k, n);
+    ggml_set_name(weights, "phase1.weight");
+
+    buffer_ptr weight_buffer(
+        ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), repack_buft),
+        ggml_backend_buffer_free);
+    if (!weight_buffer) {
+        throw std::runtime_error("XDNA_REPACK allocation failed");
+    }
+    if (std::strcmp(ggml_backend_buffer_name(weight_buffer.get()), "XDNA_REPACK") != 0) {
+        throw std::runtime_error("weight did not use XDNA_REPACK");
+    }
+    ggml_backend_tensor_set(weights, data.weights.data(), 0, data.weights.size());
+
+    ggml_tensor * acts   = ggml_new_tensor_2d(ctx.get(), GGML_TYPE_F32, k, m);
+    ggml_tensor * output = ggml_mul_mat(ctx.get(), weights, acts);
+    ggml_set_name(output, "phase1.mul_mat");
+    ggml_cgraph * graph = ggml_new_graph(ctx.get());
+    ggml_build_forward_expand(graph, output);
+
+    buffer_ptr compute_buffer(ggml_backend_alloc_ctx_tensors(ctx.get(), backend), ggml_backend_buffer_free);
+    if (!compute_buffer) {
+        throw std::runtime_error("XDNA compute tensor allocation failed");
+    }
+    ggml_backend_tensor_set(acts, data.activations.data(), 0, data.activations.size() * sizeof(float));
+
+    if (!ggml_backend_supports_op(backend, output)) {
+        throw std::runtime_error("XDNA does not support the repacked MUL_MAT");
+    }
+    const ggml_status status = ggml_backend_graph_compute(backend, graph);
+    if (status != GGML_STATUS_SUCCESS) {
+        throw std::runtime_error("XDNA graph compute failed");
+    }
+
+    std::vector<float> result(ggml_nelements(output));
+    ggml_backend_tensor_get(output, result.data(), 0, result.size() * sizeof(float));
+    return result;
+}
+
+static double nmse(const std::vector<float> & ref, const std::vector<float> & got) {
+    double square_error = 0.0;
+    double square_ref   = 1e-30;
+    for (size_t i = 0; i < ref.size(); ++i) {
+        if (!std::isfinite(got[i])) {
+            return INFINITY;
+        }
+        const double diff = (double) got[i] - ref[i];
+        square_error += diff * diff;
+        square_ref   += (double) ref[i] * ref[i];
+    }
+    return square_error / square_ref;
+}
+
+static get_npu_call_count_fn get_call_counter(ggml_backend_reg_t reg) {
+    return (get_npu_call_count_fn) ggml_backend_reg_get_proc_address(
+        reg, "ggml_backend_xdna_get_npu_call_count");
+}
+
+static int test_micro() {
+    constexpr int64_t K = 256;
+    constexpr int64_t N = 512;
+    constexpr int64_t M = 128;
+    constexpr double TOL = 5e-4;
+
+    ggml_backend_reg_t reg = ggml_backend_xdna_reg();
+    ggml_backend_dev_t dev = ggml_backend_reg_dev_get(reg, 0);
+    backend_ptr xdna(ggml_backend_xdna_init(), ggml_backend_free);
+    backend_ptr cpu(ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr), ggml_backend_free);
+    if (!xdna || !cpu) {
+        throw std::runtime_error("backend initialization failed");
+    }
+
+    auto get_extra = (ggml_backend_dev_get_extra_bufts_t)
+        ggml_backend_reg_get_proc_address(reg, "ggml_backend_dev_get_extra_bufts");
+    get_npu_call_count_fn get_calls = get_call_counter(reg);
+    ggml_backend_buffer_type_t * extra = get_extra ? get_extra(dev) : nullptr;
+    if (!extra || !extra[0]) {
+        std::printf("SKIP: XDNA NPU or GEMM artifact is unavailable\n");
+        return SKIP;
+    }
+    if (!get_calls) {
+        throw std::runtime_error("XDNA NPU call counter is unavailable");
+    }
+
+    matrix_data data = make_data(GGML_TYPE_Q4_K, K, N, M);
+    const std::vector<float> ref = run_standard(cpu.get(), GGML_TYPE_Q4_K, K, N, M, data);
+    const uint64_t calls_before = get_calls(xdna.get());
+    const std::vector<float> got = run_repacked(xdna.get(), extra[0], K, N, M, data);
+    const uint64_t calls_after = get_calls(xdna.get());
+    const double error = nmse(ref, got);
+
+    std::printf("micro: Q4_K K=%lld N=%lld M=%lld buffer=XDNA_REPACK calls=%llu->%llu nmse=%.3e tol=%.1e\n",
+        (long long) K, (long long) N, (long long) M,
+        (unsigned long long) calls_before, (unsigned long long) calls_after, error, TOL);
+    if (calls_after <= calls_before) {
+        std::fprintf(stderr, "FAIL: supported MUL_MAT did not submit to the NPU\n");
+        return 1;
+    }
+    if (error > TOL) {
+        std::fprintf(stderr, "FAIL: micro NMSE exceeds tolerance\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int test_fallback(bool npu_disabled) {
+    const int64_t K = npu_disabled ? 16 : 256;
+    const int64_t N = npu_disabled ? 17 : 513;
+    const int64_t M = npu_disabled ? 4 : 128;
+    const ggml_type type = npu_disabled ? GGML_TYPE_F32 : GGML_TYPE_Q4_K;
+    constexpr double TOL = 1e-12;
+
+    ggml_backend_reg_t reg = ggml_backend_xdna_reg();
+    backend_ptr xdna(ggml_backend_xdna_init(), ggml_backend_free);
+    backend_ptr cpu(ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr), ggml_backend_free);
+    if (!xdna || !cpu) {
+        throw std::runtime_error("backend initialization failed");
+    }
+    get_npu_call_count_fn get_calls = get_call_counter(reg);
+    if (!get_calls) {
+        throw std::runtime_error("XDNA NPU call counter is unavailable");
+    }
+
+    matrix_data data = make_data(type, K, N, M);
+    const std::vector<float> ref = run_standard(cpu.get(), type, K, N, M, data);
+    const uint64_t calls_before = get_calls(xdna.get());
+    bool claimed = false;
+    const std::vector<float> got = run_standard(xdna.get(), type, K, N, M, data, &claimed);
+    const uint64_t calls_after = get_calls(xdna.get());
+    const double error = nmse(ref, got);
+
+    std::printf("%s: %s K=%lld N=%lld M=%lld claimed=%s calls=%llu->%llu nmse=%.3e tol=%.1e\n",
+        npu_disabled ? "no-npu" : "fallback", ggml_type_name(type),
+        (long long) K, (long long) N, (long long) M, claimed ? "yes" : "no",
+        (unsigned long long) calls_before, (unsigned long long) calls_after, error, TOL);
+    if (!npu_disabled && !claimed) {
+        std::fprintf(stderr, "FAIL: own_graph did not claim the unsupported shape\n");
+        return 1;
+    }
+    if (calls_after != calls_before) {
+        std::fprintf(stderr, "FAIL: CPU fallback incremented the NPU call count\n");
+        return 1;
+    }
+    if (error > TOL) {
+        std::fprintf(stderr, "FAIL: CPU fallback differs from the CPU reference\n");
+        return 1;
+    }
+    return 0;
+}
+
+int main(int argc, char ** argv) {
+    if (argc != 2) {
+        std::fprintf(stderr, "usage: %s micro|fallback|no-npu\n", argv[0]);
+        return 2;
+    }
+
+    try {
+        const std::string mode = argv[1];
+        int result;
+        if (mode == "micro") {
+            result = test_micro();
+        } else if (mode == "fallback") {
+            result = test_fallback(false);
+        } else if (mode == "no-npu") {
+            result = test_fallback(true);
+        } else {
+            std::fprintf(stderr, "unknown mode: %s\n", argv[1]);
+            return 2;
+        }
+        ggml_quantize_free();
+        return result;
+    } catch (const std::exception & error) {
+        std::fprintf(stderr, "FAIL: %s\n", error.what());
+        ggml_quantize_free();
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Adds an AMD XDNA (NPU) backend for ggml: weight `MUL_MAT` operations are
offloaded to the AMD XDNA2 NPU via IRON (mlir-aie), while all other ops
continue to run on the standard GGML CPU backend. Includes a selective
hybrid CPU/NPU execution path tuned for Qwen3.5.

This is a **draft PR** — opening it early to get feedback on the approach
and backend integration points before finalizing. Not ready to merge yet.

## What's included

- New `ggml-xdna` backend (`ggml/src/ggml-xdna/`) with IRON-based kernel
  build pipeline (`ggml/src/ggml-xdna/iron/`)
- `--device XDNA` support for routing weight GEMMs to the NPU
- Selective hybrid execution: NPU handles GEMM, CPU handles the rest
- Documentation of the validated setup, dependencies, and known toolchain
  pitfalls in `docs/backend/XDNA.md`

## Validated environment

Built and measured on one machine so far:

- ASUS ProArt PX13 HN7306EA, AMD Ryzen AI MAX+ 395 (Strix Halo), NPU `aie2p`
- Ubuntu 24.04.4, XRT 2.25.37, `amdxdna` driver 2.25.260102.56
- IRON: mlir-aie **1.3.4** + llvm-aie 21
- Models tested: Qwen3.5-0.8B (Q4_K_M, BF16), Qwen3.5-9B (Q4_K_M)