### PR TITLE
QVAC-23796 infra: point the self-hosted CI jobs at the qvac fleet

### DIFF
--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -58,7 +58,7 @@ env:
 
 jobs:
   gpu-cuda:
-    runs-on: [self-hosted, Linux, NVIDIA]
+    runs-on: qvac-ubuntu2204-x64-gpu
 
     steps:
       - name: Clone
@@ -72,6 +72,7 @@ jobs:
           GG_BUILD_CUDA=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-rocm:
+    if: false  # QVAC-23796: no matching hardware
     runs-on: [self-hosted, Linux, AMD]
 
     steps:
@@ -92,7 +93,7 @@ jobs:
           GG_BUILD_ROCM=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-vulkan-nvidia-cm:
-    runs-on: [self-hosted, Linux, NVIDIA]
+    runs-on: qvac-ubuntu2204-x64-gpu
 
     steps:
       - name: Clone
@@ -106,7 +107,7 @@ jobs:
           GG_BUILD_VULKAN=1 GGML_VK_DISABLE_COOPMAT2=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-vulkan-nvidia-cm2:
-    runs-on: [self-hosted, Linux, NVIDIA, COOPMAT2]
+    runs-on: qvac-ubuntu2204-x64-gpu
 
     steps:
       - name: Clone
@@ -120,7 +121,7 @@ jobs:
           GG_BUILD_VULKAN=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-webgpu-nvidia:
-    runs-on: [self-hosted, Linux, NVIDIA, X64]
+    runs-on: qvac-ubuntu2404-x64-gpu
 
     steps:
       - name: Clone
@@ -193,7 +194,7 @@ jobs:
   #         GG_BUILD_ROCM=1 GG_BUILD_AMDGPU_TARGETS="gfx1101" bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-metal:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: qvac-macos26-arm64-gpu
 
     steps:
       - name: Clone
@@ -206,7 +207,7 @@ jobs:
           GG_BUILD_METAL=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-webgpu-apple:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: qvac-macos26-arm64-gpu
 
     steps:
       - name: Clone
@@ -233,7 +234,7 @@ jobs:
             bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-vulkan-apple:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: qvac-macos26-arm64-gpu
 
     steps:
       - name: Clone
@@ -247,6 +248,7 @@ jobs:
           GG_BUILD_VULKAN=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-vulkan-intel-linux:
+    if: false  # QVAC-23796: no matching hardware
     runs-on: [self-hosted, Linux, Intel]
 
     steps:
@@ -263,6 +265,7 @@ jobs:
           GG_BUILD_VULKAN=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-vulkan-intel-windows:
+    if: false  # QVAC-23796: no matching hardware
     runs-on: [self-hosted, Windows, X64, Intel]
 
     steps:
@@ -284,6 +287,7 @@ jobs:
           LLAMA_FATAL_WARNINGS=OFF GG_BUILD_NINJA=1 GG_BUILD_VULKAN=1 GG_BUILD_LOW_PERF=1 ./ci/run.sh ./results/llama.cpp ./mnt/llama.cpp
 
   gpu-openvino-low-perf:
+    if: false  # QVAC-23796: no matching hardware
     runs-on: [self-hosted, Linux, Intel, OpenVINO]
 
     env:
@@ -316,7 +320,7 @@ jobs:
           GG_BUILD_OPENVINO=1 GGML_OPENVINO_DEVICE=GPU GG_BUILD_LOW_PERF=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   cpu-x64-high-perf:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: qvac-ubuntu2204-x64
 
     steps:
       - name: Clone
@@ -329,6 +333,7 @@ jobs:
           LLAMA_ARG_THREADS=$(nproc) GG_BUILD_HIGH_PERF=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   cpu-arm64-high-perf-graviton4:
+    if: false  # QVAC-23796: no matching hardware
     runs-on: ah-ubuntu_22_04-c8g_8x
 
     steps:
@@ -371,6 +376,7 @@ jobs:
           LLAMA_ARG_THREADS=$(nproc) GG_BUILD_HIGH_PERF=1 GG_BUILD_NO_BF16=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   cpu-arm64-graviton4-kleidiai:
+    if: false  # QVAC-23796: no matching hardware
     runs-on: ah-ubuntu_22_04-c8g_8x
 
     steps:

--- a/.github/workflows/check-vendor.yml
+++ b/.github/workflows/check-vendor.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   check-vendor:
-    runs-on: [self-hosted, fast]
+    runs-on: qvac-ubuntu2404-x64
 
     steps:
       - name: Checkout

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   model-naming:
-    runs-on: [self-hosted, fast]
+    runs-on: qvac-ubuntu2404-x64
     steps:
       - uses: actions/checkout@v6
       - name: Check model naming conventions

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   editorconfig:
-    runs-on: [self-hosted, fast]
+    runs-on: qvac-ubuntu2404-x64
     steps:
       - uses: actions/checkout@v6
       - uses: editorconfig-checker/action-editorconfig-checker@840e866d93b8e032123c23bac69dece044d4d84c # v2.2.0

