### PR TITLE
xdna : add AMD XDNA backend with first NPU GEMM kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Enhanced GPU support with targeted optimizations for Qualcomm Adreno GPUs.
 - Adreno-specific Vulkan shader variants for improved throughput.
 - Vulkan Memory Allocator (VMA) integration for efficient GPU memory management.
 
+### AMD XDNA (NPU) Backend *(exclusive)*
+
+Offloads GEMM (matrix multiplication) to the AMD XDNA NPU (Ryzen AI, NPU2) via XRT for inference on Strix-class APUs. See [ggml/src/ggml-xdna/README.md](ggml/src/ggml-xdna/README.md) for build and usage instructions.
+
+Requires Linux with an NPU2 (XDNA2) device, XRT 2.25.x (installed under `/opt/xilinx/xrt`) and a Python interpreter with mlir-aie (IRON) to compile the kernels at build time. Enable with `-DGGML_XDNA=ON`.
+
 
 ## Quick Start
 
@@ -111,6 +117,11 @@ cmake --build build --config Release
 
 # With Metal support (macOS, iOS)
 cmake -B build -DGGML_METAL=ON
+cmake --build build --config Release
+
+# With AMD XDNA NPU support (Linux, Strix-class APUs)
+cmake -B build -DGGML_XDNA=ON -DGGML_OPENMP=ON \
+      -DGGML_XDNA_GEMM_PYTHON=$HOME/aie-env/bin/python
 cmake --build build --config Release
 ```
 

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -268,6 +268,7 @@ set   (GGML_OPENCL_TARGET_VERSION "300" CACHE STRING
                                             "ggml: OpenCL API version to target")
 
 option(GGML_HEXAGON                         "ggml: enable Hexagon backend"                    OFF)
+option(GGML_XDNA                            "ggml: enable AMD XDNA/NPU backend"               OFF)
 
 # toolchain for vulkan-shaders-gen
 set   (GGML_VULKAN_SHADERS_GEN_TOOLCHAIN "" CACHE FILEPATH "ggml: toolchain file for vulkan-shaders-gen")

--- a/ggml/include/ggml-xdna.h
+++ b/ggml/include/ggml-xdna.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+// backend API
+GGML_BACKEND_API ggml_backend_t ggml_backend_xdna_init(void);
+
+GGML_BACKEND_API bool ggml_backend_is_xdna(ggml_backend_t backend);
+
+GGML_BACKEND_API ggml_backend_reg_t ggml_backend_xdna_reg(void);
+
+#ifdef  __cplusplus
+}
+#endif

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -506,6 +506,7 @@ ggml_add_backend(WebGPU)
 ggml_add_backend(zDNN)
 ggml_add_backend(OpenCL)
 ggml_add_backend(Hexagon)
+ggml_add_backend(XDNA)
 ggml_add_backend(ZenDNN)
 ggml_add_backend(OPENVINO)
 

--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -64,6 +64,10 @@
 #include "ggml-hexagon.h"
 #endif
 
+#ifdef GGML_USE_XDNA
+#include "ggml-xdna.h"
+#endif
+
 #ifdef GGML_USE_BLAS
 #include "ggml-blas.h"
 #endif
@@ -150,6 +154,9 @@ struct ggml_backend_registry {
 #endif
 #ifdef GGML_USE_HEXAGON
         register_backend(ggml_backend_hexagon_reg());
+#endif
+#ifdef GGML_USE_XDNA
+        register_backend(ggml_backend_xdna_reg());
 #endif
 #ifdef GGML_USE_CANN
         register_backend(ggml_backend_cann_reg());

--- a/ggml/src/ggml-xdna/CMakeLists.txt
+++ b/ggml/src/ggml-xdna/CMakeLists.txt
@@ -1,0 +1,128 @@
+list(APPEND CMAKE_PREFIX_PATH /opt/xilinx/xrt)
+find_package(AIEBU)
+find_package(xrt REQUIRED)
+
+ggml_add_backend_library(ggml-xdna
+                         ggml-xdna.cpp
+                         xdna-runtime.cpp
+                         xdna-kernel-pool.cpp
+                         xdna-seq.cpp
+                         xdna-ops.cpp
+                        )
+
+target_link_libraries(ggml-xdna PRIVATE XRT::xrt_coreutil)
+
+# Two GEMM geometries baked into the IRON designs (see kernels/gemm.py): the
+# decode M-block (M32, native bf16 r=4, exact) and a larger prefill M-block
+# (M64, bfp16-emulated r=8, 2x mmul). The backend target receives the same
+# values as compile definitions, so xdna_gemm_tiles (xdna-seq.h) and the
+# kernel compiles stay in sync.
+set(XDNA_GEMM_M 32)         # decode M block (tile_m * n_compute_rows)
+set(XDNA_TILE_M 8)          # decode per-core M tile (r=4 native bf16)
+set(XDNA_GEMM_M_BIG 64)     # prefill M block
+set(XDNA_TILE_M_BIG 16)     # prefill per-core M tile (2*r for the bfp16 r=8 mmul)
+set(XDNA_TILE_K 64)         # per-core K tile (larger = fewer C reloads per call)
+set(XDNA_TILE_N 64)         # per-core N tile (wider = longer B DDR bursts)
+set(XDNA_N_COLS 8)          # AIE columns
+set(XDNA_N_COMPUTE_ROWS 4)  # compute tile rows
+
+target_compile_definitions(ggml-xdna PRIVATE
+    GGML_XDNA_GEMM_M=${XDNA_GEMM_M}
+    GGML_XDNA_TILE_M=${XDNA_TILE_M}
+    GGML_XDNA_GEMM_M_BIG=${XDNA_GEMM_M_BIG}
+    GGML_XDNA_TILE_M_BIG=${XDNA_TILE_M_BIG}
+    GGML_XDNA_TILE_K=${XDNA_TILE_K}
+    GGML_XDNA_TILE_N=${XDNA_TILE_N}
+    GGML_XDNA_N_COLS=${XDNA_N_COLS}
+    GGML_XDNA_N_COMPUTE_ROWS=${XDNA_N_COMPUTE_ROWS}
+)
+
+# NPU kernels are compiled out-of-line by kernels/gemm.py (IRON/MLIR-AIE) at
+# build time. Each variant is a (K N) tuple; M and the tiles are fixed by the
+# geometry above. Artifacts land in the runtime output directory and are loaded
+# from there (or the executable directory / cwd) at runtime. The .insts.bin is
+# a reference copy of the compiled DMA sequence; the runtime builds streams.
+option(GGML_XDNA_BUILD_KERNELS "ggml-xdna: build NPU GEMM kernels (requires IRON)" ON)
+set(GGML_XDNA_GEMM_PYTHON "" CACHE FILEPATH
+    "ggml-xdna: python interpreter with IRON (mlir_aie + llvm-aie) installed")
+
+# GEMM variants to build: "K N". K must be a multiple of 8, N of 256.
+set(GGML_XDNA_GEMM_VARIANTS
+    "1024 2048"
+)
+
+if (GGML_XDNA_BUILD_KERNELS)
+    if (GGML_XDNA_GEMM_PYTHON)
+        set(GEMM_PYTHON ${GGML_XDNA_GEMM_PYTHON})
+    else()
+        find_package(Python3 REQUIRED COMPONENTS Interpreter)
+        set(GEMM_PYTHON ${Python3_EXECUTABLE})
+    endif()
+
+    # The build only needs IRON when kernels are actually compiled; disable
+    # silently if the interpreter lacks it (the backend still builds).
+    execute_process(
+        COMMAND ${GEMM_PYTHON} -c "import aie.iron, aie.helpers.taplib, aie.iron.kernels"
+        RESULT_VARIABLE GEMM_IRON_RESULT
+        OUTPUT_QUIET ERROR_QUIET
+    )
+    if (NOT GEMM_IRON_RESULT EQUAL 0)
+        message(WARNING "ggml-xdna: IRON not found in ${GEMM_PYTHON}; skipping kernel build")
+        set(GGML_XDNA_BUILD_KERNELS OFF)
+    endif()
+endif()
+
+if (GGML_XDNA_BUILD_KERNELS)
+    set(GEMM_DIR "${CMAKE_CURRENT_SOURCE_DIR}/kernels")
+    set(XDNA_ARTIFACTS "")
+
+    # Geometry: "M tile_m bfp16(0/1)". Stems must match the runtime scan in
+    # xdna_ops_init (gemm_bf16_f32_M%d_K%d_N%d_c%d).
+    set(XDNA_GEOMETRIES
+        "${XDNA_GEMM_M} ${XDNA_TILE_M} 0"
+        "${XDNA_GEMM_M_BIG} ${XDNA_TILE_M_BIG} 1"
+    )
+
+    foreach(g IN LISTS XDNA_GEOMETRIES)
+        string(REPLACE " " ";" FIELDS "${g}")
+        list(GET FIELDS 0 M_VAL)
+        list(GET FIELDS 1 TM_VAL)
+        list(GET FIELDS 2 BFP16_VAL)
+
+        # Artifact stem matches the runtime cache key exactly.
+        set(KERNEL_STEM "gemm_bf16_f32_M${M_VAL}_K1024_N2048_c${XDNA_N_COLS}")
+        set(XCLBIN "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KERNEL_STEM}.xclbin")
+        set(INSTS  "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KERNEL_STEM}.insts.bin")
+
+        if (BFP16_VAL EQUAL 0)
+            set(BFP16_ARGS "--no-bfp16")
+        else()
+            set(BFP16_ARGS "")
+        endif()
+
+        add_custom_command(
+            OUTPUT ${XCLBIN} ${INSTS}
+            COMMAND ${GEMM_PYTHON} "${GEMM_DIR}/gemm.py"
+                    -M ${M_VAL} -K 1024 -N 2048
+                    --tile-m ${TM_VAL}
+                    --tile-k ${XDNA_TILE_K}
+                    --tile-n ${XDNA_TILE_N}
+                    --n-aie-cols ${XDNA_N_COLS}
+                    --n-aie-rows ${XDNA_N_COMPUTE_ROWS}
+                    -d npu2
+                    ${BFP16_ARGS}
+                    --xclbin-path ${XCLBIN}
+                    --insts-path ${INSTS}
+            DEPENDS "${GEMM_DIR}/gemm.py"
+            WORKING_DIRECTORY "${GEMM_DIR}"
+            COMMENT "ggml-xdna: compiling GEMM kernel M${M_VAL} K1024 N2048 bfp16=${BFP16_VAL} c${XDNA_N_COLS}"
+            VERBATIM
+        )
+
+        list(APPEND XDNA_ARTIFACTS ${XCLBIN} ${INSTS})
+    endforeach()
+
+    add_custom_target(ggml-xdna-kernels ALL DEPENDS ${XDNA_ARTIFACTS})
+
+    install(FILES ${XDNA_ARTIFACTS} DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()

--- a/ggml/src/ggml-xdna/README.md
+++ b/ggml/src/ggml-xdna/README.md
@@ -1,0 +1,156 @@
+# ggml-xdna: AMD XDNA (NPU) backend
+
+A ggml backend that offloads matrix multiplication (GEMM) to the AMD XDNA NPU
+(Ryzen AI, NPU2: Strix Point / Strix Halo / Krackan) through XRT. It is a
+scaffold: only `MUL_MAT` is implemented, everything else stays on the CPU.
+
+## What runs on the NPU
+
+`MUL_MAT` ops that satisfy `gemm_supported` (xdna-ops.cpp):
+
+- `src0` weights of type `BF16`, `F16` or `Q4_K` (Q4_K_S); `src1` activations
+  and result `F32`. Quantized weights are dequantized once at pack time and
+  cached as bf16 in the weight BO, so the NPU kernel is the same for every
+  type.
+- 2D contiguous tensors (no batch dimensions).
+- `N <= 16384`: wide projections (e.g. the vocabulary output layer) stay on
+  the CPU.
+- `K` is any multiple of `tile_k` (64), and a multiple of 256 for `Q4_K`;
+  wide-K ops are split into blocks.
+
+Both prefill and decode are covered. Prefill tiles the M dimension into
+32-row blocks; decode runs as `M = 1`. The final vocab projection is the only
+model GEMM that does not go to the NPU.
+
+### Hardware constraints
+
+- The kernel is BF16-in / F32-out only.
+- Every K-block is capped at 1024 (`GEMM_K_MAX`) and partial blocks are
+  zero-padded. The cap was originally added for a context-local hang observed
+  at `K_div_k > 64` with `tile_k = 16`; with the current driver the hang no
+  longer reproduces, but the conservative cap is kept.
+
+## Requirements
+
+- Linux with an AMD NPU2 (XDNA2) device (Strix Point / Strix Halo / Krackan);
+  the NPU shows up as `/dev/accel/accel0` and in `xrt-smi examine`.
+- XRT 2.25.37 installed under `/opt/xilinx/xrt`. Put the XRT tools on the
+  PATH: `export PATH=/opt/xilinx/xrt/bin:$PATH` (`xclbinutil` is needed when
+  building kernels, `xrt-smi` to inspect the device).
+- A Python interpreter with mlir-aie (IRON) and llvm-aie to compile the kernel
+  at build time (tested with mlir-aie 1.4.1, llvm-aie 21).
+- For the standalone kernel harness (`kernels/gemm.py --run`, `bstream.py`)
+  also export `PYTHONPATH=/opt/xilinx/xrt/python` so `pyxrt` imports.
+
+## Build
+
+```sh
+export PATH=/opt/xilinx/xrt/bin:$PATH
+
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_XDNA=ON -DGGML_OPENMP=ON \
+      -DGGML_XDNA_BUILD_KERNELS=ON \
+      -DGGML_XDNA_GEMM_PYTHON=$HOME/aie-env/bin/python
+cmake --build build -j$(nproc) --target llama-completion llama-server ggml-xdna-kernels
+```
+
+- `GGML_XDNA=ON` enables the backend.
+- `GGML_OPENMP=ON` is recommended: with `OMP_WAIT_POLICY=PASSIVE` the CPU idle
+  cost of waiting on the NPU drops to near zero.
+- `GGML_XDNA_BUILD_KERNELS=ON` (default) compiles the GEMM xclbin via
+  `kernels/gemm.py`. It is skipped if IRON is not importable; the backend
+  still builds.
+- `GGML_XDNA_GEMM_PYTHON` overrides the interpreter used for the kernel build;
+  point it at the local IRON (mlir-aie) install, e.g. `$HOME/aie-env/bin/python`
+  or `$HOME/ironenv-v2/bin/python`.
+- `GGML_XDNA_GEMM_VARIANTS` lists the `"K N"` variants to compile (default
+  `"1024 2048"`). A single xclbin serves every shape; the geometry is fixed by
+  the `XDNA_*` variables in this directory's CMakeLists, which are also passed
+  to the C++ code as `GGML_XDNA_*` compile definitions (xdna-seq.h).
+
+The kernel artifacts (`gemm_bf16_f32_M32_K1024_N2048_c8.xclbin` and
+`gemm_bf16_f32_M64_K1024_N2048_c8.xclbin`, plus `.insts.bin`) land in the
+build output directory (`build/bin`). At
+runtime they are looked up in the backend install dir, the executable dir and
+the working directory. The `.insts.bin` files are reference copies of the
+compiled DMA sequences; the runtime builds its own instruction streams.
+
+## Running
+
+The NPU shows up as a normal ACCEL device; use the default `-ngl 99` to place
+all layers on it:
+
+```sh
+OMP_WAIT_POLICY=PASSIVE ./build/bin/llama-server -m model.gguf \
+    --reasoning off --poll 0 --port 8080
+```
+
+Decode benchmark (single stream):
+
+```sh
+OMP_WAIT_POLICY=PASSIVE ./build/bin/llama-completion -m model.gguf \
+    -p "The capital of France is" -n 32 -t 8 -ngl 99 --poll 0 \
+    -s 42 --top-k 1 --temp 0
+```
+
+- `--list-devices` shows the NPU; `--device none` forces pure-CPU execution
+  (e.g. for a correctness baseline).
+- `--poll 0` prevents the threadpool from busy-polling while waiting for the
+  NPU.
+- `GGML_XDNA_PROFILING=1` prints a per-`MUL_MAT` timing breakdown and a
+  `FINALIZE` summary to stderr.
+
+Server flags used for the numbers in "Performance expectations":
+
+```sh
+OMP_WAIT_POLICY=PASSIVE ./build/bin/llama-server -m model.gguf \
+    -c 147456 -np 4 -b 4096 -ub 4096 --flash-attn off -t 16 --poll 0 \
+    --reasoning off --port 8080
+```
+
+### Correctness check
+
+Compare greedy output against the CPU baseline (sampling is not randomized, so
+any difference is a real numerical mismatch):
+
+```sh
+./build/bin/llama-completion -m model.gguf -p "The capital of France is" \
+    -n 64 -t 4 -ngl 99 -s 42 --poll 0 --top-k 1 --temp 0          # NPU
+./build/bin/llama-completion -m model.gguf -p "The capital of France is" \
+    -n 64 -t 4 -ngl 99 -s 42 --poll 0 --top-k 1 --temp 0 --device none  # CPU
+```
+
+The assistant text must match. With non-greedy sampling the outputs can diverge
+between runs even with the same seed: M-tiling and K-splitting change the
+accumulation order, which shifts logits within BF16 tolerance and flips sampled
+tokens. This is expected.
+
+### Performance expectations
+
+Measured with the `npu-two-kernel` branch (Qwen3.5-0.8B Q4_K_M, llama-server
+`-c 147456 -np 4 -b 4096 -ub 4096 --flash-attn off -t 16 --poll 0
+--reasoning off`, harness 3 warmup + 8 measured, 128 decode tokens; t/s):
+
+| Context | CPU prefill | XDNA prefill | CPU decode | XDNA decode |
+| ------: | ----------: | -----------: | ---------: | ----------: |
+|    1024 |       669.3 |        415.5 |       66.4 |        23.0 |
+|    4096 |       664.0 |        405.3 |       62.5 |        22.3 |
+|   16384 |       561.9 |        357.1 |       49.8 |        20.8 |
+|   32768 |       480.9 |        331.4 |       39.2 |        18.7 |
+
+Decode runs as nested CPU on phase1 (`M = 1`). The NPU rail draws ~0.7-0.9 W
+while decoding; the benefit on an edge/fabric device is freeing the CPU for
+other work, not raw throughput (XDNA decode is ~0.35-0.48x the CPU baseline).
+Time to first token at 1k context is ~2.5 s.
+
+## Code layout
+
+| File | Role |
+| :-- | :-- |
+| `ggml-xdna.cpp` | Backend/device/registry scaffolding (ggml-backend-impl). |
+| `xdna-runtime.h/.cpp` | XRT primitives: device, kernel load + insts bind, host buffers, run submit/wait. |
+| `xdna-kernel-pool.cpp` | Kernel + buffer pools, artifact scanning. |
+| `xdna-seq.h/.cpp` | TXN instruction-stream builder and the GEMM sequence. |
+| `xdna-ops.h/.cpp` | Per-op dispatch: GEMM support check, compute, finalize. |
+| `xdna-profile.h` | Optional per-op timing (`GGML_XDNA_PROFILING`). |
+| `kernels/gemm.py` | IRON design compiled to the xclbin at build time; also a standalone run/trace harness (`--run`, `--trace-size`). |
+| `kernels/bstream.py` | DDR read-bandwidth probe for the shim DMA (sequential vs strided B patterns). |

--- a/ggml/src/ggml-xdna/ggml-xdna.cpp
+++ b/ggml/src/ggml-xdna/ggml-xdna.cpp
@@ -1,0 +1,297 @@
+#include "ggml-impl.h"
+#include "ggml-xdna.h"
+#include "ggml-backend-impl.h"
+
+#include "xdna-types.h"
+#include "xdna-runtime.h"
+#include "xdna-ops.h"
+
+#include <mutex>
+#include <string>
+
+#ifdef _WIN32
+#    include <windows.h>
+#else
+#    include <unistd.h>
+#endif
+
+// Process-wide context shared by all backend instances. The xdna_device holds
+// the name/description, so nothing is duplicated here.
+struct ggml_backend_xdna_context {
+    xdna_device * device = nullptr;
+    xdna_kernel_pool * pool = nullptr;   // lazily scanned kernel pool
+
+    xdna_ops ops;   // operator-specific dispatch (GEMM variants, helpers)
+};
+
+static ggml_backend_xdna_context * ggml_xdna_device_context(void) {
+    static ggml_backend_xdna_context ctx;
+    static std::once_flag once;
+
+    std::call_once(once, [&]() {
+        ctx.device = xdna_device_open();
+        if (ctx.device) {
+            ctx.pool = new xdna_kernel_pool;
+            ctx.pool->device = ctx.device;
+            xdna_kernel_pool_scan(ctx.pool);
+            xdna_ops_init(&ctx.ops, ctx.pool);
+            if (ctx.ops.gemm_xclbin_decode.empty() && ctx.ops.gemm_xclbin_prefill.empty()) {
+                GGML_LOG_WARN("%s: no GEMM kernels found (build with GGML_XDNA=ON)\n", "ggml-xdna");
+            }
+        }
+    });
+
+    return &ctx;
+}
+
+// backend interface
+
+static const char * ggml_backend_xdna_get_name(ggml_backend_t backend) {
+    GGML_UNUSED(backend);
+    return "XDNA";
+}
+
+static void ggml_backend_xdna_free(ggml_backend_t backend) {
+    // The context is a process-wide singleton; it is not freed here.
+    GGML_UNUSED(backend);
+    delete backend;
+}
+
+static bool ggml_xdna_is_view_op(enum ggml_op op) {
+    switch (op) {
+        case GGML_OP_NONE:
+        case GGML_OP_RESHAPE:
+        case GGML_OP_VIEW:
+        case GGML_OP_PERMUTE:
+        case GGML_OP_TRANSPOSE:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static enum ggml_status ggml_backend_xdna_graph_compute(ggml_backend_t backend, struct ggml_cgraph * cgraph) {
+    ggml_backend_xdna_context * ctx = (ggml_backend_xdna_context *) backend->context;
+
+    if (!ctx->device) {
+        return GGML_STATUS_SUCCESS;
+    }
+
+    // The scheduler routes ops accepted by supports_op plus the view ops that
+    // alias their data; views are no-ops here. Kernels are submitted (started)
+    // per op and finalized once at the end, so all runs of the graph overlap.
+    for (int i = 0; i < cgraph->n_nodes; i++) {
+        struct ggml_tensor * node = cgraph->nodes[i];
+        if (ggml_xdna_is_view_op(node->op)) {
+            continue;
+        }
+        if (!xdna_ops_compute(&ctx->ops, node)) {
+            xdna_ops_finalize(&ctx->ops);
+            return GGML_STATUS_FAILED;
+        }
+    }
+    if (!xdna_ops_finalize(&ctx->ops)) {
+        return GGML_STATUS_FAILED;
+    }
+    return GGML_STATUS_SUCCESS;
+}
+
+static struct ggml_backend_i xdna_backend_i = {
+    /* .get_name                = */ ggml_backend_xdna_get_name,
+    /* .free                    = */ ggml_backend_xdna_free,
+    /* .set_tensor_async        = */ NULL,
+    /* .get_tensor_async        = */ NULL,
+    /* .set_tensor_2d_async     = */ NULL,
+    /* .get_tensor_2d_async     = */ NULL,
+    /* .cpy_tensor_async        = */ NULL,
+    /* .synchronize             = */ NULL,
+    /* .graph_plan_create       = */ NULL,
+    /* .graph_plan_free         = */ NULL,
+    /* .graph_plan_update       = */ NULL,
+    /* .graph_plan_compute      = */ NULL,
+    /* .graph_compute           = */ ggml_backend_xdna_graph_compute,
+    /* .event_record            = */ NULL,
+    /* .event_wait              = */ NULL,
+    /* .graph_optimize          = */ NULL,
+};
+
+static ggml_guid_t ggml_backend_xdna_guid(void) {
+    static ggml_guid guid = { 0x7a, 0xff, 0x0d, 0x7e, 0x5a, 0x1b, 0x4c, 0xf6, 0xbd, 0x94, 0x6e, 0xc1, 0xf1, 0xcb, 0x3f, 0xbd };
+    return &guid;
+}
+
+ggml_backend_t ggml_backend_xdna_init(void) {
+    ggml_backend_xdna_context * ctx = ggml_xdna_device_context();
+
+    // When the NPU is absent the backend is still registered (llama.cpp
+    // expects every ACCEL device to yield a backend), but supports_op()
+    // rejects everything so all work stays on the CPU.
+    if (!ctx->device) {
+        GGML_LOG_INFO("%s: XDNA backend init: disabled (no NPU)\n", __func__);
+    } else {
+        GGML_LOG_INFO("%s: XDNA backend init: device=%s\n", __func__, ctx->device->name.c_str());
+    }
+
+    ggml_backend_t backend = new ggml_backend {
+        /* .guid    = */ ggml_backend_xdna_guid(),
+        /* .iface   = */ xdna_backend_i,
+        /* .device  = */ ggml_backend_reg_dev_get(ggml_backend_xdna_reg(), 0),
+        /* .context = */ ctx,
+    };
+
+    return backend;
+}
+
+bool ggml_backend_is_xdna(ggml_backend_t backend) {
+    return backend != NULL && ggml_guid_matches(backend->guid, ggml_backend_xdna_guid());
+}
+
+// device interface
+
+static const char * ggml_backend_xdna_device_get_name(ggml_backend_dev_t dev) {
+    ggml_backend_xdna_context * ctx = (ggml_backend_xdna_context *) dev->context;
+    return ctx->device ? ctx->device->name.c_str() : "XDNA";
+}
+
+static const char * ggml_backend_xdna_device_get_description(ggml_backend_dev_t dev) {
+    ggml_backend_xdna_context * ctx = (ggml_backend_xdna_context *) dev->context;
+    return ctx->device ? ctx->device->description.c_str() : "AMD XDNA (no NPU device)";
+}
+
+static void ggml_backend_xdna_device_get_memory(ggml_backend_dev_t dev, size_t * free, size_t * total) {
+    GGML_UNUSED(dev);
+    // The NPU reads/writes host-visible BOs, so report the host memory the
+    // device can consume (fit params divides by the free size, so it must be
+    // non-zero for the XDNA device to be used with --fit).
+#ifdef _WIN32
+    MEMORYSTATUSEX status;
+    status.dwLength = sizeof(status);
+    GlobalMemoryStatusEx(&status);
+    *total = status.ullTotalPhys;
+    *free  = status.ullAvailPhys;
+#else
+    long pages = sysconf(_SC_PHYS_PAGES);
+    long page_size = sysconf(_SC_PAGE_SIZE);
+    *total = (size_t) pages * page_size;
+    // "free" system memory is ill-defined, for practical purposes assume all of it is free:
+    *free = *total;
+#endif // _WIN32
+}
+
+static enum ggml_backend_dev_type ggml_backend_xdna_device_get_type(ggml_backend_dev_t dev) {
+    GGML_UNUSED(dev);
+    return GGML_BACKEND_DEVICE_TYPE_GPU;
+}
+
+static void ggml_backend_xdna_device_get_props(ggml_backend_dev_t dev, struct ggml_backend_dev_props * props) {
+    props->name        = ggml_backend_xdna_device_get_name(dev);
+    props->description = ggml_backend_xdna_device_get_description(dev);
+    props->type        = ggml_backend_xdna_device_get_type(dev);
+    ggml_backend_xdna_device_get_memory(dev, &props->memory_free, &props->memory_total);
+    props->caps = {
+        /* .async                 = */ false,
+        /* .host_buffer           = */ false,
+        /* .buffer_from_host_ptr  = */ true,
+        /* .events                = */ false,
+    };
+}
+
+static ggml_backend_t ggml_backend_xdna_device_init_backend(ggml_backend_dev_t dev, const char * params) {
+    GGML_UNUSED(dev);
+    GGML_UNUSED(params);
+    return ggml_backend_xdna_init();
+}
+
+static ggml_backend_buffer_type_t ggml_backend_xdna_device_get_buffer_type(ggml_backend_dev_t dev) {
+    GGML_UNUSED(dev);
+    return ggml_backend_cpu_buffer_type();
+}
+
+static ggml_backend_buffer_t ggml_backend_xdna_device_buffer_from_host_ptr(ggml_backend_dev_t dev, void * ptr, size_t size, size_t max_tensor_size) {
+    GGML_UNUSED(dev);
+    GGML_UNUSED(max_tensor_size);
+    return ggml_backend_cpu_buffer_from_ptr(ptr, size);
+}
+
+static bool ggml_backend_xdna_device_supports_op(ggml_backend_dev_t dev, const struct ggml_tensor * op) {
+    ggml_backend_xdna_context * ctx = (ggml_backend_xdna_context *) dev->context;
+
+    if (!ctx->device || !ctx->pool) {
+        return false;
+    }
+
+    return xdna_ops_supported(&ctx->ops, op);
+}
+
+static bool ggml_backend_xdna_device_supports_buft(ggml_backend_dev_t dev, ggml_backend_buffer_type_t buft) {
+    GGML_UNUSED(dev);
+    return ggml_backend_buft_is_host(buft);
+}
+
+static const struct ggml_backend_device_i ggml_backend_xdna_device_i = {
+    /* .get_name             = */ ggml_backend_xdna_device_get_name,
+    /* .get_description      = */ ggml_backend_xdna_device_get_description,
+    /* .get_memory           = */ ggml_backend_xdna_device_get_memory,
+    /* .get_type             = */ ggml_backend_xdna_device_get_type,
+    /* .get_props            = */ ggml_backend_xdna_device_get_props,
+    /* .init_backend         = */ ggml_backend_xdna_device_init_backend,
+    /* .get_buffer_type      = */ ggml_backend_xdna_device_get_buffer_type,
+    /* .get_host_buffer_type = */ NULL,
+    /* .buffer_from_host_ptr = */ ggml_backend_xdna_device_buffer_from_host_ptr,
+    /* .supports_op          = */ ggml_backend_xdna_device_supports_op,
+    /* .supports_buft        = */ ggml_backend_xdna_device_supports_buft,
+    /* .offload_op           = */ NULL,
+    /* .event_new            = */ NULL,
+    /* .event_free           = */ NULL,
+    /* .event_synchronize    = */ NULL,
+};
+
+// backend reg interface
+
+static const char * ggml_backend_xdna_reg_get_name(ggml_backend_reg_t reg) {
+    GGML_UNUSED(reg);
+    return "XDNA";
+}
+
+static size_t ggml_backend_xdna_reg_get_device_count(ggml_backend_reg_t reg) {
+    GGML_UNUSED(reg);
+    return ggml_xdna_device_context()->device ? 1 : 0;
+}
+
+static ggml_backend_dev_t ggml_backend_xdna_reg_get_device(ggml_backend_reg_t reg, size_t index) {
+    GGML_ASSERT(index == 0);
+    GGML_UNUSED(index);
+
+    static ggml_backend_device ggml_backend_xdna_device = {
+        /* .iface   = */ ggml_backend_xdna_device_i,
+        /* .reg     = */ reg,
+        /* .context = */ ggml_xdna_device_context(),
+    };
+
+    return &ggml_backend_xdna_device;
+}
+
+static void * ggml_backend_xdna_get_proc_address(ggml_backend_reg_t reg, const char * name) {
+    GGML_UNUSED(reg);
+    GGML_UNUSED(name);
+    return NULL;
+}
+
+static const struct ggml_backend_reg_i ggml_backend_xdna_reg_i = {
+    /* .get_name         = */ ggml_backend_xdna_reg_get_name,
+    /* .get_device_count = */ ggml_backend_xdna_reg_get_device_count,
+    /* .get_device       = */ ggml_backend_xdna_reg_get_device,
+    /* .get_proc_address = */ ggml_backend_xdna_get_proc_address,
+};
+
+ggml_backend_reg_t ggml_backend_xdna_reg(void) {
+    static struct ggml_backend_reg ggml_backend_xdna_reg = {
+        /* .api_version = */ GGML_BACKEND_API_VERSION,
+        /* .iface       = */ ggml_backend_xdna_reg_i,
+        /* .context     = */ NULL,
+    };
+
+    return &ggml_backend_xdna_reg;
+}
+
+GGML_BACKEND_DL_IMPL(ggml_backend_xdna_reg)

--- a/ggml/src/ggml-xdna/kernels/bstream.py
+++ b/ggml/src/ggml-xdna/kernels/bstream.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Pure DDR read-bandwidth probe for the XDNA shim DMA.
+
+Streams a [K x N] bf16 buffer from host (DDR) through the shim tile into the
+mem tile via ObjectFifo, with no compute. The shim reads the buffer in
+CONTIGUOUS 64KB bursts (sequential pattern). Lets us compare against the
+strided 4D pattern the GEMM's B DMA uses (sizes=[8,64,16,32] strides=
+[256,32768,2048,1], 64-byte inner bursts).
+
+Usage: python bstream.py -K 1024 -N 2048 -d npu2 [--iters 20 --warmup 3]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+import aie.iron as iron
+from aie.iron import (
+    CompileTime, ObjectFifo, Program, Runtime, TaskGroup, Worker,
+    ceildiv,
+)
+from aie.iron.device import from_name, Tile
+from aie.helpers.taplib import TensorAccessPattern
+from aie.helpers.dialects.scf import _for as range_
+from aie.utils.hostruntime.argparse import add_compile_args
+import pyxrt as xrt
+
+CHUNK = 16384  # bytes per BD, sequential
+
+
+@iron.jit
+def bstream(
+    *,
+    K: CompileTime[int],
+    N: CompileTime[int],
+    cols: CompileTime[int],
+    strided: CompileTime[int],
+    row512: CompileTime[int],
+    dev_name: CompileTime[str] = "npu2",
+):
+    nbytes = K * N * 2
+    slice_bytes = nbytes // cols   # per-column slice
+    n_chunks = slice_bytes // CHUNK
+    b_ty = np.ndarray[(nbytes,), np.dtype[np.uint8]]
+    c_ty = np.ndarray[(CHUNK,), np.dtype[np.uint8]]
+
+    # Strided mode replicates the GEMM B BD geometry: a 4D box
+    # sizes=[4,4,16,32] strides=[256,32768,2048,1] (bf16 elements) = 16KB per
+    # BD with 64-byte inner bursts and 4KB row jumps. Mirrors the compiled
+    # B_L3L2 BD (sizes=[8,64,16,32], same strides) at mem-tile-slot size.
+    s_ty = np.ndarray[(CHUNK,), np.dtype[np.uint8]]
+    per_col = N // cols
+    box_rows = 4 * 16 + 16  # 80 rows covered per 4D box (K-dim)
+    n_boxes = -(-K // box_rows)  # ceil
+    total_read = box_rows * 32 * 2 * n_boxes * cols
+
+    # "row" mode: 512B bursts (the full per-column row segment: 256 bf16),
+    # rows 4KB apart. One 16KB fill = 32 rows.
+    row_tap_rows = 32
+    n_row_fills = -(-K // row_tap_rows)
+
+    workers = []
+    rt_args = [b_ty]
+    seq_args = []
+
+    for col in range(cols):
+        if strided:
+            of = ObjectFifo(s_ty, name="b%d" % col, depth=1)
+            of_l2l1 = of.cons().forward(obj_type=s_ty, name="b%d_l2l1" % col, tile=Tile(col, 1))
+
+            def core_fn(inp, n=n_boxes):
+                for _ in range_(n):
+                    inp.acquire(1)
+                    inp.release(1)
+        elif row512:
+            of = ObjectFifo(s_ty, name="b%d" % col, depth=1)
+            of_l2l1 = of.cons().forward(obj_type=s_ty, name="b%d_l2l1" % col, tile=Tile(col, 1))
+
+            def core_fn(inp, n=n_row_fills):
+                for _ in range_(n):
+                    inp.acquire(1)
+                    inp.release(1)
+        else:
+            of = ObjectFifo(c_ty, name="b%d" % col, depth=1)
+            of_l2l1 = of.cons().forward(obj_type=c_ty, name="b%d_l2l1" % col, tile=Tile(col, 1))
+
+            def core_fn(inp, n=n_chunks):
+                for _ in range_(n):
+                    inp.acquire(1)
+                    inp.release(1)
+
+        workers.append(Worker(core_fn, [of_l2l1.cons()]))
+        prod = of.prod(tile=Tile(col, 0))
+        seq_args.append((prod, col))
+        rt_args.append(prod)
+
+    def seq_fn(B, *args):
+        for prod, col in seq_args:
+            if strided:
+                # One 4D-stride BD per 80-row box, 16KB slot, grouped to reuse
+                # the shim's 16 BD slots.
+                for base in range(0, n_boxes, 4):
+                    tg = TaskGroup()
+                    for rb in range(base, min(base + 4, n_boxes)):
+                        prod.fill(
+                            B,
+                            tap=TensorAccessPattern(
+                                (K * N,),
+                                offset=(rb * box_rows) * N + col * per_col,
+                                sizes=[4, 4, 16, 32],
+                                strides=[256, 32768, 2048, 1],
+                            ),
+                            group=tg,
+                        )
+                    tg.finish()
+            elif row512:
+                # 512B bursts: 32 rows x 256 bf16 per fill, rows N apart.
+                for base in range(0, n_row_fills, 4):
+                    tg = TaskGroup()
+                    for rf in range(base, min(base + 4, n_row_fills)):
+                        prod.fill(
+                            B,
+                            tap=TensorAccessPattern(
+                                (K * N,),
+                                offset=(rf * row_tap_rows) * N + col * per_col,
+                                sizes=[row_tap_rows, per_col],
+                                strides=[N, 1],
+                            ),
+                            group=tg,
+                        )
+                    tg.finish()
+            else:
+                col_off = col * slice_bytes
+                for base in range(0, n_chunks, 8):
+                    tg = TaskGroup()
+                    for c in range(base, min(base + 8, n_chunks)):
+                        prod.fill(
+                            B,
+                            tap=TensorAccessPattern(
+                                (nbytes,), offset=col_off + c * CHUNK, sizes=[CHUNK], strides=[1]
+                            ),
+                            group=tg,
+                        )
+                    tg.finish()
+
+    rt = Runtime(seq_fn, rt_args)
+    prog = Program(from_name(dev_name, n_cols=cols), rt, workers)
+    return prog.resolve_program()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="bstream")
+    add_compile_args(parser)
+    parser.add_argument("-K", type=int, default=1024)
+    parser.add_argument("-N", type=int, default=2048)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--cols", type=int, default=8,
+                        help="Shim columns reading their B slice in parallel")
+    parser.add_argument("--strided", action="store_true",
+                        help="Read with the GEMM B pattern (64B bursts, 4KB jumps) instead of contiguous")
+    parser.add_argument("--row512", action="store_true",
+                        help="Read per-column row segments as 512B bursts (32 bf16 -> full 256-col slice)")
+    parser.add_argument("--workdir", type=str, default="build/bin")
+    opts = parser.parse_args()
+    if opts.dev is None:
+        opts.dev = "npu2"
+
+    kw = {"K": opts.K, "N": opts.N, "cols": opts.cols,
+          "strided": 1 if opts.strided else 0,
+          "row512": 1 if opts.row512 else 0,
+          "dev_name": opts.dev}
+    os.makedirs(opts.workdir, exist_ok=True)
+    tag = "_strided" if opts.strided else ("_row512" if opts.row512 else "")
+    base = os.path.join(opts.workdir, "bstream_K%d_N%d_c%d%s" % (
+        opts.K, opts.N, opts.cols, tag))
+    xclbin_path, insts_path = bstream.specialize(**kw).compile(
+        xclbin_path=base + ".xclbin", inst_path=base + ".insts.bin")
+
+    dev = xrt.device(0)
+    xb = xrt.xclbin(str(xclbin_path))
+    dev.register_xclbin(xb)
+    ctx = xrt.hw_context(dev, xb.get_uuid())
+    kernel = xrt.kernel(ctx, xb.get_kernels()[0].get_name())
+
+    insts = np.frombuffer(Path(insts_path).read_bytes(), dtype=np.uint32)
+    insts_bo = xrt.bo(dev, insts.nbytes, xrt.bo.cacheable, kernel.group_id(1))
+    np.frombuffer(insts_bo.map(), dtype=np.uint32)[:] = insts
+    insts_bo.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+
+    nbytes = opts.K * opts.N * 2
+    if opts.strided:
+        n_fills = -(-opts.K // 80)
+    elif opts.row512:
+        n_fills = -(-opts.K // 32)
+    else:
+        n_fills = opts.K * opts.N * 2 // CHUNK // opts.cols
+    read_bytes = n_fills * CHUNK * opts.cols
+    b_bo = xrt.bo(dev, nbytes, xrt.bo.host_only, 0)
+    np.frombuffer(b_bo.map(), dtype=np.uint8)[:] = np.zeros(nbytes, dtype=np.uint8)
+    b_bo.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+
+    def once():
+        run = kernel(3, insts_bo, int(insts.nbytes), b_bo)
+        st = run.wait()
+        if st != xrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED:
+            sys.exit("wait state %s" % str(st))
+
+    for _ in range(max(opts.warmup, 0)):
+        once()
+    n = max(opts.iters, 1)
+    t0 = time.perf_counter()
+    for _ in range(n):
+        once()
+    dt = (time.perf_counter() - t0) / n
+    bw = read_bytes / dt / 1e9
+    mode = "strided (64B bursts / 4KB jumps)" if opts.strided else (
+        "512B row bursts" if opts.row512 else "sequential contiguous")
+    print("stream    : K=%d N=%d buf=%.2f MiB, %d cols, %s"
+          % (opts.K, opts.N, nbytes / 1048576, opts.cols, mode))
+    print("avg       : %.3f ms/run -> %.1f GB/s aggregate read (%.2f MiB read)"
+          % (dt * 1000, bw, read_bytes / 1048576))
+
+
+if __name__ == "__main__":
+    main()

--- a/ggml/src/ggml-xdna/kernels/gemm.py
+++ b/ggml/src/ggml-xdna/kernels/gemm.py
@@ -1,0 +1,866 @@
+#!/usr/bin/env python3
+# gemm.py -*- Python -*-
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Minimal IRON design for the ggml-xdna GEMM kernel (C = A @ B, bf16 -> f32).
+#
+# Compile-only mode (builds .xclbin + .insts.bin artifacts):
+#
+#   python3 gemm.py -M 32 -K 1024 -N 2048 -d npu2 \
+#       --xclbin-path build/bin/gemm.xclbin \
+#       --insts-path  build/bin/gemm.insts.bin
+#
+# The per-core loop counts (K_div_k, n_tiles_per_core) are runtime parameters
+# written by the sequence into per-core RTP buffers before the DMA starts, so
+# the compiled xclbin is (K, N)-independent: the same xclbin can be reused
+# across dimension variants by swapping only the instruction stream.
+#
+# The instruction stream always starts with zero(C), so cross-call accumulation
+# on the device is not possible. The C++ backend accumulates partial results
+# in host memory.
+#
+# Reference: kernels/ggml-xdna-gemm.py in the qvac-fabric-llm.cpp_a repo.
+# This file is a trimmed-down copy: bf16_f32 only, npu2 only, row-major A/B/C.
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import numpy as np
+
+import aie.iron as iron
+from aie.iron import (
+    Buffer, CompileTime, ObjectFifo, Program, Runtime, TaskGroup, Worker,
+    WorkerRuntimeBarrier, str_to_dtype, ceildiv,
+)
+from aie.iron.device import from_name, Tile
+from aie.helpers.taplib import (
+    TensorTiler2D, TensorAccessPattern,
+)
+from aie.helpers.dialects.scf import _for as range_
+from aie.utils.hostruntime.argparse import add_compile_args
+from aie.utils.hostruntime.cli import run_design_cli
+import aie.iron.kernels as akernels
+
+
+# bf16 -> f32 only.
+DTYPE_COMBOS = {
+    "bf16_f32": {"label": "bf16->f32"},
+}
+
+# Micro-kernel MAC dimensions (r, s, t) for NPU2 native bf16.
+MICROKERNEL_MAC_DIM = (4, 8, 8)
+
+
+def _validate(opts) -> None:
+    r, s, t = MICROKERNEL_MAC_DIM
+
+    if opts.M % (2 * r) != 0:
+        raise SystemExit(f"-M ({opts.M}) must be a multiple of 2*r ({2 * r})")
+    if opts.K % s != 0:
+        raise SystemExit(f"-K ({opts.K}) must be a multiple of s ({s})")
+    if opts.N % (2 * t) != 0:
+        raise SystemExit(f"-N ({opts.N}) must be a multiple of 2*t ({2 * t})")
+
+    n_aie_rows = opts.n_aie_rows
+    n_aie_cols = opts.n_aie_cols
+    n_A_tiles_per_shim = n_aie_rows // n_aie_cols if n_aie_cols < n_aie_rows else 1
+    mem_tile_m_A = opts.tile_m * n_A_tiles_per_shim
+    mem_tile_m_C = opts.tile_m * n_aie_rows
+    mem_tile_n = opts.tile_n * n_aie_cols
+
+    if opts.M % mem_tile_m_A != 0:
+        raise SystemExit(f"-M ({opts.M}) must be a multiple of mem_tile_m_A ({mem_tile_m_A})")
+    if opts.M % mem_tile_m_C != 0:
+        raise SystemExit(f"-M ({opts.M}) must be a multiple of mem_tile_m_C ({mem_tile_m_C})")
+    if opts.K % opts.tile_k != 0:
+        raise SystemExit(f"-K ({opts.K}) must be a multiple of -k ({opts.tile_k})")
+    if opts.N % mem_tile_n != 0:
+        raise SystemExit(f"-N ({opts.N}) must be a multiple of mem_tile_n ({mem_tile_n})")
+
+    if opts.tile_m % (2 * r) != 0:
+        raise SystemExit(f"--tile-m ({opts.tile_m}) must be a multiple of 2*r ({2 * r})")
+    if opts.tile_k % s != 0:
+        raise SystemExit(f"--tile-k ({opts.tile_k}) must be a multiple of s ({s})")
+    if opts.tile_n % (2 * t) != 0:
+        raise SystemExit(f"--tile-n ({opts.tile_n}) must be a multiple of 2*t ({2 * t})")
+
+
+def _compile_kwargs(opts) -> dict:
+    dtype_in_str, dtype_out_str = opts.dtype.split("_")  # "bf16_f32" -> "bf16", "f32"
+    return {
+        "M":            opts.M,
+        "K":            opts.K,
+        "N":            opts.N,
+        "m":            opts.tile_m,
+        "k":            opts.tile_k,
+        "n":            opts.tile_n,
+        "n_aie_cols":   opts.n_aie_cols,
+        "n_aie_rows":   opts.n_aie_rows,
+        "dtype_in_str": dtype_in_str,
+        "dtype_out_str": dtype_out_str,
+        "dev_name":     opts.dev,
+        "emulate_bf16_mmul_with_bfp16": 0 if getattr(opts, "no_bfp16", False) else 1,
+        "trace_size":   getattr(opts, "trace_size", 0),
+        "trace_rows":   tuple(getattr(opts, "trace_rows", None) or ()),
+        "trace_cols":   tuple(getattr(opts, "trace_cols", None) or ()),
+        "trace_egress": getattr(opts, "trace_egress", 0),
+    }
+
+
+@iron.jit
+def bf16_f32_gemm(
+    *,
+    M:                       CompileTime[int],
+    K:                       CompileTime[int],
+    N:                       CompileTime[int],
+    m:                       CompileTime[int],
+    k:                       CompileTime[int],
+    n:                       CompileTime[int],
+    n_aie_cols:              CompileTime[int],
+    n_aie_rows:              CompileTime[int] = 4,
+    dtype_in_str:            CompileTime[str],
+    dtype_out_str:           CompileTime[str],
+    dev_name:                CompileTime[str] = "npu2",
+    emulate_bf16_mmul_with_bfp16: CompileTime[int] = 1,
+    trace_size:              CompileTime[int] = 0,
+    trace_rows:              CompileTime[tuple] = (),
+    trace_cols:              CompileTime[tuple] = (),
+    trace_egress:            CompileTime[int] = 0,
+):
+    dtype_in = str_to_dtype(dtype_in_str)
+    dtype_out = str_to_dtype(dtype_out_str)
+
+    # With n_aie_cols > n_aie_rows the A shim/mem tiles are capped at
+    # n_aie_rows: there are only n_aie_rows row tiles of A to feed.
+    n_shim_mem_A = min(n_aie_cols, n_aie_rows)
+    n_A_tiles_per_shim = n_aie_rows // n_aie_cols if n_aie_cols < n_aie_rows else 1
+
+    mem_tile_m_A = m * n_A_tiles_per_shim
+    mem_tile_m_C = m * n_aie_rows
+    mem_tile_n = n * n_aie_cols
+
+    # Per-variant tile counts. The host always submits the full baked M/K/N
+    # block (inputs are zero-padded). The loop counts are passed to the cores
+    # as runtime parameters (RTP) written by the runtime sequence, so a single
+    # xclbin serves every (K, N) variant; only the instruction stream (DMA
+    # tiling + RTP values) differs between variants.
+    K_div_k = K // k
+    n_c_col_tiles_per_core = N // mem_tile_n
+    n_c_row_tiles_per_core = M // mem_tile_m_C
+
+    if dev_name == "npu1" and n_aie_cols > 4:
+        raise AssertionError("Invalid configuration: NPU (Phoenix/Hawk) has 4 columns")
+    if dev_name == "npu2" and n_aie_cols > 8:
+        raise AssertionError(
+            "Invalid configuration: NPU2 (Strix/Strix Halo/Krackan) has 8 columns"
+        )
+
+    # Matmul micro-kernel from the IRON kernel library. bfp16 emulation uses
+    # the r=8 mmul (2x throughput); --no-bfp16 builds the native bf16 r=4
+    # kernel (tile_m 8) used for the decode M-block.
+    _matmul_kernel = akernels.mm(
+        m, k, n,
+        input_dtype=dtype_in,
+        output_dtype=dtype_out,
+        vectorized=True,
+        emulate_bf16_mmul_with_bfp16=bool(emulate_bf16_mmul_with_bfp16),
+    )
+    r, s, t = _matmul_kernel.mac_dims
+
+    assert M % mem_tile_m_A == 0, "A must be tileable into (m * n_A_tiles_per_shim, k)-sized blocks"
+    assert K % k == 0
+    assert N % mem_tile_n == 0, "B must be tileable into (k, n * n_aie_cols)-sized blocks"
+    assert M % mem_tile_m_C == 0, "C must be tileable into (m * n_aie_rows, n)-sized blocks"
+
+    assert m % r == 0
+    assert k % s == 0
+    assert n % t == 0
+
+    # Reduce to 1 only if CDO generation runs out of program memory (slow).
+    fifo_depth = 2
+
+    dev_ty = from_name(dev_name, n_cols=n_aie_cols)
+
+    # Tensor types
+    A_ty = np.ndarray[(M * K,), np.dtype[dtype_in]]
+    B_ty = np.ndarray[(K * N,), np.dtype[dtype_in]]
+    C_ty = np.ndarray[(M * N,), np.dtype[dtype_out]]
+    A_l2_ty = np.ndarray[(mem_tile_m_A * k,), np.dtype[dtype_in]]
+    B_l2_ty = np.ndarray[(k * n,), np.dtype[dtype_in]]
+    C_l2_ty = np.ndarray[(mem_tile_m_C * n,), np.dtype[dtype_out]]
+    A_l1_ty = np.ndarray[(m, k), np.dtype[dtype_in]]
+    B_l1_ty = np.ndarray[(k, n), np.dtype[dtype_in]]
+    C_l1_ty = np.ndarray[(m, n), np.dtype[dtype_out]]
+
+    zero_kernel = _matmul_kernel.zero
+    matmul_kernel = _matmul_kernel
+    fifo_depth_out = fifo_depth
+
+    # AIE tiles: rows 0-1 mem tiles, rows 2-5 compute cores.
+    tiles = [[(col, row) for col in range(0, n_aie_cols)] for row in range(0, 6)]
+    core_tiles = tiles[2:]
+
+    # AIE-array data movement with object fifos
+    A_l3l2_fifos = [None] * n_shim_mem_A
+    A_l2l1_fifos = [None] * n_aie_rows
+
+    B_l3l2_fifos = [None] * n_aie_cols
+    B_l2l1_fifos = [None] * n_aie_cols
+
+    C_l1l2_fifos = [[None] * n_aie_cols for _ in range(n_aie_rows)]
+    C_l2l3_fifos = [None] * n_aie_cols
+
+    # Input A: L3-L2, then split along rows to the L2-L1 fifos.
+    for i in range(n_shim_mem_A):
+        A_l3l2_fifos[i] = ObjectFifo(A_l2_ty, name=f"A_L3L2_{i}", depth=fifo_depth)
+        start_row = i * n_A_tiles_per_shim
+        stop_row = start_row + n_A_tiles_per_shim
+        of_offsets = [m * k * j for j in range(stop_row - start_row)]
+        dims_to_stream = [
+            [
+                (m // r, r * k),
+                (k // s, s),
+                (r, k),
+                (s, 1),
+            ]
+        ] * (stop_row - start_row)
+        a_tmp_fifos = (
+            A_l3l2_fifos[i]
+            .cons()
+            .split(
+                of_offsets,
+                obj_types=[A_l1_ty] * (stop_row - start_row),
+                names=[f"A_L2L1_{row}" for row in range(start_row, stop_row)],
+                dims_to_stream=dims_to_stream,
+                tile=Tile(
+                    2 * i if n_aie_cols == 8 else i, 1
+                ),  # alternate columns in full 4x8 NPU2 case
+            )
+        )
+        for j in range(stop_row - start_row):
+            A_l2l1_fifos[j + start_row] = a_tmp_fifos[j]
+
+    # Input B: L3-L2, then forward to L2-L1 (row-major [k x n] tiles).
+    for col in range(n_aie_cols):
+        B_l3l2_fifos[col] = ObjectFifo(B_l2_ty, name=f"B_L3L2_{col}", depth=fifo_depth)
+        dims_to_stream = [(k // s, s * n), (n // t, t), (s, n), (t, 1)]
+        B_l2l1_fifos[col] = (
+            B_l3l2_fifos[col]
+            .cons()
+            .forward(
+                obj_type=B_l1_ty,
+                name=f"B_L2L1_{col}",
+                dims_to_stream=dims_to_stream,
+                tile=Tile(col, 1),
+            )
+        )
+
+        # Output C: L1-L2 (join along rows), then L2-L3 (row-major [m x n] tiles).
+        dims_to_stream = [(m // r, r * n), (r, t), (n // t, r * t), (t, 1)]
+        C_l2l3_fifos[col] = ObjectFifo(
+            C_l2_ty,
+            name=f"C_L2L3_{col}",
+            depth=fifo_depth,
+            dims_to_stream=dims_to_stream,
+        )
+        of_offsets = [m * n * i for i in range(n_aie_rows)]
+        c_tmp_fifos = (
+            C_l2l3_fifos[col]
+            .prod()
+            .join(
+                of_offsets,
+                obj_types=[C_l1_ty] * n_aie_rows,
+                names=[f"C_L1L2_{col}_{row}" for row in range(n_aie_rows)],
+                depths=[fifo_depth_out] * n_aie_rows,
+                tile=Tile(col, 1),
+            )
+        )
+        for row in range(n_aie_rows):
+            C_l1l2_fifos[row][col] = c_tmp_fifos[row]
+
+    n_tiles_per_core = n_c_row_tiles_per_core * n_c_col_tiles_per_core
+
+    # Per-core RTP buffers (K_div_k, n_tiles_per_core) and a lock barrier so a
+    # core never reads its counts before the sequence has written them.
+    rtps = [
+        [
+            Buffer(
+                np.ndarray[(2,), np.dtype[np.int32]],
+                name=f"rtp{row}_{col}",
+                initial_value=np.array([0, 0], dtype=np.int32),
+                use_write_rtp=True,
+            )
+            for col in range(n_aie_cols)
+        ]
+        for row in range(n_aie_rows)
+    ]
+    barriers = [
+        [WorkerRuntimeBarrier() for col in range(n_aie_cols)]
+        for row in range(n_aie_rows)
+    ]
+
+    # Tasks for each worker to perform
+    def core_fn(in_a, in_b, out_c, zero, matmul, rtp, barrier):
+        barrier.wait_for_value(1)
+        rtp_K_div_k = rtp[0]
+        rtp_n_tiles_per_core = rtp[1]
+        for _ in range_(rtp_n_tiles_per_core):
+            elem_out = out_c.acquire(1)
+            zero(elem_out)
+
+            for _ in range_(rtp_K_div_k):
+                elem_in_a = in_a.acquire(1)
+                elem_in_b = in_b.acquire(1)
+                matmul(elem_in_a, elem_in_b, elem_out)
+                in_a.release(1)
+                in_b.release(1)
+
+            out_c.release(1)
+
+    # Set up compute tiles
+    workers = Worker.grid(
+        n_aie_rows,
+        n_aie_cols,
+        lambda row, col: Worker(
+            core_fn,
+            [
+                A_l2l1_fifos[row].cons(),
+                B_l2l1_fifos[col].cons(),
+                C_l1l2_fifos[row][col].prod(),
+                zero_kernel,
+                matmul_kernel,
+                rtps[row][col],
+                barriers[row][col],
+            ],
+            tile=Tile(*core_tiles[row][col]),
+            stack_size=0xD00,
+        ),
+    )
+
+    # Define tensor access patterns (tiling) for A, B, and C
+    A_tiles = TensorTiler2D.group_tiler(
+        (M, K),  # Size of A matrix
+        (mem_tile_m_A, k),  # Size of A (smallest) tile
+        (1, K_div_k),  # Size of "group" of tiles
+        # Repeat data so can distribute across whole column
+        pattern_repeat=n_c_col_tiles_per_core,
+        prune_step=False,
+    )
+    B_tiles = TensorTiler2D.step_tiler(
+        (K, N),  # Size of B matrix
+        (k, n),  # Size of B tile
+        # Number of tiles per transfer in each dimension (whole col, partial row)
+        tile_group_repeats=(K_div_k, n_c_col_tiles_per_core),
+        # Contiguous tile group in col, but send every n_aie_cols-th tile in the row
+        tile_group_steps=(1, n_aie_cols),
+        tile_group_col_major=True,  # Send all tiles in column before moving on to next column
+        prune_step=False,
+    )
+
+    # Shim-side fifo handles, registered with the Runtime so their shim
+    # endpoints are bound before resolution.
+    A_prods = [
+        A_l3l2_fifos[i].prod(tile=Tile(2 * i if n_aie_cols == 8 else i, 0))
+        for i in range(n_shim_mem_A)
+    ]
+    B_prods = [B_l3l2_fifos[col].prod(tile=Tile(col, 0)) for col in range(n_aie_cols)]
+    C_conss = [C_l2l3_fifos[col].cons(tile=Tile(col, 0)) for col in range(n_aie_cols)]
+
+    # We are limited in the number of BDs. After synchronizing, we can reuse BDs.
+    # We only transfer 4 rows of tiles at once before starting a new transfer block.
+    tb_max_n_rows = 4
+
+    def seq_fn(A, B, C, *args):
+        # args: A_prods (n_shim_mem_A), B_prods (n_aie_cols), C_conss (n_aie_cols),
+        #       rtps (n_aie_rows x n_aie_cols), barriers (n_aie_rows x n_aie_cols)
+        arg_iter = iter(args)
+        a_prods = [next(arg_iter) for _ in range(n_shim_mem_A)]
+        b_prods = [next(arg_iter) for _ in range(n_aie_cols)]
+        c_conss = [next(arg_iter) for _ in range(n_aie_cols)]
+        rtps_seq = [[next(arg_iter) for _ in range(n_aie_cols)] for _ in range(n_aie_rows)]
+        barriers_seq = [[next(arg_iter) for _ in range(n_aie_cols)] for _ in range(n_aie_rows)]
+
+        # Program the per-core loop counts (K_div_k, n_tiles_per_core) and
+        # release the barrier so the cores start with the values for this
+        # variant. Written before any DMA so a core never reads stale counts.
+        for row in range(n_aie_rows):
+            for col in range(n_aie_cols):
+                rtps_seq[row][col][0] = K_div_k
+                rtps_seq[row][col][1] = n_tiles_per_core
+                barriers_seq[row][col].set(1)
+
+        # Task groups determine when to sync/await/free DMA runtime ops.
+        for tb in range(ceildiv(n_c_row_tiles_per_core, tb_max_n_rows)):
+            for pingpong in [0, 1]:
+                row_base = tb * tb_max_n_rows + pingpong * tb_max_n_rows // 2
+                current_tb_n_rows = min(
+                    [tb_max_n_rows // 2, n_c_row_tiles_per_core - row_base]
+                )
+                if current_tb_n_rows <= 0:
+                    # For small input sizes, we may not even need a "pong" iteration
+                    break
+                tg = TaskGroup()
+                for col in range(n_aie_cols):
+                    # C output transfer: one (m*n_aie_rows)-x-n sub-tile per
+                    # column, evenly spaced, repeated current_tb_n_rows times
+                    # for the next contiguous blocks of rows.
+                    C_row_offset = row_base * mem_tile_m_C * N
+                    C_col_offset = col * n
+                    C_offset = C_col_offset + C_row_offset
+                    C_sizes = [
+                        current_tb_n_rows,
+                        N // mem_tile_n,
+                        mem_tile_m_C,
+                        n,
+                    ]
+                    C_strides = [mem_tile_m_C * N, mem_tile_n, N, 1]
+                    C_tile = TensorAccessPattern(
+                        (M, N),
+                        offset=C_offset,
+                        sizes=C_sizes,
+                        strides=C_strides,
+                    )
+
+                    c_conss[col].drain(C, tap=C_tile, wait=True, group=tg)
+
+                    for tile_row in range(current_tb_n_rows):
+                        # A input transfer: one (m*n_A_tiles_per_shim)-sized
+                        # row sub-tile per column, repeated N//n//n_aie_cols.
+                        if col < n_shim_mem_A:
+                            tile_offset = (
+                                (row_base + tile_row) * n_shim_mem_A + col
+                            ) % len(A_tiles)
+                            a_prods[col].fill(A, tap=A_tiles[tile_offset], group=tg)
+
+                        # B input transfer: one (k x n) column sub-tile per column.
+                        b_prods[col].fill(B, tap=B_tiles[col], group=tg)
+                tg.finish()
+
+    # Runtime sequence arguments: the three host buffers first, then the
+    # shim fifo handles, then the per-core RTP buffers and barriers in a
+    # fixed order matched by seq_fn's unpacking.
+    rt_args: list = [A_ty, B_ty, C_ty]
+    rt_args.extend(A_prods)
+    rt_args.extend(B_prods)
+    rt_args.extend(C_conss)
+    for row in range(n_aie_rows):
+        for col in range(n_aie_cols):
+            rt_args.append(rtps[row][col])
+    for row in range(n_aie_rows):
+        for col in range(n_aie_cols):
+            rt_args.append(barriers[row][col])
+
+    rt = Runtime(seq_fn, rt_args)
+    my_program = Program(dev_ty, rt, [w for row in workers for w in row])
+
+    if trace_size > 0:
+        from aie.utils.trace.events import CoreEvent
+
+        rows = list(trace_rows) or list(range(n_aie_rows))
+        cols = list(trace_cols) or list(range(n_aie_cols))
+        traced = [workers[r][c] for r in rows for c in cols]
+        # The trace overlay assigns one packet ID per traced tile; the 5-bit
+        # packet-id field (with ID 0 reserved) caps the set at 31 tiles.
+        if len(traced) > 31:
+            print("gemm: trace capped to 31 tiles (hardware packet-id limit); "
+                  "use --trace-rows/--trace-cols to select a subset",
+                  file=sys.stderr)
+            traced = traced[:31]
+        my_program.enable_trace(
+            trace_size,
+            workers=traced,
+            coretile_events=[
+                CoreEvent.INSTR_EVENT_0,
+                CoreEvent.INSTR_EVENT_1,
+                CoreEvent.INSTR_VECTOR,
+                CoreEvent.MEMORY_STALL,
+                CoreEvent.STREAM_STALL,
+                CoreEvent.LOCK_STALL,
+                CoreEvent.ACTIVE,
+            ],
+            egress_shim_col=trace_egress,
+        )
+
+    module = my_program.resolve_program()
+    return module
+
+
+def _run_gemm(design, opts) -> None:
+    """Compile the GEMM kernel and run it standalone on the NPU.
+
+    Mirrors the ggml-xdna C++ submission scheme (xdna-ops.cpp): the host K
+    dimension is tiled into GEMM_K_MAX-wide blocks, each block submitted as
+    its own kernel run, and A/C buffers are ping-ponged so a block's C
+    readback overlaps the next block's NPU execution. Synthetic bf16 data is
+    used; pass --verify to compare against a numpy reference.
+
+    With --hang the kernel is compiled at K > 1024 (K_div_k > 64) and run as a
+    single submission with a watchdog; a background thread keeps snapshots of
+    the trace buffer so the state just before a stall is preserved.
+    """
+    import os
+    import time
+    from pathlib import Path
+
+    import pyxrt as xrt
+    from ml_dtypes import bfloat16
+
+    if opts.dev is None:
+        from aie.utils import get_current_device
+        from aie.utils.compile import resolve_target_arch
+
+        rtdev = get_current_device()
+        if rtdev is None:
+            sys.exit("--run: no NPU runtime device detected (pass --dev npu2)")
+        opts.dev = "npu2" if resolve_target_arch(rtdev) == "aie2p" else "npu"
+
+    _validate(opts)
+
+    GEMM_K_MAX = 1024
+
+    Mk = opts.M
+    N = opts.N
+    kernel_K = opts.K
+    host_K = opts.host_K if opts.host_K is not None else opts.K
+    host_M = opts.host_M if opts.host_M is not None else opts.M
+
+    n_m_blocks = ceildiv(host_M, Mk)
+    n_k_blocks = ceildiv(host_K, kernel_K)
+
+    if opts.hang and n_k_blocks != 1:
+        sys.exit("--hang expects a single full-K run (set -K > 1024, not --host-K tiling)")
+    if opts.hang and host_M > Mk:
+        sys.exit("--hang expects host M <= baked M block (decode-style, --host-M <= %d)" % Mk)
+
+    # --- compile ------------------------------------------------------------
+    os.makedirs(opts.workdir, exist_ok=True)
+    base = os.path.join(opts.workdir, "gemm_M%d_K%d_N%d" % (Mk, kernel_K, N))
+    if opts.trace_size > 0:
+        base += "_tr%d" % opts.trace_size
+    xclbin_path = base + ".xclbin"
+    insts_path = base + ".insts.bin"
+
+    spec = design.specialize(**_compile_kwargs(opts))
+    xclbin_path, insts_path = spec.compile(xclbin_path=xclbin_path, inst_path=insts_path)
+
+    physical_mlir = None
+    try:
+        kdir = spec.compilable._kernel_dir
+        if kdir is not None:
+            pm = kdir / "input_with_addresses.mlir"
+            if pm.exists():
+                physical_mlir = str(pm)
+    except Exception:
+        pass
+
+    # --- device -------------------------------------------------------------
+    dev = xrt.device(0)
+    xb = xrt.xclbin(str(xclbin_path))
+    dev.register_xclbin(xb)
+    ctx = xrt.hw_context(dev, xb.get_uuid())
+    kernel = xrt.kernel(ctx, xb.get_kernels()[0].get_name())
+
+    insts = np.frombuffer(Path(insts_path).read_bytes(), dtype=np.uint32)
+    insts_bo = xrt.bo(dev, insts.nbytes, xrt.bo.cacheable, kernel.group_id(1))
+    np.frombuffer(insts_bo.map(), dtype=np.uint32)[:] = insts
+    insts_bo.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+    insts_bytes = int(insts.nbytes)
+
+    to_dev = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE
+    from_dev = xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE
+
+    def alloc(nbytes):
+        return xrt.bo(dev, nbytes, xrt.bo.host_only, 0)
+
+    a_bos = [alloc(Mk * kernel_K * np.dtype(bfloat16).itemsize) for _ in range(2)]
+    c_bos = [alloc(Mk * N * np.dtype(np.float32).itemsize) for _ in range(2)]
+    b_bos = [alloc(kernel_K * N * np.dtype(bfloat16).itemsize) for _ in range(n_k_blocks)]
+
+    trace_bo = None
+    if opts.trace_size > 0:
+        trace_bo = alloc(opts.trace_size)
+        if n_k_blocks > 1:
+            sys.exit("--trace-size with host K tiling: trace only a single K-block (set --host-K <= 1024)")
+
+    # --- data ---------------------------------------------------------------
+    rng = np.random.default_rng(7)
+    A = rng.standard_normal((host_M, host_K)).astype(np.float32).astype(bfloat16)
+    B = rng.standard_normal((host_K, N)).astype(np.float32).astype(bfloat16)
+
+    for kb in range(n_k_blocks):
+        k0 = kb * kernel_K
+        kc = min(kernel_K, host_K - k0)
+        blk = np.frombuffer(b_bos[kb].map(), dtype=bfloat16).reshape(kernel_K, N)
+        blk.fill(bfloat16(0))
+        blk[0:kc, :] = B[k0:k0 + kc, :]
+        b_bos[kb].sync(to_dev)
+
+    def fill_a(bo, mb, kb):
+        m0 = mb * Mk
+        mc = min(Mk, host_M - m0)
+        k0 = kb * kernel_K
+        kc = min(kernel_K, host_K - k0)
+        a = np.frombuffer(bo.map(), dtype=bfloat16).reshape(Mk, kernel_K)
+        a.fill(bfloat16(0))
+        a[0:mc, 0:kc] = A[m0:m0 + mc, k0:k0 + kc]
+        bo.sync(to_dev)
+
+    # --- submission loop ----------------------------------------------------
+    trace_words = None
+
+    def run_once():
+        nonlocal trace_words
+        c_host = np.zeros((n_m_blocks * Mk, N), dtype=np.float32)
+        bank = 0
+        pending = -1
+        pend_mb = 0
+        run_prev = None
+        stats = np.zeros(5)  # pack, sync, submit, wait, read
+
+        for kb in range(n_k_blocks):
+            for mb in range(n_m_blocks):
+                t0 = time.perf_counter()
+                fill_a(a_bos[bank], mb, kb)
+                stats[0] += time.perf_counter() - t0
+
+                t0 = time.perf_counter()
+                a_bos[bank].sync(to_dev)
+                stats[1] += time.perf_counter() - t0
+
+                args = [a_bos[bank], b_bos[kb], c_bos[bank]]
+                if trace_bo is not None:
+                    args += [trace_bo]
+                t0 = time.perf_counter()
+                run = kernel(3, insts_bo, insts_bytes, *args)
+                stats[2] += time.perf_counter() - t0
+
+                if pending >= 0:
+                    t0 = time.perf_counter()
+                    st = run_prev.wait()
+                    stats[3] += time.perf_counter() - t0
+                    if st != xrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED:
+                        sys.exit("--run: kernel wait state %s" % str(st))
+                    t0 = time.perf_counter()
+                    c_bos[pending].sync(from_dev)
+                    c = np.frombuffer(c_bos[pending].map(), dtype=np.float32).copy().reshape(Mk, N)
+                    stats[4] += time.perf_counter() - t0
+                    c_host[pend_mb * Mk:(pend_mb + 1) * Mk, :] += c
+                run_prev = run
+                pend_mb = mb
+                pending = bank
+                bank = 1 - bank
+
+        if pending >= 0:
+            t0 = time.perf_counter()
+            st = run_prev.wait()
+            stats[3] += time.perf_counter() - t0
+            if st != xrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED:
+                sys.exit("--run: kernel wait state %s" % str(st))
+            t0 = time.perf_counter()
+            c_bos[pending].sync(from_dev)
+            c = np.frombuffer(c_bos[pending].map(), dtype=np.float32).copy().reshape(Mk, N)
+            stats[4] += time.perf_counter() - t0
+            c_host[pend_mb * Mk:(pend_mb + 1) * Mk, :] += c
+
+        if trace_bo is not None:
+            trace_bo.sync(from_dev)
+            trace_words = np.frombuffer(trace_bo.map(), dtype=np.uint32).copy()
+
+        return c_host, stats
+
+    def run_hang():
+        """Single full-K (K > 1024) run with a watchdog and a trace saver.
+
+        The run normally wedges the shared hw_context; the trace BO is a
+        host-only buffer written by the shim DMA directly into system memory,
+        so polling its mapping preserves the events emitted just before the
+        stall.
+        """
+        import threading
+
+        fill_a(a_bos[0], 0, 0)
+        a_bos[0].sync(to_dev)
+        args = [a_bos[0], b_bos[0], c_bos[0]]
+        if trace_bo is not None:
+            args += [trace_bo]
+        run = kernel(3, insts_bo, insts_bytes, *args)
+
+        done = [False]
+        result = [None]
+        started = time.perf_counter()
+
+        def waiter():
+            result[0] = run.wait()
+            done[0] = True
+
+        threading.Thread(target=waiter, daemon=True).start()
+
+        snapshots = []
+        while not done[0]:
+            if trace_bo is not None:
+                snapshots.append(np.frombuffer(trace_bo.map(), dtype=np.uint32).copy())
+            if time.perf_counter() - started > opts.hang_timeout:
+                break
+            time.sleep(0.05)
+
+        elapsed = time.perf_counter() - started
+        if done[0]:
+            st = result[0]
+            if st != xrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED:
+                sys.exit("--hang: kernel returned %s" % str(st))
+            print("--hang: run completed in %.3f ms (no wedge at K=%d)" % (elapsed * 1000, kernel_K))
+            if trace_bo is not None and snapshots:
+                _save_trace(snapshots[-1])
+            return
+
+        print("--hang: run did not complete within %.0f s - context WEDGE at K=%d (K_div_k=%d)"
+              % (opts.hang_timeout, kernel_K, kernel_K // opts.tile_k))
+        if trace_bo is not None and snapshots:
+            _save_trace(snapshots[-1])
+        sys.exit(2)
+
+    def _save_trace(words):
+        from aie.utils.trace import TraceConfig
+
+        tcfg = TraceConfig(trace_size=opts.trace_size, trace_file=opts.trace_file)
+        tcfg.write_trace(words)
+        print("trace      : %d words -> %s" % (len(words), opts.trace_file))
+        if not physical_mlir:
+            print("  note: no input_with_addresses.mlir found; cannot parse")
+            return
+        try:
+            from aie.utils.trace.parse import parse_trace
+            from aie.utils.trace.utils import print_cycles_summary
+            import json as _json
+
+            buf = tcfg.read_trace()
+            with open(physical_mlir) as f:
+                mlir = f.read()
+            events = parse_trace(buf, mlir, colshift=0)
+            json_path = opts.trace_file + ".json"
+            with open(json_path, "w") as f:
+                _json.dump(events, f)
+            print("  parsed   : -> %s" % json_path)
+            print_cycles_summary(json_path)
+        except Exception as e:
+            print("  parse/summary failed: %r" % e)
+        print("  commands : python -m aie.utils.trace.parse --input %s --mlir %s --output trace.json --colshift 0"
+              % (opts.trace_file, physical_mlir))
+
+    if opts.hang:
+        run_hang()
+        return
+
+    # warmup + iters
+    for _ in range(max(opts.warmup, 0)):
+        run_once()
+    iters = max(opts.iters, 1)
+    c_host = None
+    stats_sum = np.zeros(5)
+    t_wall = time.perf_counter()
+    for _ in range(iters):
+        c_host, stats = run_once()
+        stats_sum += stats
+    wall = (time.perf_counter() - t_wall) / iters * 1000.0
+    stats_avg = stats_sum / iters * 1000.0
+
+    # --- report -------------------------------------------------------------
+    flops = 2.0 * host_M * host_K * N
+    print("shape      : M=%d K=%d N=%d (kernel M=%d K=%d, %d K-block(s) x %d M-block(s))"
+          % (host_M, host_K, N, Mk, kernel_K, n_k_blocks, n_m_blocks))
+    print("avg wall   : %.3f ms/iter -> %.1f GFLOP/s, %.1f tokens/s" % (wall, flops / wall / 1e6, 1000.0 / wall))
+    print("  pack     : %.3f ms (%.1f%%)" % (stats_avg[0], 100 * stats_avg[0] / wall))
+    print("  sync A   : %.3f ms (%.1f%%)" % (stats_avg[1], 100 * stats_avg[1] / wall))
+    print("  submit   : %.3f ms (%.1f%%)" % (stats_avg[2], 100 * stats_avg[2] / wall))
+    print("  wait NPU : %.3f ms (%.1f%%)" % (stats_avg[3], 100 * stats_avg[3] / wall))
+    print("  read C   : %.3f ms (%.1f%%)" % (stats_avg[4], 100 * stats_avg[4] / wall))
+
+    if not opts.no_verify:
+        C_ref = A.astype(np.float32) @ B.astype(np.float32)
+        C = c_host[0:host_M, :]
+        err = np.max(np.abs(C - C_ref))
+        print("verify     : max abs err %.4g (bf16 tolerance ~1e-2)" % err)
+
+    if trace_words is not None:
+        _save_trace(trace_words)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="gemm",
+        description="Build the ggml-xdna NPU GEMM kernel (C = A @ B, bf16->f32)",
+    )
+    add_compile_args(parser)
+    parser.add_argument("-M", type=int, default=32,
+                        help="Total M dimension (rows, multiple of 4*tile_m)")
+    parser.add_argument("-K", type=int, default=1024,
+                        help="Total K dimension (inner dim, multiple of tile_k). "
+                             "1024 = GEMM_K_MAX; set > 1024 with --hang to probe the K_div_k > 64 boundary")
+    parser.add_argument("-N", type=int, default=2048,
+                        help="Total N dimension (cols, multiple of tile_n*n_aie_cols)")
+
+    # Tile dimensions (sub-block sizes)
+    parser.add_argument("--tile-m", type=int, default=8, dest="tile_m",
+                        help="Per-core M tile (default: 8)")
+    parser.add_argument("--tile-k", type=int, default=64, dest="tile_k",
+                        help="Per-core K tile (default: 64; larger = fewer C reloads)")
+    # bfp16 emulation uses the r=8 mmul (2x throughput, tile_m % 16 == 0);
+    # --no-bfp16 builds the native bf16 r=4 kernel (tile_m 8) for decode.
+    parser.add_argument("--no-bfp16", action="store_true", dest="no_bfp16",
+                        help="Use the native bf16 r=4 mmul (tile-m 8, M 32)")
+    parser.add_argument("--tile-n", type=int, default=64, dest="tile_n",
+                        help="Per-core N tile (default: 64; wider = longer B DDR bursts)")
+
+    # AIE array configuration
+    parser.add_argument("--n-aie-cols", type=int, default=8, dest="n_aie_cols",
+                        help="Number of AIE columns (1-8, default: 8)")
+    parser.add_argument("--n-aie-rows", type=int, default=4, dest="n_aie_rows",
+                        help="Number of AIE core rows used (1-4, default: 4)")
+
+    parser.add_argument("--dtype", choices=sorted(DTYPE_COMBOS), default="bf16_f32")
+
+    # Standalone run mode
+    parser.add_argument("--run", action="store_true",
+                        help="Compile and run the kernel on the NPU (no ggml backend)")
+    parser.add_argument("--host-M", type=int, default=None, dest="host_M",
+                        help="Host matrix M rows (decode=1, prefill=32+); default = -M")
+    parser.add_argument("--host-K", type=int, default=None, dest="host_K",
+                        help="Host matrix K (tiled into -K blocks); default = -K")
+    parser.add_argument("--iters", type=int, default=10, help="Benchmark iterations")
+    parser.add_argument("--warmup", type=int, default=2, help="Warmup iterations")
+    parser.add_argument("--workdir", type=str, default="build/bin",
+                        help="Directory for compiled artifacts (default: build/bin)")
+    parser.add_argument("--trace-size", type=int, default=0, dest="trace_size",
+                        help="AIE trace buffer size in bytes (0 = off)")
+    parser.add_argument("--trace-file", type=str, default="trace.txt", dest="trace_file")
+    parser.add_argument("--trace-rows", type=int, nargs="*", default=None, dest="trace_rows",
+                        help="Compute rows to trace (0..n_aie_rows-1); default all")
+    parser.add_argument("--trace-cols", type=int, nargs="*", default=None, dest="trace_cols",
+                        help="Compute cols to trace (0..n_aie_cols-1); default all")
+    parser.add_argument("--trace-egress", type=int, default=0, dest="trace_egress",
+                        help="Shim column the trace packets are routed to (default: 0)")
+    parser.add_argument("--no-verify", action="store_true",
+                        help="Skip the numpy reference check")
+    parser.add_argument("--hang", action="store_true",
+                        help="Single full-K run with K > 1024 and a watchdog (probe the documented wedge)")
+    parser.add_argument("--hang-timeout", type=float, default=15.0, dest="hang_timeout",
+                        help="Seconds to wait for the --hang run before declaring a wedge")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    opts = parser.parse_args()
+
+    if opts.run or opts.hang:
+        _run_gemm(bf16_f32_gemm, opts)
+    else:
+        run_design_cli(
+            bf16_f32_gemm,
+            opts,
+            compile_kwargs=_compile_kwargs,
+            validate=_validate,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/ggml/src/ggml-xdna/xdna-kernel-pool.cpp
+++ b/ggml/src/ggml-xdna/xdna-kernel-pool.cpp
@@ -1,0 +1,95 @@
+#include "xdna-runtime.h"
+
+#include "ggml-impl.h"
+
+#include <system_error>
+
+namespace fs = std::filesystem;
+
+void xdna_kernel_pool_scan(xdna_kernel_pool * pool) {
+    for (const fs::path & dir : xdna_kernel_search_dirs()) {
+        std::error_code ec;
+        for (const auto & entry : fs::directory_iterator(dir, ec)) {
+            if (ec) {
+                break;
+            }
+            if (entry.path().extension() != ".xclbin") {
+                continue;
+            }
+            pool->names.push_back(entry.path().stem().string());
+        }
+    }
+}
+
+xdna_kernel * xdna_kernel_pool_get_built(xdna_kernel_pool * pool, const std::string & name,
+                                         const char * xclbin_name, const uint32_t * insts, size_t n_words) {
+    std::lock_guard<std::mutex> lock(pool->kernel_mutex);
+
+    auto it = pool->kernels.find(name);
+    if (it != pool->kernels.end()) {
+        return it->second;
+    }
+
+    // nullptr is sticky: a failed lookup is not retried.
+    pool->kernels[name] = nullptr;
+
+    // `xclbin_name` is the artifact stem; resolve it to a real path.
+    xdna_kernel * kern = nullptr;
+    for (const fs::path & dir : xdna_kernel_search_dirs()) {
+        const fs::path xclbin = dir / (std::string(xclbin_name) + ".xclbin");
+        if (fs::exists(xclbin)) {
+            kern = xdna_kernel_load_hw(pool->device, xclbin.c_str());
+            break;
+        }
+    }
+    if (!kern) {
+        GGML_LOG_WARN("%s: kernel %s (hw %s) not found\n", "xdna-kernel-pool",
+                      name.c_str(), xclbin_name);
+        pool->kernels[name] = nullptr;
+        return nullptr;
+    }
+    if (!xdna_kernel_bind_insts(pool->device, kern, insts, n_words)) {
+        xdna_kernel_free(kern);
+        pool->kernels[name] = nullptr;
+        return nullptr;
+    }
+    pool->kernels[name] = kern;
+    return kern;
+}
+
+xdna_buffer * xdna_kernel_pool_acquire_buffer(xdna_kernel_pool * pool, size_t bytes) {
+    {
+        std::lock_guard<std::mutex> lock(pool->pool_mutex);
+        size_t best = pool->pool.size();
+        size_t best_size = 0;
+        for (size_t i = 0; i < pool->pool.size(); i++) {
+            const size_t sz = pool->pool[i].buf->bytes;
+            if (sz >= bytes && (best == pool->pool.size() || sz < best_size)) {
+                best = i;
+                best_size = sz;
+            }
+        }
+        if (best != pool->pool.size()) {
+            xdna_buffer * buf = pool->pool[best].buf;
+            pool->pool.erase(pool->pool.begin() + best);
+            return buf;
+        }
+    }
+    return xdna_buffer_alloc(pool->device, bytes);
+}
+
+void xdna_kernel_pool_release_buffer(xdna_kernel_pool * pool, xdna_buffer * buf) {
+    std::lock_guard<std::mutex> lock(pool->pool_mutex);
+    pool->pool.push_back({buf, ++pool->pool_tick});
+
+    if (pool->pool.size() > xdna_kernel_pool::MAX_POOL_SIZE) {
+        size_t lru = 0;
+        for (size_t i = 1; i < pool->pool.size(); i++) {
+            if (pool->pool[i].seq < pool->pool[lru].seq) {
+                lru = i;
+            }
+        }
+        xdna_buffer_free(pool->pool[lru].buf);
+        pool->pool.erase(pool->pool.begin() + lru);
+    }
+}

--- a/ggml/src/ggml-xdna/xdna-ops.cpp
+++ b/ggml/src/ggml-xdna/xdna-ops.cpp
@@ -1,0 +1,476 @@
+#include "xdna-ops.h"
+#include "xdna-runtime.h"
+#include "xdna-profile.h"
+
+#include "ggml-impl.h"
+#include "ggml-quants.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+// --- GEMM internals (static) ------------------------------------------------
+
+// K is split into blocks of at most GEMM_K_MAX: a per-core K-loop count above
+// 64 (K > 1024 with tile_k=16) wedges the shared hw_context. GEMM_N_MAX is a
+// practical cap on N: wide projections (e.g. the vocabulary output) need a
+// huge B transpose and run too long on the NPU.
+static const int GEMM_K_MAX = 1024;
+static const int GEMM_N_MAX = 16384;
+
+// Per-call breakdown is printed when GGML_XDNA_PROFILING=1.
+static bool ggml_xdna_profiling_enabled(void) {
+    static const bool en = []() {
+        const char * v = getenv("GGML_XDNA_PROFILING");
+        return v != nullptr && atoi(v) >= 1;
+    }();
+    return en;
+}
+
+static int xdna_env_int(const char * name, int def) {
+    const char * v = getenv(name);
+    return v ? atoi(v) : def;
+}
+
+// Pick the geometry for an op: the prefill (M=64) geometry for ops wide
+// enough to fill it, otherwise the decode (M=32) geometry. Both the tiles and
+// the xclbin stem derive from the same condition, so they never disagree.
+static const xdna_gemm_tiles & xdna_pick_tiles(const xdna_ops * ops, int M) {
+    if (M >= ops->gemm_big_m_min && !ops->gemm_xclbin_prefill.empty()) {
+        return ops->gemm_tiles_prefill;
+    }
+    return ops->gemm_tiles;
+}
+
+static const char * xdna_pick_xclbin(const xdna_ops * ops, int M) {
+    if (M >= ops->gemm_big_m_min && !ops->gemm_xclbin_prefill.empty()) {
+        return ops->gemm_xclbin_prefill.c_str();
+    }
+    return ops->gemm_xclbin_decode.c_str();
+}
+
+// Return the device BO holding the packed [K_pad x N] bf16 weight for `src0`,
+// built and cached on first use. K_pad rounds K up to the GEMM block, so every
+// K-block reads a valid slice. Weights are immutable, so the transpose + bf16
+// conversion runs once.
+static xdna_buffer * gemm_weight_bo(xdna_ops * ops, const struct ggml_tensor * src0, int K, int N) {
+    const xdna_ops::weight_key key = { src0->data, K, N };
+    {
+        std::lock_guard<std::mutex> lock(ops->weight_mutex);
+        auto it = ops->weight_bo.find(key);
+        if (it != ops->weight_bo.end()) {
+            return it->second;
+        }
+    }
+
+    const int K_pad = (K + GEMM_K_MAX - 1) / GEMM_K_MAX * GEMM_K_MAX;
+    xdna_buffer * bo_w = xdna_buffer_alloc(ops->pool->device, (size_t) K_pad * N * sizeof(ggml_bf16_t));
+    if (!bo_w) {
+        GGML_LOG_ERROR("%s: failed to allocate weight BO\n", "xdna-ops");
+        return nullptr;
+    }
+
+    ggml_bf16_t * w = (ggml_bf16_t *) bo_w->bo.map();
+    std::memset(w, 0, (size_t) K_pad * N * sizeof(ggml_bf16_t));
+    if (src0->type == GGML_TYPE_BF16) {
+        const auto * d = (const ggml_bf16_t *) src0->data;
+        for (int n = 0; n < N; n++) {
+            for (int k = 0; k < K; k++) {
+                w[(size_t) k * N + n] = d[(size_t) n * K + k];
+            }
+        }
+    } else if (src0->type == GGML_TYPE_F16) {
+        std::vector<float> row(K);
+        for (int n = 0; n < N; n++) {
+            ggml_fp16_to_fp32_row((const ggml_fp16_t *) src0->data + (size_t) n * K, row.data(), K);
+            for (int k = 0; k < K; k++) {
+                ggml_fp32_to_bf16_row(&row[k], &w[(size_t) k * N + n], 1);
+            }
+        }
+    } else if (src0->type == GGML_TYPE_Q4_K) {
+        // Quantized weights are dequantized once at pack time and stored as
+        // bf16, so the NPU kernel stays unchanged.
+        std::vector<float> row(K);
+        const int nb = K / QK_K;
+        for (int n = 0; n < N; n++) {
+            dequantize_row_q4_K((const block_q4_K *) src0->data + (size_t) n * nb, row.data(), K);
+            for (int k = 0; k < K; k++) {
+                ggml_fp32_to_bf16_row(&row[k], &w[(size_t) k * N + n], 1);
+            }
+        }
+    }
+    xdna_buffer_sync_to_device(bo_w);
+
+    std::lock_guard<std::mutex> lock(ops->weight_mutex);
+    ops->weight_bo.emplace(key, bo_w);
+    return bo_w;
+}
+
+// MUL_MAT follows ggml's convention: src0 = weights [K, N] (stored as N rows
+// of K), src1 = activations [K, M] (stored as M rows of K), so dst[M, N] =
+// src1^T @ src0. src1's memory feeds the kernel directly as A [M, K]; src0's
+// memory is transposed to B [K, N]. The stream is built per shape via
+// xdna_gemm_seq_build, so only A's rows are padded to the baked M block.
+//
+// Submission is pipelined: two A/C buffer banks are ping-ponged. The run for
+// block (m0, k0) is submitted without waiting, then the previous block's run
+// is waited and its C read back while the NPU processes the new one, so the
+// C readback overlaps the GEMM. The last few runs are finished in
+// xdna_ops_finalize().
+static bool gemm_compute(xdna_ops * ops, struct ggml_tensor * node) {
+    const struct ggml_tensor * src0 = node->src[0];
+    const struct ggml_tensor * src1 = node->src[1];
+
+    const int M = (int) src1->ne[1];
+    const int K = (int) src1->ne[0];
+    const int N = (int) src0->ne[1];
+
+    // Guaranteed to be supported: compute is only reached for ops accepted by
+    // xdna_ops_supported.
+    const xdna_gemm_tiles & tiles = xdna_pick_tiles(ops, M);
+    const int Mk = tiles.M;   // baked M block of the selected geometry
+
+    const bool prof_en = ggml_xdna_profiling_enabled();
+    xdna_mul_mat_profile prof;
+    const xdna_timer t_op;
+
+    // B is a persistent BO with the packed [K_pad x N] weights; each K-block's
+    // stream points into it via its K offset, so no per-call weight copy.
+    xdna_buffer * bo_w = gemm_weight_bo(ops, src0, K, N);
+    if (!bo_w) {
+        return false;
+    }
+
+    // All blocks use the full GEMM_K_MAX kernel: a partial K block (K < 1024)
+    // after a run of full blocks wedges the shared hw_context, so the last
+    // block is zero-padded in K and runs the same K1024 kernel as the rest.
+    xdna_ops::pending_op op;
+    op.node = node;
+    op.M = M;
+    op.N = N;
+    op.Mk = Mk;
+    op.m_off = 0;
+    for (int m0 = 0; m0 < M; m0 += Mk) {
+        xdna_ops::pending_m_block mb;
+        mb.m0 = m0;
+        mb.c_acc.assign((size_t) Mk * N, 0.0f);
+        op.m_blocks.push_back(std::move(mb));
+    }
+
+    // Ping-pong A/C banks. Bank b is reused only after its in-flight run has
+    // been waited and its C read back, so the readback overlaps the NPU run
+    // that follows.
+    xdna_ops::pending_run banks[2];
+    int bank = 0;
+    int pending_bank = -1;   // bank with a submitted, un-waited run
+
+    for (int k0 = 0; k0 < K; k0 += GEMM_K_MAX) {
+        const int Kb = std::min(GEMM_K_MAX, K - k0);
+        const uint32_t b_offset = (uint32_t) k0 * N * 2;
+
+        // Build the instruction stream for (GEMM_K_MAX, N) with this block's
+        // B offset and cache the bound kernel under the shape key.
+        xdna_seq seq;
+        if (!xdna_gemm_seq_build(&seq, &tiles, Mk, GEMM_K_MAX, N, b_offset)) {
+            GGML_LOG_ERROR("%s: failed to build GEMM stream M=%d K=%d N=%d\n", "xdna-ops", M, K, N);
+            return false;
+        }
+        std::vector<uint32_t> insts = xdna_seq_build(&seq);
+
+        char name[64];
+        snprintf(name, sizeof(name), "gemm_K%d_N%d_b%d_m%d", GEMM_K_MAX, N, k0, Mk);
+        xdna_kernel * kern = xdna_kernel_pool_get_built(ops->pool, name, xdna_pick_xclbin(ops, M),
+                                                        insts.data(), insts.size());
+        if (!kern) {
+            GGML_LOG_ERROR("%s: failed to load GEMM kernel %s\n", "xdna-ops", name);
+            return false;
+        }
+
+        for (auto & mb : op.m_blocks) {
+            const int mc = std::min(Mk, M - mb.m0);
+
+            // Pack A into the current bank and submit. The NPU starts on this
+            // run right away; the previous bank's run (already queued ahead of
+            // it) is then waited and read back while this one runs.
+            xdna_ops::pending_run & pr = banks[bank];
+            if (pr.bo_a == nullptr) {
+                pr.bo_a = xdna_kernel_pool_acquire_buffer(ops->pool, (size_t) Mk * GEMM_K_MAX * sizeof(ggml_bf16_t));
+                pr.bo_c = xdna_kernel_pool_acquire_buffer(ops->pool, (size_t) Mk * N * sizeof(float));
+                if (!pr.bo_a || !pr.bo_c) {
+                    GGML_LOG_ERROR("%s: failed to allocate GEMM buffers\n", "xdna-ops");
+                    return false;
+                }
+                pr.c_buf.assign((size_t) Mk * N, 0.0f);
+                pr.N = N;
+            }
+            pr.mb_idx = (int) (&mb - op.m_blocks.data());
+            {
+                const xdna_timer t;
+                ggml_bf16_t * a_map = (ggml_bf16_t *) pr.bo_a->bo.map();
+                std::memset(a_map, 0, (size_t) Mk * GEMM_K_MAX * sizeof(ggml_bf16_t));
+                for (int m = 0; m < mc; m++) {
+                    ggml_fp32_to_bf16_row((const float *) src1->data + (size_t) (mb.m0 + m) * K + k0,
+                                          a_map + (size_t) m * GEMM_K_MAX, Kb);
+                }
+                if (prof_en) prof.a_pack += t.ms();
+            }
+
+            {
+                const xdna_timer t;
+                xdna_buffer_sync_to_device(pr.bo_a);
+                if (prof_en) prof.sync += t.ms();
+            }
+
+            xdna_buffer * args[3] = { pr.bo_a, bo_w, pr.bo_c };
+            {
+                const xdna_timer t;
+                pr.run = xdna_kernel_run_start(kern, args, 3);
+                if (!pr.run) {
+                    GGML_LOG_ERROR("%s: GEMM submit failed M=%d K=%d N=%d kernel=gemm_K%d_N%d_b%d\n",
+                                   "xdna-ops", M, K, N, GEMM_K_MAX, N, k0);
+                    return false;
+                }
+                if (prof_en) prof.run += t.ms();
+            }
+
+            // The NPU is now working on `bank`; wait + read back the previous
+            // bank's run (queued ahead of this one) in parallel with it.
+            if (pending_bank >= 0) {
+                xdna_ops::pending_run & prev = banks[pending_bank];
+                {
+                    const xdna_timer t;
+                    if (!xdna_run_wait(prev.run)) {
+                        GGML_LOG_ERROR("%s: GEMM wait failed M=%d K=%d N=%d\n", "xdna-ops", M, K, N);
+                        return false;
+                    }
+                    if (prof_en) prof.wait += t.ms();
+                }
+                {
+                    const xdna_timer t;
+                    // Read back only the valid rows: rows [mc, Mk) of a padded
+                    // block are zero (the padded A rows are zeroed), so the
+                    // prefix is exact and the readback drops to mc*N elements.
+                    const size_t p_elems = (size_t) std::min(Mk, op.M - op.m_blocks[prev.mb_idx].m0) * prev.N;
+                    xdna_buffer_read(prev.bo_c, prev.c_buf.data(), p_elems * sizeof(float));
+                    if (prof_en) prof.read += t.ms();
+                }
+                const size_t p_elems = (size_t) std::min(Mk, op.M - op.m_blocks[prev.mb_idx].m0) * prev.N;
+                for (size_t i = 0; i < p_elems; i++) {
+                    op.m_blocks[prev.mb_idx].c_acc[i] += prev.c_buf[i];
+                }
+                xdna_kernel_pool_release_buffer(ops->pool, prev.bo_a);
+                xdna_kernel_pool_release_buffer(ops->pool, prev.bo_c);
+                banks[pending_bank].bo_a = nullptr;
+                banks[pending_bank].bo_c = nullptr;
+            }
+
+            pending_bank = bank;
+            bank = 1 - bank;
+            prof.n_blocks++;
+        }
+    }
+
+    // Flush the trailing banks into the op so finalize waits+reads them.
+    if (pending_bank >= 0) {
+        op.m_blocks[banks[pending_bank].mb_idx].runs.push_back(std::move(banks[pending_bank]));
+        banks[pending_bank] = xdna_ops::pending_run();
+        pending_bank = -1;
+    }
+
+    ops->pending.push_back(std::move(op));
+
+    if (prof_en) {
+        prof.total = t_op.ms();
+        fprintf(stderr,
+                "xdna-profile: MUL_MAT %s M=%d K=%d N=%d blocks=%d "
+                "total=%.3fms apack=%.3f sync=%.3f submit=%.3f wait=%.3f read=%.3f\n",
+                node->name, M, K, N, prof.n_blocks,
+                prof.total, prof.a_pack, prof.sync, prof.run, prof.wait, prof.read);
+    }
+
+    return true;
+}
+
+bool xdna_ops_finalize(xdna_ops * ops) {
+    if (ops->pending.empty()) {
+        return true;
+    }
+
+    const bool prof_en = ggml_xdna_profiling_enabled();
+    const xdna_timer t_all;
+
+    // Wait all runs first so all kernels of the layer complete together.
+    const xdna_timer t_wait;
+    for (auto & op : ops->pending) {
+        for (auto & mb : op.m_blocks) {
+            for (auto & pr : mb.runs) {
+                if (!xdna_run_wait(pr.run)) {
+                    GGML_LOG_ERROR("%s: finalize: kernel wait failed\n", "xdna-ops");
+                    for (auto & fop : ops->pending) {
+                        for (auto & fmb : fop.m_blocks) {
+                            for (auto & fpr : fmb.runs) {
+                                xdna_kernel_pool_release_buffer(ops->pool, fpr.bo_a);
+                                xdna_kernel_pool_release_buffer(ops->pool, fpr.bo_c);
+                            }
+                        }
+                    }
+                    ops->pending.clear();
+                    return false;
+                }
+            }
+        }
+    }
+    const double ms_wait = t_wait.ms();
+
+    // Read C, accumulate K-blocks per M-block, write dst, release buffers.
+    // Most runs are already waited/read/accumulated inside gemm_compute's
+    // pipeline; only the trailing banks land here. m_blocks without runs have
+    // their c_acc fully accumulated already, so just scatter them.
+    const xdna_timer t_read;
+    for (auto & op : ops->pending) {
+        const int Mk = op.Mk;   // per-op geometry M block
+        for (auto & mb : op.m_blocks) {
+            // Trailing runs are read back here; read only the valid rows.
+            const size_t mc_elems = (size_t) std::min(Mk, op.M - mb.m0) * op.N;
+            for (auto & pr : mb.runs) {
+                xdna_buffer_read(pr.bo_c, pr.c_buf.data(), mc_elems * sizeof(float));
+                for (size_t i = 0; i < mc_elems; i++) {
+                    mb.c_acc[i] += pr.c_buf[i];
+                }
+            }
+            const int mc = std::min(Mk, op.M - mb.m0);
+            for (int m = 0; m < mc; m++) {
+                std::memcpy((char *) op.node->data + (size_t) (op.m_off + mb.m0 + m) * op.node->nb[1],
+                            mb.c_acc.data() + (size_t) m * op.N,
+                            (size_t) op.N * sizeof(float));
+            }
+            for (auto & pr : mb.runs) {
+                xdna_kernel_pool_release_buffer(ops->pool, pr.bo_a);
+                xdna_kernel_pool_release_buffer(ops->pool, pr.bo_c);
+            }
+        }
+    }
+
+    if (prof_en) {
+        fprintf(stderr, "xdna-profile: FINALIZE ops=%zu total=%.3fms wait=%.3f read=%.3f\n",
+                ops->pending.size(), t_all.ms(), ms_wait, t_read.ms());
+    }
+
+    ops->pending.clear();
+    return true;
+}
+
+static bool gemm_supported(const xdna_ops * ops, const struct ggml_tensor * op) {
+    if (op->op != GGML_OP_MUL_MAT) {
+        return false;
+    }
+
+    const struct ggml_tensor * src0 = op->src[0];
+    const struct ggml_tensor * src1 = op->src[1];
+    if (!src0 || !src1) {
+        return false;
+    }
+
+    const int K = (int) src1->ne[0];
+    const int N = (int) src0->ne[1];
+    const int M = (int) src1->ne[1];
+
+    if (ops->gemm_xclbin_decode.empty()) {
+        return false;
+    }
+    if (M <= 0) {
+        return false;
+    }
+    // The picked geometry falls back to the next smaller artifact; the op is
+    // rejected only when the decode kernel is absent.
+    if (M >= ops->gemm_big_m_min && ops->gemm_xclbin_prefill.empty()) {
+        return false;
+    }
+    const xdna_gemm_tiles & tiles = xdna_pick_tiles(ops, M);
+    // The stream is always built for the baked M block, so the geometry check
+    // is on the block M; op M is tiled into blocks.
+    if (!xdna_gemm_seq_supported(&tiles, tiles.M, K, N)) {
+        return false;
+    }
+    // Practical cap on N: wide projections (e.g. the vocabulary output) need a
+    // huge B transpose and run too long on the NPU; those stay on the CPU.
+    if (N > GEMM_N_MAX) {
+        return false;
+    }
+    if (src0->ne[0] != K) {
+        return false;
+    }
+    if (src0->ne[2] * src0->ne[3] != 1 || src1->ne[2] * src1->ne[3] != 1) {
+        return false;
+    }
+    if (src1->type != GGML_TYPE_F32 || op->type != GGML_TYPE_F32) {
+        return false;
+    }
+    if (src0->type != GGML_TYPE_BF16 && src0->type != GGML_TYPE_F16 &&
+        src0->type != GGML_TYPE_Q4_K) {
+        return false;
+    }
+    // Q4_K rows are packed in 256-element blocks (QK_K); dequantization needs
+    // whole blocks.
+    if (src0->type == GGML_TYPE_Q4_K && K % QK_K != 0) {
+        return false;
+    }
+    if (!ggml_is_contiguous(op) || !ggml_is_contiguous(src0) || !ggml_is_contiguous(src1)) {
+        return false;
+    }
+
+    return true;
+}
+
+// --- public API -------------------------------------------------------------
+
+void xdna_ops_init(xdna_ops * ops, xdna_kernel_pool * pool) {
+    ops->pool = pool;
+    ops->gemm_tiles = xdna_gemm_tiles{};
+    ops->gemm_tiles_prefill = xdna_gemm_tiles{};
+    ops->gemm_tiles_prefill.M = GGML_XDNA_GEMM_M_BIG;
+    ops->gemm_tiles_prefill.tile_m = GGML_XDNA_TILE_M_BIG;
+    ops->gemm_tiles_prefill.rtp_base = XDNA_RTP_BASE_TILE_M16;
+    ops->gemm_xclbin_decode.clear();
+    ops->gemm_xclbin_prefill.clear();
+    ops->gemm_big_m_min = xdna_env_int("GGML_XDNA_GEMM_BIG_M_MIN", 64);
+
+    // Stems are gemm_bf16_f32_M%d_K%d_N%d_c%d (see CMakeLists).
+    for (const std::string & name : pool->names) {
+        int M = 0, K = 0, N = 0, C = 0;
+        if (sscanf(name.c_str(), "gemm_bf16_f32_M%d_K%d_N%d_c%d", &M, &K, &N, &C) != 4) {
+            continue;
+        }
+        if (M == GGML_XDNA_GEMM_M_BIG) {
+            ops->gemm_xclbin_prefill = name;
+        } else if (M == GGML_XDNA_GEMM_M) {
+            ops->gemm_xclbin_decode = name;
+        }
+    }
+
+    GGML_LOG_INFO("%s: GEMM geometries: decode=%s prefill=%s (big-M threshold %d)\n", "xdna-ops",
+                  ops->gemm_xclbin_decode.c_str(), ops->gemm_xclbin_prefill.c_str(),
+                  ops->gemm_big_m_min);
+}
+
+bool xdna_ops_supported(const xdna_ops * ops, const struct ggml_tensor * op) {
+    switch (op->op) {
+        case GGML_OP_MUL_MAT:
+            return gemm_supported(ops, op);
+        default:
+            return false;
+    }
+}
+
+bool xdna_ops_compute(xdna_ops * ops, struct ggml_tensor * node) {
+    switch (node->op) {
+        case GGML_OP_MUL_MAT:
+            return gemm_compute(ops, node);
+        default:
+            GGML_LOG_ERROR("%s: unsupported op %d in XDNA graph\n",
+                           "xdna-ops", (int) node->op);
+            return false;
+    }
+}

--- a/ggml/src/ggml-xdna/xdna-ops.h
+++ b/ggml/src/ggml-xdna/xdna-ops.h
@@ -1,0 +1,100 @@
+#pragma once
+
+// Operator-specific dispatch for the XDNA backend, kept out of ggml-xdna.cpp
+// so backend scaffolding and per-op logic stay separate. Only GEMM is
+// implemented so far; other ops get their own helpers here.
+
+#include "xdna-types.h"
+#include "xdna-runtime.h"
+#include "xdna-seq.h"
+#include "ggml.h"
+
+#include <map>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+struct ggml_tensor;
+
+// Operator-specific state. Data only; the API lives below as C-style
+// functions.
+struct xdna_ops {
+    xdna_kernel_pool * pool = nullptr;
+
+    // Two GEMM geometries: decode (M=32, native bf16 r=4, exact) and prefill
+    // (M=64, bfp16-emulated r=8, 2x mmul). Ops with M >= gemm_big_m_min use
+    // the prefill geometry; everything else the decode one.
+    xdna_gemm_tiles gemm_tiles;          // decode geometry (default)
+    xdna_gemm_tiles gemm_tiles_prefill;  // prefill geometry (M=64, rtp 0xd000)
+    std::string gemm_xclbin_decode;      // discovered M32 xclbin stem
+    std::string gemm_xclbin_prefill;     // discovered M64 xclbin stem
+    int gemm_big_m_min = 64;             // M >= this -> prefill geometry
+
+    // Packed-weight cache: tensor data pointer + K + N -> device BO holding the
+    // transposed [K_pad x N] bf16 weights (K_pad = K rounded up to the GEMM
+    // block). Weights are immutable, so the pack (transpose + bf16 conversion)
+    // is done once per tensor and reused; kernels point into it via B offsets.
+    struct weight_key {
+        const void * data = nullptr;
+        int          K = 0;
+        int          N = 0;
+
+        bool operator==(const weight_key & o) const {
+            return data == o.data && K == o.K && N == o.N;
+        }
+    };
+    struct weight_hash {
+        size_t operator()(const weight_key & k) const {
+            size_t h = std::hash<const void *>{}(k.data);
+            h = h * 31 + (size_t) k.K;
+            h = h * 31 + (size_t) k.N;
+            return h;
+        }
+    };
+
+    std::unordered_map<weight_key, xdna_buffer *, weight_hash> weight_bo;
+    std::mutex weight_mutex;
+
+    // Batching: MUL_MAT ops are submitted (started without wait) and collected
+    // here; xdna_ops_finalize() waits them all, reads C back, and writes dst.
+    // Each op is tiled in M (the baked M block) and K (GEMM_K_MAX blocks): a
+    // pending_run is one (M-block, K-block) submission.
+    struct pending_run {
+        xrt::run       run;
+        xdna_buffer *  bo_c = nullptr;   // held until readback
+        xdna_buffer *  bo_a = nullptr;   // released after readback
+        std::vector<float> c_buf;        // Mk x N readback target
+        int N = 0;
+        int mb_idx = 0;                  // index into pending_op::m_blocks
+    };
+    struct pending_m_block {
+        int m0 = 0;                      // dst row offset of this M-block
+        std::vector<float> c_acc;        // Mk x N accumulator
+        std::vector<pending_run> runs;   // one per K-block
+    };
+    struct pending_op {
+        struct ggml_tensor * node = nullptr;
+        int Mk = 0;                      // M block of the geometry used (32 or 64)
+        int m_off = 0;                   // first row of the range in the op
+        int M = 0;                       // total rows of the op
+        int N = 0;                       // total columns of the op
+        std::vector<pending_m_block> m_blocks;
+    };
+    std::vector<pending_op> pending;
+};
+
+// Discover the GEMM xclbin and set up the fixed geometry.
+void xdna_ops_init(xdna_ops * ops, xdna_kernel_pool * pool);
+
+// True when `op` can be run on the NPU. Dispatches per-op (only GEMM so far).
+bool xdna_ops_supported(const xdna_ops * ops, const struct ggml_tensor * op);
+
+// Execute `node` on the NPU. Dispatches per-op; returns false on failure.
+// With batching this only submits (starts) the kernels; call xdna_ops_finalize
+// after all ops of a layer to wait and write results.
+bool xdna_ops_compute(xdna_ops * ops, struct ggml_tensor * node);
+
+// Wait all pending submissions, read C back, accumulate K-blocks, write dst,
+// and release buffers. Safe to call when nothing is pending.
+bool xdna_ops_finalize(xdna_ops * ops);

--- a/ggml/src/ggml-xdna/xdna-profile.h
+++ b/ggml/src/ggml-xdna/xdna-profile.h
@@ -1,0 +1,30 @@
+#pragma once
+
+// Lightweight per-op timing for the XDNA backend (GGML_XDNA_PROFILING=1).
+// Uses ggml_time_us() for wall-clock timing.
+
+#include "ggml.h"
+
+#include <cstdint>
+
+struct xdna_timer {
+    int64_t t0 = ggml_time_us();
+
+    // Milliseconds since construction.
+    double ms() const {
+        return (double) (ggml_time_us() - t0) / 1000.0;
+    }
+};
+
+// Per-call MUL_MAT timing breakdown, filled when profiling is enabled. The
+// block phases are summed across all K-blocks.
+struct xdna_mul_mat_profile {
+    double a_pack   = 0;   // pack A rows to bf16 (memset + convert)
+    double sync     = 0;   // sync A BO to the device
+    double run      = 0;   // kernel submission (start without wait)
+    double wait     = 0;   // wait for the previous bank's run (NPU time)
+    double read     = 0;   // read back the previous bank's C
+
+    int    n_blocks = 0;   // K-blocks executed
+    double total    = 0;   // whole MUL_MAT (submit phase only)
+};

--- a/ggml/src/ggml-xdna/xdna-runtime.cpp
+++ b/ggml/src/ggml-xdna/xdna-runtime.cpp
@@ -1,0 +1,210 @@
+#include "xdna-runtime.h"
+
+#include "ggml-impl.h"
+
+#include <xrt/experimental/xrt_kernel.h>
+#include <xrt/experimental/xrt_xclbin.h>
+#include <xrt/xrt_kernel.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+// NPU kernel ABI: arg 0 is the opcode, where 3 = RUN the instruction stream.
+static constexpr int XAIE_NPU_OPCODE_RUN = 3;
+
+// Loaded xclbins: uuid -> shared hw_context. All variants of one xclbin share
+// a context; kernels hold a shared_ptr so contexts outlive every kernel that
+// references them.
+static std::mutex                                            g_ctx_mutex;
+static std::map<xrt::uuid, std::shared_ptr<xrt::hw_context>> g_ctxs;
+
+// --- device -----------------------------------------------------------
+
+xdna_device * xdna_device_open(void) {
+    xdna_device * dev = new xdna_device;
+    try {
+        dev->device      = xrt::device(0);
+        dev->name        = dev->device.get_info<xrt::info::device::name>();
+        dev->description = dev->device.get_info<xrt::info::device::bdf>();
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: failed to open NPU device: %s\n", "xdna-runtime", e.what());
+        delete dev;
+        return nullptr;
+    }
+    return dev;
+}
+
+// --- kernel -------------------------------------------------------------
+
+std::vector<fs::path> xdna_kernel_search_dirs(void) {
+    std::vector<fs::path> dirs;
+#ifdef GGML_BACKEND_DIR
+    dirs.emplace_back(GGML_BACKEND_DIR);
+#endif
+#ifdef __linux__
+    std::error_code ec;
+    fs::path exe = fs::read_symlink("/proc/self/exe", ec);
+    if (!ec) {
+        dirs.push_back(exe.parent_path());
+    }
+#endif
+    dirs.emplace_back(fs::current_path());
+    return dirs;
+}
+
+// Load an xclbin into a kernel handle without an instruction stream. The
+// stream is bound later with xdna_kernel_bind_insts. Returns nullptr on
+// failure.
+xdna_kernel * xdna_kernel_load_hw(xdna_device * dev, const char * xclbin_path) {
+    if (!dev) {
+        GGML_LOG_ERROR("%s: kernel load: no device\n", "xdna-runtime");
+        return nullptr;
+    }
+
+    try {
+        const std::string xclbin_path_str(xclbin_path);
+        const xrt::xclbin xclbin{xclbin_path_str};
+        dev->device.register_xclbin(xclbin);
+        const xrt::uuid xclbin_uuid = xclbin.get_uuid();
+
+        // Reuse the hw_context for this xclbin across all kernel variants.
+        std::shared_ptr<xrt::hw_context> context;
+        {
+            std::lock_guard<std::mutex> lock(g_ctx_mutex);
+            auto it = g_ctxs.find(xclbin_uuid);
+            if (it != g_ctxs.end()) {
+                context = it->second;
+            } else {
+                context = std::make_shared<xrt::hw_context>(dev->device, xclbin_uuid);
+                g_ctxs.emplace(xclbin_uuid, context);
+            }
+        }
+
+        const auto kernels = xclbin.get_kernels();
+        if (kernels.empty()) {
+            GGML_LOG_ERROR("%s: no kernel found in %s\n", "xdna-runtime", xclbin_path);
+            return nullptr;
+        }
+
+        xdna_kernel * kern = new xdna_kernel;
+        kern->context      = context;
+        kern->kernel       = xrt::kernel(*context, kernels[0].get_name());
+        return kern;
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: failed to load kernel %s: %s\n", "xdna-runtime", xclbin_path, e.what());
+        return nullptr;
+    }
+}
+
+// Bind an in-memory instruction stream to a loaded kernel. The insts BO is
+// created on group 1 (the instruction buffer). `dev` must be the same handle
+// used for the data buffers (XRT treats copies of xrt::device as distinct;
+// mixing them can wedge submissions). Returns false on failure.
+bool xdna_kernel_bind_insts(xdna_device * dev, xdna_kernel * kern, const uint32_t * insts, size_t n_words) {
+    if (!dev || !kern || !insts || n_words == 0) {
+        GGML_LOG_ERROR("%s: bind insts: null device/kernel/insts or empty stream\n", "xdna-runtime");
+        return false;
+    }
+    try {
+        kern->insts_bytes = (int64_t)(n_words * sizeof(uint32_t));
+        kern->insts_bo    = xrt::bo(dev->device, (size_t) kern->insts_bytes,
+                                    xrt::bo::flags::cacheable, kern->kernel.group_id(1));
+        std::memcpy(kern->insts_bo.map(), insts, (size_t) kern->insts_bytes);
+        kern->insts_bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        return true;
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: failed to bind instruction stream: %s\n", "xdna-runtime", e.what());
+        return false;
+    }
+}
+
+void xdna_kernel_free(xdna_kernel * kern) {
+    delete kern;
+}
+
+// --- buffer -------------------------------------------------------------
+
+xdna_buffer * xdna_buffer_alloc(xdna_device * dev, size_t bytes) {
+    if (!dev) {
+        GGML_LOG_ERROR("%s: buffer alloc: no device\n", "xdna-runtime");
+        return nullptr;
+    }
+    xdna_buffer * buf = new xdna_buffer;
+    try {
+        buf->bo    = xrt::bo(dev->device, bytes, xrt::bo::flags::host_only, 0);
+        buf->bytes = bytes;
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: failed to allocate %zu-byte BO: %s\n", "xdna-runtime", bytes, e.what());
+        delete buf;
+        return nullptr;
+    }
+    return buf;
+}
+
+void xdna_buffer_free(xdna_buffer * buf) {
+    delete buf;
+}
+
+void xdna_buffer_sync_to_device(xdna_buffer * buf) {
+    if (buf) {
+        buf->bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    }
+}
+
+void xdna_buffer_read(xdna_buffer * buf, void * host, size_t bytes) {
+    buf->bo.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+    std::memcpy(host, buf->bo.map(), bytes);
+}
+
+// --- execution ------------------------------------------------------------
+
+// Configure a run for `kern` with `n_args` host buffers (ABI: 0=opcode,
+// 1=instruction BO, 2=ninstr, 3..=host buffers).
+static xrt::run make_run(xdna_kernel * kern, xdna_buffer ** args, size_t n_args) {
+    xrt::run run(kern->kernel);
+    run.set_arg(0, XAIE_NPU_OPCODE_RUN);
+    run.set_arg(1, kern->insts_bo);
+    run.set_arg(2, kern->insts_bytes);
+    for (size_t i = 0; i < n_args; i++) {
+        run.set_arg((int) (3 + i), args[i]->bo);
+    }
+    return run;
+}
+
+xrt::run xdna_kernel_run_start(xdna_kernel * kern, xdna_buffer ** args, size_t n_args) {
+    if (!kern || !args || n_args == 0) {
+        GGML_LOG_ERROR("%s: run start: null kernel/args or no buffers\n", "xdna-runtime");
+        return xrt::run{};
+    }
+    try {
+        xrt::run run = make_run(kern, args, n_args);
+        run.start();
+        return run;
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: kernel run start exception: %s\n", "xdna-runtime", e.what());
+        return xrt::run{};
+    }
+}
+
+bool xdna_run_wait(xrt::run & run) {
+    try {
+        const ert_cmd_state st = run.wait();
+        if (st != ERT_CMD_STATE_COMPLETED) {
+            GGML_LOG_ERROR("%s: kernel wait state %d\n", "xdna-runtime", (int) st);
+            return false;
+        }
+        return true;
+    } catch (const std::exception & e) {
+        GGML_LOG_ERROR("%s: kernel wait exception: %s\n", "xdna-runtime", e.what());
+        return false;
+    }
+}
+
+

--- a/ggml/src/ggml-xdna/xdna-runtime.h
+++ b/ggml/src/ggml-xdna/xdna-runtime.h
@@ -1,0 +1,70 @@
+#pragma once
+
+// Thin runtime over XRT for the AMD XDNA NPU: device, kernel (xclbin + insts)
+// and host-visible buffers. Struct definitions live in xdna-types.h.
+
+#include "xdna-types.h"
+
+#include <filesystem>
+#include <vector>
+
+// --- device -----------------------------------------------------------
+
+// Open the first NPU. Returns nullptr when no device is available.
+xdna_device * xdna_device_open(void);
+
+// --- kernel -------------------------------------------------------------
+
+// Kernel search dirs (the backend dir, the executable dir, cwd).
+std::vector<std::filesystem::path> xdna_kernel_search_dirs(void);
+
+// Load an xclbin into a kernel handle without an instruction stream; bind one
+// later with xdna_kernel_bind_insts. Returns nullptr on failure.
+xdna_kernel * xdna_kernel_load_hw(xdna_device * dev, const char * xclbin_path);
+
+// Bind an in-memory instruction stream (TXN words) to a loaded kernel. `dev`
+// must be the same handle used for the data buffers.
+bool xdna_kernel_bind_insts(xdna_device * dev, xdna_kernel * kern, const uint32_t * insts, size_t n_words);
+
+void          xdna_kernel_free(xdna_kernel * kern);
+
+// --- buffer -------------------------------------------------------------
+
+// Allocate a host-visible device buffer object of `bytes` bytes.
+xdna_buffer * xdna_buffer_alloc(xdna_device * dev, size_t bytes);
+
+void          xdna_buffer_free(xdna_buffer * buf);
+
+// Copy device -> host (sync + memcpy).
+void          xdna_buffer_read(xdna_buffer * buf, void * host, size_t bytes);
+
+// Make host-side writes to the mapped memory visible to the NPU.
+void          xdna_buffer_sync_to_device(xdna_buffer * buf);
+
+// --- execution ------------------------------------------------------------
+
+// Submit a kernel without waiting (so multiple kernels can run back-to-back).
+// Returns a run handle that must be waited with xdna_run_wait() before the
+// buffers are reused; an empty handle means the submission failed.
+xrt::run xdna_kernel_run_start(xdna_kernel * kern, xdna_buffer ** args, size_t n_args);
+
+// Wait for a started run. Returns true on success.
+bool xdna_run_wait(xrt::run & run);
+
+// --- kernel pool ----------------------------------------------------------
+
+// Populate `pool->names` from the kernel search dirs. Idempotent per pool.
+void xdna_kernel_pool_scan(xdna_kernel_pool * pool);
+
+// Load (or fetch from cache) a kernel for `name` with an in-memory built
+// instruction stream: on a miss, load the hw from `xclbin_name` and bind the
+// stream. A failed lookup is cached and not retried.
+xdna_kernel * xdna_kernel_pool_get_built(xdna_kernel_pool * pool, const std::string & name,
+                                         const char * xclbin_name, const uint32_t * insts, size_t n_words);
+
+// Acquire a device buffer of at least `bytes` bytes, reusing an idle one from
+// the pool when possible.
+xdna_buffer * xdna_kernel_pool_acquire_buffer(xdna_kernel_pool * pool, size_t bytes);
+
+// Return a buffer to the pool, freeing the LRU entry past the limit.
+void xdna_kernel_pool_release_buffer(xdna_kernel_pool * pool, xdna_buffer * buf);

--- a/ggml/src/ggml-xdna/xdna-seq.cpp
+++ b/ggml/src/ggml-xdna/xdna-seq.cpp
@@ -1,0 +1,248 @@
+#include "xdna-seq.h"
+
+// TXN instruction encodings (NPU2 / XDNA2). Each op is a fixed-size word
+// group; the last word of each group holds op_size * 4 (the total op size in
+// bytes), which the firmware uses to advance the instruction pointer.
+
+static constexpr uint32_t BD_D0_SIZE_SHIFT   = 20;
+static constexpr uint32_t BD_D1_SIZE_SHIFT   = 20;
+static constexpr uint32_t BD_D1_BURST        = 0xC0000000u;
+static constexpr uint32_t BD_D2_CACHE_SHIFT  = 24;
+static constexpr uint32_t BD_ITER_SIZE_SHIFT = 20;
+
+void xdna_seq_write(xdna_seq * seq, uint32_t col, uint32_t row, uint32_t reg, uint32_t value) {
+    seq->n_instr++;
+    seq->ops.push_back(xdna_txn::OP_WRITE);
+    seq->ops.push_back(0);
+    seq->ops.push_back(xdna_txn::tile_reg(col, row, reg));
+    seq->ops.push_back(0);
+    seq->ops.push_back(value);
+    seq->ops.push_back(xdna_txn::SZ_WRITE * 4);
+}
+
+void xdna_seq_blockwrite(xdna_seq * seq, uint32_t col, uint32_t row, uint32_t bd_id, const xdna_bd * bd) {
+    seq->n_instr++;
+    seq->ops.push_back(xdna_txn::OP_BLOCKWRITE);
+    seq->ops.push_back(0);
+    seq->ops.push_back(xdna_txn::tile_reg(col, row, xdna_txn::SHIM_BD_BASE + bd_id * xdna_txn::SHIM_BD_STRIDE));
+    seq->ops.push_back(xdna_txn::SZ_BLOCKWRITE * 4);
+    seq->ops.push_back(bd->buf_len);
+    seq->ops.push_back(bd->buf_off);
+    seq->ops.push_back((bd->packet_enable ? 1u : 0u) << 30 |
+                       (bd->out_of_order_id & 0x3F) << 24 |
+                       (bd->packet_id & 0x1F) << 19 |
+                       (bd->packet_type & 0x7) << 16);
+    seq->ops.push_back((bd->d0_size & 0x3FF) << BD_D0_SIZE_SHIFT | ((bd->d0_stride - 1) & 0xFFFFF));
+    seq->ops.push_back(BD_D1_BURST | (bd->d1_size & 0x3FF) << BD_D1_SIZE_SHIFT | ((bd->d1_stride - 1) & 0xFFFFF));
+    seq->ops.push_back((bd->ax_cache & 0xFF) << BD_D2_CACHE_SHIFT | ((bd->d2_stride - 1) & 0xFFFFF));
+    seq->ops.push_back(((bd->iter_size - 1) & 0x3FF) << BD_ITER_SIZE_SHIFT | ((bd->iter_stride - 1) & 0xFFFFF));
+    seq->ops.push_back(xdna_txn::bd_ctrl(bd->next_bd, bd->valid, 0, 0, false, 0, 0));
+}
+
+void xdna_seq_ddr_patch(xdna_seq * seq, uint32_t col, uint32_t row, uint32_t bd_id,
+                        uint32_t arg_idx, uint32_t arg_offset) {
+    seq->n_instr++;
+    seq->ops.push_back(xdna_txn::OP_DDR_PATCH);
+    seq->ops.push_back(xdna_txn::SZ_DDR_PATCH * 4);
+    seq->ops.push_back(0);
+    seq->ops.push_back(0);
+    seq->ops.push_back(0);
+    seq->ops.push_back(0);
+    seq->ops.push_back(xdna_txn::tile_reg(col, row, xdna_txn::SHIM_BD_ADDR + bd_id * xdna_txn::SHIM_BD_STRIDE));
+    seq->ops.push_back(0);
+    seq->ops.push_back(arg_idx);
+    seq->ops.push_back(0);
+    seq->ops.push_back(arg_offset);
+    seq->ops.push_back(0);
+}
+
+void xdna_seq_maskwrite(xdna_seq * seq, uint32_t col, uint32_t row, uint32_t reg,
+                        uint32_t value, uint32_t mask) {
+    seq->n_instr++;
+    seq->ops.push_back(xdna_txn::OP_MASKWRITE);
+    seq->ops.push_back(0);
+    seq->ops.push_back(xdna_txn::tile_reg(col, row, reg));
+    seq->ops.push_back(0);
+    seq->ops.push_back(value);
+    seq->ops.push_back(mask);
+    seq->ops.push_back(xdna_txn::SZ_MASKWRITE * 4);
+}
+
+void xdna_seq_push_queue(xdna_seq * seq, uint32_t col, uint32_t row, uint32_t bd_id, xdna_dma_dir dir,
+                         uint32_t channel, bool issue_token, uint32_t repeat) {
+    const uint32_t reg = xdna_txn::SHIM_PUSHQ_BASE +
+                         (channel > 0 ? xdna_txn::SHIM_CTRL_STRIDE : 0) +
+                         (dir == xdna_dma_dir::MM2S ? xdna_txn::SHIM_DIR_STRIDE : 0);
+    uint32_t value = (bd_id & xdna_txn::PUSH_BD_ID_MASK) | (repeat << xdna_txn::PUSH_REPEAT_SHIFT);
+    if (issue_token) {
+        value |= xdna_txn::PUSH_ISSUE_TOKEN;
+    }
+    xdna_seq_write(seq, col, row, reg, value);
+}
+
+void xdna_seq_issue_token(xdna_seq * seq, uint32_t col, uint32_t row, xdna_dma_dir dir,
+                          uint32_t channel, uint32_t ctrl_pkt_id) {
+    const uint32_t reg = xdna_txn::SHIM_TOKEN_BASE +
+                         channel * xdna_txn::SHIM_CTRL_STRIDE +
+                         (dir == xdna_dma_dir::MM2S ? xdna_txn::SHIM_DIR_STRIDE : 0);
+    xdna_seq_maskwrite(seq, col, row, reg, ctrl_pkt_id << 8, 0x1F00);
+}
+
+void xdna_seq_wait_token(xdna_seq * seq, uint32_t col, uint32_t row, xdna_dma_dir dir, uint32_t channel) {
+    seq->n_instr++;
+    seq->ops.push_back(xdna_txn::OP_TCT);
+    seq->ops.push_back(xdna_txn::SZ_TCT * 4);
+    seq->ops.push_back((row & 0xFF) << 8 | (col & 0xFF) << 16 | (dir == xdna_dma_dir::MM2S ? 1u : 0u));
+    seq->ops.push_back((channel & 0xFF) << 24 | xdna_txn::TCT_W3_CONST);
+}
+
+std::vector<uint32_t> xdna_seq_build(const xdna_seq * seq) {
+    std::vector<uint32_t> out;
+    out.reserve(4 + seq->ops.size());
+    out.push_back(xdna_txn::DEV_MAJOR |
+                  xdna_txn::DEV_MINOR << xdna_txn::HDR_W0_MINOR_SHIFT |
+                  xdna_txn::DEV_GEN   << xdna_txn::HDR_W0_GEN_SHIFT |
+                  seq->n_rows         << xdna_txn::HDR_W0_ROWS_SHIFT);
+    out.push_back(seq->n_cols | seq->mem_tile_rows << xdna_txn::HDR_W1_MEMTILE_SHIFT);
+    out.push_back(seq->n_instr);
+    out.push_back((uint32_t)((4 + seq->ops.size()) * sizeof(uint32_t)));
+    out.insert(out.end(), seq->ops.begin(), seq->ops.end());
+    return out;
+}
+
+// --- GEMM sequence -----------------------------------------------------------
+
+bool xdna_gemm_seq_supported(const xdna_gemm_tiles * tiles, int M, int K, int N) {
+    if (M <= 0 || M > tiles->M) {
+        return false;
+    }
+    if (K <= 0 || K % tiles->tile_k != 0) {
+        return false;
+    }
+    const int mem_tile_n = tiles->tile_n * tiles->n_cols;
+    if (N < mem_tile_n || N % mem_tile_n != 0) {
+        return false;
+    }
+    return true;
+}
+
+// Element stride -> 4-byte address-gen words.
+static uint32_t to_words(uint32_t elem_stride, uint32_t elem_bytes) {
+    return elem_stride * elem_bytes / 4;
+}
+
+static void emit_bd(xdna_seq * seq, int col, int bd_id, const xdna_bd & bd,
+                    uint32_t arg, uint32_t off) {
+    xdna_seq_blockwrite(seq, (uint32_t) col, 0, (uint32_t) bd_id, &bd);
+    xdna_seq_ddr_patch(seq, (uint32_t) col, 0, (uint32_t) bd_id, arg, off);
+}
+
+// Emits the same instruction stream IRON's seq_fn produces for the GEMM
+// kernel. The BD field semantics follow mlir-aie's AIEDmaToNpu.cpp:
+//   - d0_size / d1_size in 4-byte address-gen words (elements*elem_bytes/4)
+//   - d2 has stride only; its size is inferred as len/(d0_size*d1_size)
+//   - buffer_length is in 4-byte words
+//   - the outer tap dim folds into the queue push repeat_count (stride 0)
+//     or the BD iteration field (stride > 0)
+bool xdna_gemm_seq_build(xdna_seq * seq, const xdna_gemm_tiles * t, int M, int K, int N,
+                         uint32_t b_offset) {
+    const int n_cols = t->n_cols;
+    const int n_rows = t->n_compute_rows;
+    const int tile_n = t->tile_n;
+    const int tile_k = t->tile_k;
+
+    const int mem_tile_n   = tile_n * n_cols;    // 128 or 256
+    const int K_div_k      = K / tile_k;         // per-core K loop count
+    const int n_col_tiles  = N / mem_tile_n;     // column tiles per core
+    // A shims are capped at the number of compute rows (a column can only feed
+    // as many row tiles as there are core rows).
+    const int n_shim_mem_A = n_cols < n_rows ? n_cols : n_rows;
+    const int M_per_shim   = M / n_shim_mem_A;   // 8 rows of A per A shim
+
+    // RTP writes + barriers (rows 2..5, cols 0..7)
+    for (int row = 2; row < 2 + n_rows; row++) {
+        for (int col = 0; col < n_cols; col++) {
+            xdna_seq_write(seq, (uint32_t) col, (uint32_t) row, (uint32_t) (t->rtp_base + 0x000), (uint32_t) K_div_k);
+            xdna_seq_write(seq, (uint32_t) col, (uint32_t) row, (uint32_t) (t->rtp_base + 0x004), (uint32_t) n_col_tiles);
+            xdna_seq_write(seq, (uint32_t) col, (uint32_t) row, 0x1f000, 1);
+        }
+    }
+
+    // DMA: per shim column, C output then A/B inputs. BD ids are allocated per
+    // shim (in write order), matching IRON: even shims 0,2,4,6 carry the A of
+    // logical col/2 plus their own C and B, odd shims only C and B.
+    uint32_t shim_bd[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+    for (int col = 0; col < n_cols; col++) {
+        // C output [M x N] f32. Column c covers tile_n output columns laid
+        // out every mem_tile_n elements (interleaved by the tiler). The d2
+        // sweep visits the n_col_tiles column blocks; no queue repeat.
+        {
+            xdna_bd bd;
+            bd.buf_len   = (uint32_t)(M * tile_n * n_col_tiles); // words
+            bd.buf_off   = (uint32_t) col * tile_n * 4;          // bytes into C
+            bd.d0_size   = (uint32_t) tile_n;                    // words (f32)
+            bd.d0_stride = 1;
+            bd.d1_size   = (uint32_t) M;                         // elements
+            bd.d1_stride = to_words((uint32_t) N, 4);
+            bd.d2_stride = n_col_tiles > 1 ? to_words((uint32_t) mem_tile_n, 4) : 1;
+            bd.ax_cache  = 2;
+            const uint32_t bd_id = shim_bd[col]++;
+            emit_bd(seq, col, bd_id, bd, 2, (uint32_t) col * tile_n * 4);
+            xdna_seq_issue_token(seq, (uint32_t) col, 0, xdna_dma_dir::S2MM, 0, 0xF);
+            xdna_seq_push_queue(seq, (uint32_t) col, 0, bd_id, xdna_dma_dir::S2MM, 0, true, 0);
+        }
+
+        // A input [M x K] bf16 on A shim cols 0,2,4,6; shim 2*c reads rows
+        // [c*8, c*8+8). One BD covers 8 rows x K, repeated n_col_tiles times
+        // (stride 0) to re-feed the cores per column-tile pass.
+        if (col < n_shim_mem_A) {
+            const int a_col = col * 2;
+            xdna_bd bd;
+            bd.buf_len   = (uint32_t)(M_per_shim * tile_k * K_div_k / 2); // words
+            bd.buf_off   = (uint32_t) col * M_per_shim * K * 2;           // bytes into A
+            bd.d0_size   = (uint32_t)(tile_k / 2);                        // words
+            bd.d0_stride = 1;
+            bd.d1_size   = (uint32_t) M_per_shim;                         // elements
+            bd.d1_stride = to_words((uint32_t) K, 2);
+            bd.d2_stride = to_words((uint32_t) tile_k, 2);
+            bd.ax_cache  = 2;
+            const uint32_t bd_id = shim_bd[a_col]++;
+            emit_bd(seq, a_col, bd_id, bd, 0, (uint32_t) col * M_per_shim * K * 2);
+            xdna_seq_push_queue(seq, (uint32_t) a_col, 0, bd_id, xdna_dma_dir::MM2S, 0, false,
+                                n_col_tiles > 1 ? (uint32_t) (n_col_tiles - 1) : 0);
+        }
+
+        // B input [K x N] bf16. Column c reads tile_n columns interleaved
+        // every mem_tile_n elements. d0/d1 = tile_n x tile_k inner tile, d2
+        // sweeps K_div_k k-tiles (stride tile_k*N), iteration sweeps the
+        // n_col_tiles column blocks. Channel: A occupies MM2S ch0 on the A
+        // shims (cols 0,2,4,6), so B uses ch1 there and ch0 elsewhere.
+        {
+            const int b_ch = (col % 2 == 0) ? 1 : 0;
+            xdna_bd bd;
+            bd.buf_len   = (uint32_t)(tile_n * tile_k * K_div_k / 2); // words
+            bd.buf_off   = (uint32_t) col * tile_n * 2 + b_offset;    // bytes into B
+            bd.d0_size   = (uint32_t)(tile_n / 2);                    // words
+            bd.d0_stride = 1;
+            bd.d1_size   = (uint32_t) tile_k;                         // elements
+            bd.d1_stride = to_words((uint32_t) N, 2);
+            bd.d2_stride = to_words((uint32_t)(tile_k * N), 2);
+            bd.ax_cache  = 2;
+            if (n_col_tiles > 1) {
+                bd.iter_size   = (uint32_t) n_col_tiles;
+                bd.iter_stride = to_words((uint32_t) mem_tile_n, 2);
+            }
+            const uint32_t bd_id = shim_bd[col]++;
+            emit_bd(seq, col, bd_id, bd, 1, (uint32_t) col * tile_n * 2 + b_offset);
+            xdna_seq_push_queue(seq, (uint32_t) col, 0, bd_id, xdna_dma_dir::MM2S, (uint32_t) b_ch, false,
+                                n_col_tiles > 1 ? (uint32_t) (n_col_tiles - 1) : 0);
+        }
+    }
+
+    // Wait for all 8 C output tokens
+    for (int col = 0; col < n_cols; col++) {
+        xdna_seq_wait_token(seq, (uint32_t) col, 0, xdna_dma_dir::S2MM, 0);
+    }
+
+    return true;
+}

--- a/ggml/src/ggml-xdna/xdna-seq.h
+++ b/ggml/src/ggml-xdna/xdna-seq.h
@@ -1,0 +1,205 @@
+#pragma once
+
+// Instruction stream (TXN) builders for the AMD XDNA NPU, kept out of the
+// backend scaffold. A TXN stream is a flat little-endian uint32 array: a
+// 4-word header followed by fixed-size instructions. The stream is bound to a
+// loaded xclbin as its insts BO. Only GEMM sequences exist so far; other ops
+// extend this module with their own builders.
+
+#include <cstdint>
+#include <vector>
+
+// TXN format constants (hardware ABI, NPU2/XDNA2, gen=4, 6 rows x 8 cols).
+namespace xdna_txn {
+
+static constexpr uint32_t DEV_MAJOR = 0;
+static constexpr uint32_t DEV_MINOR = 1;
+static constexpr uint32_t DEV_GEN   = 4;
+
+enum {
+    HDR_W0_ROWS_SHIFT     = 24,
+    HDR_W0_GEN_SHIFT      = 16,
+    HDR_W0_MINOR_SHIFT    = 8,
+    HDR_W1_MEMTILE_SHIFT  = 8,
+};
+
+enum opcode : uint32_t {
+    OP_WRITE       = 0x00,   // 6 words - register write / DMA push-queue
+    OP_BLOCKWRITE  = 0x01,   // 12 words - shim DMA buffer descriptor
+    OP_MASKWRITE   = 0x03,   // 7 words - masked register write / issue token
+    OP_TCT         = 0x80,   // 4 words - wait for task-complete token
+    OP_DDR_PATCH   = 0x81,   // 12 words - patch a BD address with a buffer's device address
+};
+
+static constexpr uint32_t SZ_WRITE      = 6;
+static constexpr uint32_t SZ_BLOCKWRITE = 12;
+static constexpr uint32_t SZ_MASKWRITE  = 7;
+static constexpr uint32_t SZ_TCT        = 4;
+static constexpr uint32_t SZ_DDR_PATCH  = 12;
+
+static constexpr uint32_t SHIM_BD_BASE       = 0x1D000;  // BD length register
+static constexpr uint32_t SHIM_BD_STRIDE     = 0x20;     // per-BD register stride
+static constexpr uint32_t SHIM_BD_ADDR       = 0x1D004;  // BD address register (patched)
+static constexpr uint32_t SHIM_PUSHQ_BASE    = 0x1D204;  // push-queue for S2MM ch0
+static constexpr uint32_t SHIM_TOKEN_BASE    = 0x1D200;  // token-issue register for S2MM ch0
+static constexpr uint32_t SHIM_CTRL_STRIDE   = 0x08;     // per-channel stride
+static constexpr uint32_t SHIM_DIR_STRIDE    = 0x10;     // per-direction stride (MM2S)
+
+static constexpr uint32_t BD_NEXT_SHIFT      = 27;
+static constexpr uint32_t BD_VALID_SHIFT     = 25;
+static constexpr uint32_t BD_LOCK_REL_VAL_SH = 18;
+static constexpr uint32_t BD_LOCK_REL_ID_SH  = 13;
+static constexpr uint32_t BD_LOCK_ACQ_EN_SH  = 12;
+static constexpr uint32_t BD_LOCK_ACQ_VAL_SH = 5;
+static constexpr uint32_t BD_LOCK_ACQ_ID_SH  = 0;
+
+static constexpr uint32_t PUSH_BD_ID_MASK    = 0x0F;
+static constexpr uint32_t PUSH_REPEAT_SHIFT  = 16;
+static constexpr uint32_t PUSH_ISSUE_TOKEN   = 0x80000000u;
+
+static constexpr uint32_t TCT_W3_CONST       = 0x00010100;
+
+// Encode the 20-bit register offset + tile position into the address word.
+inline uint32_t tile_reg(uint32_t col, uint32_t row, uint32_t reg) {
+    return ((col & 0x7F) << 25) | ((row & 0x1F) << 20) | (reg & 0xFFFFF);
+}
+
+// Encode the BLOCKWRITE "next" control word.
+inline uint32_t bd_ctrl(uint32_t next_bd, bool valid, uint32_t lock_rel_val,
+                        uint32_t lock_rel_id, bool lock_acq_en, uint32_t lock_acq_val,
+                        uint32_t lock_acq_id) {
+    return ((next_bd & 0x1F) << BD_NEXT_SHIFT) |
+           (valid << BD_VALID_SHIFT) |
+           ((lock_rel_val & 0x3F) << BD_LOCK_REL_VAL_SH) |
+           ((lock_rel_id & 0x1F) << BD_LOCK_REL_ID_SH) |
+           ((lock_acq_en ? 1u : 0u) << BD_LOCK_ACQ_EN_SH) |
+           ((lock_acq_val & 0x3F) << BD_LOCK_ACQ_VAL_SH) |
+           (lock_acq_id & 0x1F);
+}
+
+} // namespace xdna_txn
+
+// DMA direction for shim-queue operations.
+enum class xdna_dma_dir : uint32_t {
+    S2MM = 0,   // host -> device
+    MM2S = 1,   // device -> host
+};
+
+// Shim DMA buffer descriptor (the payload of a BLOCKWRITE). Strides and sizes
+// are given as real element/byte counts; the emitter encodes (value - 1).
+struct xdna_bd {
+    uint32_t buf_len   = 0;   // total transfer length in bytes
+    uint32_t buf_off   = 0;   // byte offset into the host buffer
+    uint32_t d0_size   = 0;   // dim0 size (elements)
+    uint32_t d0_stride = 0;   // dim0 stride (bytes)
+    uint32_t d1_size   = 0;   // dim1 size (elements)
+    uint32_t d1_stride = 0;   // dim1 stride (bytes)
+    uint32_t d2_stride = 0;   // dim2 stride (bytes); d2 size inferred
+    uint32_t ax_cache  = 0;   // AXI cache bits (usually 2)
+    uint32_t iter_size   = 1; // iteration count (outermost repeat)
+    uint32_t iter_stride = 1; // iteration stride (bytes)
+    uint32_t next_bd   = 0;   // next BD id in the chain (0 = none)
+    bool     valid     = true;
+
+    // packet header (only when used with packet routing)
+    bool     packet_enable   = false;
+    uint32_t packet_type     = 0;
+    uint32_t packet_id       = 0;
+    uint32_t out_of_order_id = 0;
+};
+
+// Builder state. Data only; the API lives below as C-style functions.
+struct xdna_seq {
+    uint32_t n_cols = 8;        // AIE columns
+    uint32_t n_rows = 6;        // total rows (mem tiles + cores)
+    uint32_t mem_tile_rows = 1;
+    std::vector<uint32_t> ops;
+    uint32_t n_instr = 0;
+};
+
+// 32-bit register write (also used for RTP values and DMA push-queue).
+void xdna_seq_write(xdna_seq * seq, uint32_t col, uint32_t row, uint32_t reg, uint32_t value);
+
+// Shim DMA buffer descriptor write.
+void xdna_seq_blockwrite(xdna_seq * seq, uint32_t col, uint32_t row, uint32_t bd_id, const xdna_bd * bd);
+
+// Bind a previously-written BD's address register to host buffer arg_idx.
+void xdna_seq_ddr_patch(xdna_seq * seq, uint32_t col, uint32_t row, uint32_t bd_id,
+                        uint32_t arg_idx, uint32_t arg_offset);
+
+// Masked register write (also used to issue a task-complete token).
+void xdna_seq_maskwrite(xdna_seq * seq, uint32_t col, uint32_t row, uint32_t reg,
+                        uint32_t value, uint32_t mask);
+
+// Push a BD onto a shim DMA queue. `issue_token` stamps the completion so a
+// later wait_token() can sync on this transfer.
+void xdna_seq_push_queue(xdna_seq * seq, uint32_t col, uint32_t row, uint32_t bd_id, xdna_dma_dir dir,
+                         uint32_t channel, bool issue_token, uint32_t repeat);
+
+// Issue a task-complete token on a DMA channel (MASKWRITE form).
+void xdna_seq_issue_token(xdna_seq * seq, uint32_t col, uint32_t row, xdna_dma_dir dir,
+                          uint32_t channel, uint32_t ctrl_pkt_id);
+
+// Wait for a task-complete token on a DMA channel.
+void xdna_seq_wait_token(xdna_seq * seq, uint32_t col, uint32_t row, xdna_dma_dir dir, uint32_t channel);
+
+// Assemble the full stream (4-word header + instructions).
+std::vector<uint32_t> xdna_seq_build(const xdna_seq * seq);
+
+// GEMM tile/geometry constants baked into the IRON design (see kernels/gemm.py
+// and ggml/src/ggml-xdna/CMakeLists.txt, which defines GGML_XDNA_* for the
+// backend target). The geometry is fixed by the compiled xclbin; only the
+// shape is dynamic. The values must match the CMake definitions.
+#ifndef GGML_XDNA_GEMM_M
+#define GGML_XDNA_GEMM_M 32
+#endif
+#ifndef GGML_XDNA_TILE_M
+#define GGML_XDNA_TILE_M 8
+#endif
+#ifndef GGML_XDNA_GEMM_M_BIG
+#define GGML_XDNA_GEMM_M_BIG 64
+#endif
+#ifndef GGML_XDNA_TILE_M_BIG
+#define GGML_XDNA_TILE_M_BIG 16
+#endif
+
+// Per-tile RTP buffer base in the core tile (input_with_addresses.mlir);
+// it shifts with the L1 buffer sizes: 0xc800 for tile_m=8 (decode, r=4),
+// 0xd000 for tile_m=16 (prefill, bfp16 r=8).
+constexpr int XDNA_RTP_BASE_TILE_M8  = 0xc800;
+constexpr int XDNA_RTP_BASE_TILE_M16 = 0xd000;
+#ifndef GGML_XDNA_TILE_K
+#define GGML_XDNA_TILE_K 64
+#endif
+#ifndef GGML_XDNA_TILE_N
+#define GGML_XDNA_TILE_N 64
+#endif
+#ifndef GGML_XDNA_N_COLS
+#define GGML_XDNA_N_COLS 8
+#endif
+#ifndef GGML_XDNA_N_COMPUTE_ROWS
+#define GGML_XDNA_N_COMPUTE_ROWS 4
+#endif
+
+struct xdna_gemm_tiles {
+    int M        = GGML_XDNA_GEMM_M;      // baked M block
+    int tile_m   = GGML_XDNA_TILE_M;      // per-core M tile
+    int tile_k   = GGML_XDNA_TILE_K;      // per-core K tile
+    int tile_n   = GGML_XDNA_TILE_N;      // per-core N tile
+    int n_cols   = GGML_XDNA_N_COLS;      // AIE columns
+    int n_compute_rows = GGML_XDNA_N_COMPUTE_ROWS;  // compute tile rows
+    // Per-tile RTP buffer base in the core tile (XDNA_RTP_BASE_TILE_M*).
+    int rtp_base = XDNA_RTP_BASE_TILE_M8;
+};
+
+// True when the dims fit the baked geometry: M <= M block, K multiple of
+// tile_k, N at least one column tile and a multiple of tile_n*n_cols.
+bool xdna_gemm_seq_supported(const xdna_gemm_tiles * tiles, int M, int K, int N);
+
+// Build the full TXN stream for C = A @ B with the geometry described by
+// `tiles`. Buffer layout (row-major): arg 0 = A [M x K] bf16, arg 1 = B
+// [K x N] bf16, arg 2 = C [M x N] f32. M must equal the baked block.
+// `b_offset` (bytes) shifts the B base address, so a K-block can point into a
+// persistent full-weight buffer.
+bool xdna_gemm_seq_build(xdna_seq * seq, const xdna_gemm_tiles * tiles, int M, int K, int N,
+                         uint32_t b_offset = 0);

--- a/ggml/src/ggml-xdna/xdna-types.h
+++ b/ggml/src/ggml-xdna/xdna-types.h
@@ -1,0 +1,65 @@
+#pragma once
+
+// Transparent XDNA types. The backend always links XRT, so the structs hold
+// XRT handles directly instead of hiding them behind opaque pointers.
+
+#include <xrt/xrt_bo.h>
+#include <xrt/xrt_device.h>
+#include <xrt/xrt_hw_context.h>
+#include <xrt/xrt_kernel.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// The NPU device. One per process.
+struct xdna_device {
+    xrt::device device;
+    std::string name;
+    std::string description;
+};
+
+// A loaded kernel: one xclbin plus one instruction stream (insts BO) bound to
+// a shared hw_context. All variants of the same xclbin share the context via
+// the shared_ptr; the runtime keeps contexts alive for the process lifetime.
+struct xdna_kernel {
+    std::shared_ptr<xrt::hw_context> context;
+    xrt::kernel                      kernel;
+    xrt::bo                          insts_bo;
+    int64_t                          insts_bytes = 0;
+};
+
+// A host-visible device buffer object (BO).
+struct xdna_buffer {
+    xrt::bo  bo;
+    size_t   bytes = 0;
+};
+
+// Pool of kernels: auto-scans the search dirs for kernel artifacts (xclbin
+// files), exposes their names, and lazily loads kernels on demand. Backend-specific selection (which kernel fits an op) is
+// done by the caller against the names. The runtime caches one hw_context per
+// xclbin uuid, so variants of one xclbin share it with no reload penalty.
+// Also pools host-visible buffers. Data only; the pool API lives in
+// xdna-runtime.h as C-style functions.
+struct xdna_kernel_pool {
+    struct pool_entry {
+        xdna_buffer * buf;
+        uint64_t      seq;   // idle stamp, lower = older
+    };
+
+    static constexpr size_t MAX_POOL_SIZE = 16;
+
+    xdna_device * device = nullptr;
+
+    std::vector<std::string>                       names;    // artifact stems
+    std::unordered_map<std::string, xdna_kernel *> kernels;  // name -> kernel
+    std::mutex                                     kernel_mutex;
+
+    std::vector<pool_entry> pool;
+    uint64_t                pool_tick = 0;
+    std::mutex              pool_mutex;
+};


### PR DESCRIPTION
## Summary

Introduces the AMD XDNA (NPU) backend: first working GEMM kernel built via
IRON (mlir-aie), routing weight `MUL_MAT` to the XDNA2 NPU. This is the
initial version of the backend, predating the selective-hybrid execution
path in a later branch.

Draft PR — opening for early feedback on the backend structure before
finalizing.

## What's included

- New `ggml-xdna` backend (`ggml/src/ggml-xdna/`) with IRON-based kernel
  build pipeline (`ggml/src/ggml-xdna/iron/`)
- `--device XDNA` support for routing weight GEMMs to the NPU
- Selective hybrid execution: NPU handles GEMM, CPU handles the rest
- Documentation of the validated setup, dependencies, and known toolchain
  pitfalls in `docs/backend/XDNA.md`

## Validated environment

Built and measured on one machine so far:

- ASUS ProArt PX13 HN7306EA, AMD Ryzen AI MAX+ 395 (Strix Halo), NPU `aie2p`
- Ubuntu 24.04.4, XRT 2.25.37, `amdxdna` driver 2.25.260102.56
- IRON: mlir-aie **1.4.1** + llvm-aie 21
- Models tested: Qwen3.5-0.8B (Q4_K_M, BF16), Qwen3.5-9B (Q4_K_M)