--- a/.github/workflows/python-check-requirements.yml
+++ b/.github/workflows/python-check-requirements.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   python-check-requirements:
-    runs-on: [self-hosted, CPU, fast]
+    runs-on: qvac-ubuntu2404-x64
     name: check-requirements
     steps:
       - name: Check out source repository

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   flake8-lint:
-    runs-on: [self-hosted, fast]
+    runs-on: qvac-ubuntu2404-x64
     name: Lint
     steps:
       - name: Check out source repository

--- a/.github/workflows/python-type-check.yml
+++ b/.github/workflows/python-type-check.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   python-type-check:
-    runs-on: [self-hosted, fast]
+    runs-on: qvac-ubuntu2404-x64
     name: python type-check
     steps:
       - name: Check out source repository

--- a/.github/workflows/ui-build-self-hosted.yml
+++ b/.github/workflows/ui-build-self-hosted.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, fast]
+    runs-on: qvac-ubuntu2404-x64
     timeout-minutes: 20
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/ui-self-hosted.yml
+++ b/.github/workflows/ui-self-hosted.yml
@@ -47,7 +47,7 @@ jobs:
   ui-checks:
     name: Checks
     needs: ui-build
-    runs-on: [self-hosted, PLAYWRIGHT]
+    runs-on: qvac-ubuntu2404-x64
     continue-on-error: true
     timeout-minutes: 30
     steps:
@@ -60,6 +60,11 @@ jobs:
       - name: Install dependencies
         id: setup
         run: npm ci
+        working-directory: tools/ui
+
+      - name: Install Playwright browser
+        if: ${{ always() && steps.setup.conclusion == 'success' }}
+        run: npx playwright install chromium
         working-directory: tools/ui
 
       - name: Download built UI artifacts
@@ -91,7 +96,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     needs: ui-build
-    runs-on: [self-hosted, PLAYWRIGHT]
+    runs-on: qvac-ubuntu2404-x64
     timeout-minutes: 30
     steps:
       - name: Checkout code
@@ -103,6 +108,11 @@ jobs:
       - name: Install dependencies
         id: setup
         run: npm ci
+        working-directory: tools/ui
+
+      - name: Install Playwright browser
+        if: ${{ always() && steps.setup.conclusion == 'success' }}
+        run: npx playwright install chromium
         working-directory: tools/ui
 
       - name: Download built UI artifacts


### PR DESCRIPTION
Port of #209 onto `temp-10297`.

## What

Points the jobs that were **already** pinned to self-hosted runners at the qvac fleet. GitHub-hosted jobs are untouched.

## Why

Those jobs carried upstream ggml-org labels no runner in this org advertises — `[self-hosted, Linux, NVIDIA]`, `[…, COOPMAT2]`, `[self-hosted, Linux, AMD]`, `[self-hosted, fast]`, `[self-hosted, PLAYWRIGHT]`, `ah-ubuntu_22_04-c8g_8x`.

They never failed. They queued until GitHub's 24h timeout reaped them, which reports as *cancelled* and reads like noise rather than breakage. On master, **9 of the 13 jobs in `CI (self-hosted)` had never executed once** — every run records `steps=0` and `completed == started + 24h`. `ui-self-hosted.yml` had never passed.

## Changes

- **9 `runs-on` changes** across 9 workflows → `qvac-*` labels
- **6 jobs disabled** (`if: false`) — ROCm, Intel ×2, OpenVINO, Graviton ×2. No matching hardware; disabled rather than deleted so they can be revived by dropping the `if`. Leaving one enabled would keep holding the workflow in progress for 24h and blocking log access for the jobs that do work.
- **`ui-self-hosted.yml`** gains `npx playwright install chromium` after `npm ci` — the runners carry Playwright's OS libs but no browsers

## Differences from #209

Both because `temp-10297` has moved on from master:

- **`gpu-rocm` is new here**, on `[self-hosted, Linux, AMD]` — another label with no runner behind it, so it joins the disabled set.
- **The `ggml-vulkan` fix in #209 is not needed.** `temp-10297` already registers the `TQ1_0`/`TQ2_0` `mul_mat_id` pipelines with `mul_mat_id_param_count`, so this PR touches no C++ and needs no backend reviewer.

## Not covered — needs a decision

`temp-10297` carries dead-label jobs that don't exist on master, left untouched here to keep this a faithful port:

`server-self-hosted.yml` (3 jobs) · `build-sanitize.yml` · `build-openvino.yml` · `build-cmake-pkg.yml` · `pre-tokenizer-hashes.yml` · `update-ops-docs.yml` · `ai-issues.yml`

Same disease, same fix — say the word and I'll extend this PR or raise a follow-up.
