### PR TITLE
QVAC-23763 fix[cuda]: avoid unsupported-device and Tegra VMM crashes

### DIFF
--- a/ggml/include/ggml-cuda.h
+++ b/ggml/include/ggml-cuda.h
@@ -33,6 +33,11 @@ GGML_BACKEND_API bool ggml_backend_cuda_allreduce_tensor(ggml_backend_t * backen
 // pinned host buffer for use with the CPU backend for faster copies between CPU and GPU
 GGML_BACKEND_API ggml_backend_buffer_type_t ggml_backend_cuda_host_buffer_type(void);
 
+// Number of CUDA devices the driver reports, NOT the number this build can use.
+// QVAC-23763 made ggml_backend_cuda_reg() skip devices with no compiled kernels
+// for their compute capability, so ids inside this range can be holes:
+// ggml_backend_cuda_init() and ggml_backend_cuda_buffer_type() both return NULL
+// for them. For usable devices, walk ggml_backend_reg_dev_count(reg) instead.
 GGML_BACKEND_API int  ggml_backend_cuda_get_device_count(void);
 GGML_BACKEND_API void ggml_backend_cuda_get_device_description(int device, char * description, size_t description_size);
 GGML_BACKEND_API void ggml_backend_cuda_get_device_memory(int device, size_t * free, size_t * total);

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -667,7 +667,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "visionOS")
     target_compile_definitions(ggml-base PUBLIC _DARWIN_C_SOURCE)
 endif()
 
-if (BUILD_SHARED_LIBS OR GGML_BACKEND_DL)
+if (BUILD_SHARED_LIBS OR (GGML_BACKEND_DL AND NOT WIN32))
     foreach (target ${GGML_CORE_TARGETS})
         set_target_properties(${target} PROPERTIES POSITION_INDEPENDENT_CODE ON)
         target_compile_definitions(${target} PRIVATE GGML_BUILD)

--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -245,6 +245,7 @@ extern "C" {
             GGML_BACKEND_API ggml_backend_reg_t ggml_backend_init(void); \
             }                                                            \
             ggml_backend_reg_t ggml_backend_init(void) {                 \
+                ggml_time_init();                                        \
                 return reg_fn();                                         \
             }
 #        define GGML_BACKEND_DL_SCORE_IMPL(score_fn)       \
@@ -252,17 +253,20 @@ extern "C" {
             GGML_BACKEND_API int ggml_backend_score(void); \
             }                                              \
             int ggml_backend_score(void) {                 \
+                ggml_time_init();                          \
                 return score_fn();                         \
             }
 #    else
 #        define GGML_BACKEND_DL_IMPL(reg_fn)                              \
             GGML_BACKEND_API ggml_backend_reg_t ggml_backend_init(void);  \
             ggml_backend_reg_t                  ggml_backend_init(void) { \
+                ggml_time_init();                                         \
                 return reg_fn();                                          \
             }
 #        define GGML_BACKEND_DL_SCORE_IMPL(score_fn)        \
             GGML_BACKEND_API int ggml_backend_score(void);  \
             int                  ggml_backend_score(void) { \
+                ggml_time_init();                           \
                 return score_fn();                          \
             }
 #    endif

--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -1,17 +1,19 @@
+#include "ggml-backend-dl.h"
 #include "ggml-backend-impl.h"
 #include "ggml-backend.h"
-#include "ggml-backend-dl.h"
 #include "ggml-impl.h"
+
 #include <algorithm>
+#include <cctype>
 #include <cstring>
 #include <filesystem>
 #include <limits>
 #include <memory>
+#include <regex>
 #include <string>
 #include <type_traits>
+#include <unordered_set>
 #include <vector>
-#include <cctype>
-#include <regex>
 
 #ifdef _WIN32
 #    define WIN32_LEAN_AND_MEAN
@@ -120,7 +122,12 @@ struct ggml_backend_registry {
 
     ggml_backend_registry() {
 #ifdef GGML_USE_CUDA
+    // Add runtime disable check
+    if (getenv("GGML_DISABLE_CUDA") == nullptr) {
         register_backend(ggml_backend_cuda_reg());
+    } else {
+        GGML_LOG_DEBUG("CUDA backend disabled by GGML_DISABLE_CUDA environment variable\n");
+    }
 #endif
 #ifdef GGML_USE_METAL
         register_backend(ggml_backend_metal_reg());
@@ -236,6 +243,10 @@ struct ggml_backend_registry {
             return nullptr;
         }
 
+        return load_backend(path, silent, std::move(handle));
+    }
+
+    ggml_backend_reg_t load_backend(const fs::path & path, bool silent, dl_handle_ptr handle) {
         auto backend_init_fn = (ggml_backend_init_t) dl_get_sym(handle.get(), "ggml_backend_init");
         if (!backend_init_fn) {
             if (!silent) {
@@ -502,10 +513,37 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
 
     int best_score = 0;
     fs::path best_path;
+    dl_handle_ptr   best_handle;
     std::error_code ec;
+    std::unordered_set<std::string> attempted_paths;
 
-    auto tryEntryWithScore = [&best_score, &best_path, silent, _func = __func__](const fs::path & entryPath,
-                                                                                 int              scoreOffset = 1) {
+    auto markAttempted = [&attempted_paths](const fs::path & path, bool name_only) {
+        std::string key;
+        if (name_only) {
+            key = "name:" + path_str(path);
+        } else {
+            std::error_code path_ec;
+            fs::path        canonical_path = fs::weakly_canonical(path, path_ec);
+            if (path_ec) {
+                path_ec.clear();
+                canonical_path = fs::absolute(path, path_ec);
+            }
+            if (path_ec) {
+                canonical_path = path;
+            }
+            key = "path:" + path_str(canonical_path.lexically_normal());
+        }
+#ifdef _WIN32
+        std::transform(key.begin(), key.end(), key.begin(), [](unsigned char c) { return std::tolower(c); });
+#endif
+        return attempted_paths.insert(std::move(key)).second;
+    };
+
+    auto tryEntryWithScore = [&best_score, &best_path, &best_handle, &markAttempted, silent, _func = __func__](
+                                 const fs::path & entryPath, int scoreOffset = 1, bool name_only = false) {
+        if (!markAttempted(entryPath, name_only)) {
+            return;
+        }
         dl_handle_ptr handle{ dl_load_library(entryPath) };
         if (!handle && !silent) {
             GGML_LOG_ERROR("%s: failed to load %s: %s\n", _func, path_str(entryPath).c_str(), dl_error());
@@ -514,7 +552,11 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
             auto score_fn = (ggml_backend_score_t) dl_get_sym(handle.get(), "ggml_backend_score");
             int  s        = 1;
             if (score_fn) {
-                s = score_fn() + scoreOffset;
+                const int backend_score = score_fn();
+                if (backend_score == 0) {
+                    return;
+                }
+                s = backend_score + scoreOffset;
             }
 #ifdef NDEBUG
             GGML_LOG_DEBUG("%s: %s score: %d\n", _func, path_str(entryPath).c_str(), s);
@@ -522,6 +564,7 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
             if (s > best_score) {
                 best_score = s;
                 best_path  = entryPath;
+                best_handle = std::move(handle);
             }
         }
     };
@@ -554,7 +597,9 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
             fs::path filename = backend_filename_prefix().native() + name_path.native() + backend_filename_extension().native();
             fs::path path = search_path / filename;
             if (std::error_code ec; fs::exists(path, ec)) {
-                return get_reg().load_backend(path, silent);
+                if (markAttempted(path, false)) {
+                    return get_reg().load_backend(path, silent);
+                }
             } else {
                 if (ec) {
                     GGML_LOG_DEBUG("%s: posix_stat(%s) failure, error-message: %s\n", __func__, path_str(path).c_str(), ec.message().c_str());
@@ -580,11 +625,14 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
             // Try loading backend with just the library name, leave to dlopen path resolution.
             fs::path     filename     = backend_filename_prefix().native() + loopNamePath.native() +
                                 backend_filename_extension().native();
-            tryEntryWithScore(filename, 1+scoreOffset);
+            tryEntryWithScore(filename, 1 + scoreOffset, true);
         }
     }
 
-    return get_reg().load_backend(best_path, silent);
+    if (!best_handle) {
+        return nullptr;
+    }
+    return get_reg().load_backend(best_path, silent, std::move(best_handle));
 }
 
 void ggml_backend_load_all() {
@@ -648,7 +696,19 @@ void ggml_backend_load_all_from_path(const char * dir_path) {
     ggml_backend_load_best("blas", silent, dir_path);
     ggml_backend_load_best("zendnn", silent, dir_path);
     ggml_backend_load_best("cann", silent, dir_path);
-    ggml_backend_load_best("cuda", silent, dir_path);
+    // QVAC-23763: the static path above is compiled out of DL builds, so the
+    // check is repeated here; this is where it actually fires on linux and
+    // android.
+    //
+    // GGML_DISABLE_VULKAN has no equivalent guard here, so on a DL build it is
+    // a no-op. That is pre-existing and not changed by this commit, but the two
+    // env vars now behave differently on the same build, which is worth knowing
+    // before assuming they are siblings.
+    if (getenv("GGML_DISABLE_CUDA") == nullptr) {
+        ggml_backend_load_best("cuda", silent, dir_path);
+    } else {
+        GGML_LOG_DEBUG("CUDA backend disabled by GGML_DISABLE_CUDA environment variable\n");
+    }
     ggml_backend_load_best("hip", silent, dir_path);
     ggml_backend_load_best("metal", silent, dir_path);
     ggml_backend_load_best("rpc", silent, dir_path);

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -165,11 +165,46 @@ constexpr int ggml_cuda_highest_compiled_arch_impl(const int arch, const int cur
 constexpr int ggml_cuda_highest_compiled_arch(const int arch) {
     return ggml_cuda_highest_compiled_arch_impl(arch, 0, __CUDA_ARCH_LIST__);
 }
+
+// The -1 below is what lets registration skip a device. Upstream ggml aborts
+// there instead, so a resync of the impl above must not drop it silently.
+static_assert(ggml_cuda_highest_compiled_arch_impl(750, 0, 800, 860, 890) == -1,
+              "a device below every compiled arch must resolve to -1 so registration can skip it");
+static_assert(ggml_cuda_highest_compiled_arch_impl(800, 0, 800, 860, 890) == 800,
+              "a device matching the compiled floor must resolve to that floor");
+static_assert(ggml_cuda_highest_compiled_arch_impl(890, 0, 800, 860, 890) == 890,
+              "a device with an exact compiled arch must resolve to it");
+static_assert(ggml_cuda_highest_compiled_arch_impl(1200, 0, 800, 860, 890) == 890,
+              "a device above every compiled arch must resolve to the highest compiled one");
 #else
 static int ggml_cuda_highest_compiled_arch(const int arch) {
     return arch;
 }
 #endif // __CUDA_ARCH_LIST__
+
+// Fast rejection for devices below the compiled floor. The registration path
+// also asks the CUDA runtime to load a probe kernel, which covers real-only gaps,
+// devices above an all-real ceiling, and PTX rejected by an older driver.
+static bool ggml_cuda_compiled_code_available(const int cc) {
+    if (!GGML_CUDA_CC_IS_NVIDIA(cc)) {
+        return true;
+    }
+    return ggml_cuda_highest_compiled_arch(cc) > 0;
+}
+
+constexpr int ggml_cuda_arch_score_impl(const int loadable_devices, const int exact_devices) {
+    return loadable_devices == 0 ? 0 : loadable_devices * (GGML_CUDA_MAX_DEVICES + 1) + exact_devices;
+}
+
+static bool ggml_cuda_arch_is_exact(const int cc) {
+    return GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) == cc;
+}
+
+static_assert(ggml_cuda_arch_score_impl(2, 0) > ggml_cuda_arch_score_impl(1, 1),
+              "covering every device must beat a partial exact match");
+static_assert(ggml_cuda_arch_score_impl(1, 1) > ggml_cuda_arch_score_impl(1, 0),
+              "an exact arch must win when coverage is equal");
+static_assert(ggml_cuda_arch_score_impl(0, 0) == 0, "a module that covers no device must be rejected");
 
 // ---------------------------------------------------------------------------------------------------------
 
@@ -1680,4 +1715,3 @@ static __inline__ void ggml_cuda_kernel_launch(Kernel kernel, const ggml_cuda_ke
     kernel<<<launch_params.block_nums, launch_params.block_dims, launch_params.shmem, launch_params.stream>>>(std::forward<Args>(args)... );
     CUDA_CHECK(cudaGetLastError());
 }
-

--- a/ggml/src/ggml-cuda/gated_delta_net_back.cu
+++ b/ggml/src/ggml-cuda/gated_delta_net_back.cu
@@ -283,7 +283,7 @@ gated_delta_net_back_cuda(const float * data_q_ptr,
                 }
 
                 for (int t = int(n_tokens) - 1; t >= 0; t--) {
-                    const uint32_t ut = uint(t);
+                    const uint32_t ut       = static_cast<uint32_t>(t);
                     const uint32_t q_off  = iq3 * args.sq3 + ut * args.sq2 + iq1 * args.sq1;
                     const uint32_t k_off  = q_off;
                     const uint32_t gb_off = iv3 * args.sb3 + ut * args.sb2 + iv1 * args.sb1;
@@ -604,32 +604,31 @@ ggml_cuda_op_gated_delta_net_back(ggml_backend_cuda_context & ctx, ggml_tensor *
         
     cudaStream_t stream = ctx.stream();
 
-    const ggml_cuda_gated_delta_net_back_kargs kargs = {
-        .H           = H,
-        .n_tokens    = n_tokens,
-        .n_seqs      = n_seqs,
-        .K           = static_cast<uint32_t>(ggml_get_op_params_i32(dst, 0)),
-        .s_off       = (S_v * H * n_tokens * n_seqs),
-        .sq1         = nbq1 / fsz,
-        .sq2         = nbq2 / fsz,
-        .sq3         = nbq3 / fsz,
-        .sv1         = nbv1 / fsz,
-        .sv2         = nbv2 / fsz,
-        .sv3         = nbv3 / fsz,
-        .sb1         = nbb1 / fsz,
-        .sb2         = nbb2 / fsz,
-        .sb3         = nbb3 / fsz,
-        .neq1        = neq1,
-        .rq3         = nev3 / neq3,
-        .off_dk      = off_dk,
-        .off_dv      = off_dv,
-        .off_dg      = off_dg,     
-        .off_db      = off_db,     
-        .off_ds      = off_ds,     
-        .off_scratch = off_scratch,
-        .wg_stride   = n_tokens * (2*S_v*S_v + 2*S_v),
-        .scale       = 1.0f / sqrtf((float) S_v),
-    };
+    ggml_cuda_gated_delta_net_back_kargs kargs{};
+    kargs.H           = H;
+    kargs.n_tokens    = n_tokens;
+    kargs.n_seqs      = n_seqs;
+    kargs.K           = static_cast<uint32_t>(ggml_get_op_params_i32(dst, 0));
+    kargs.s_off       = S_v * H * n_tokens * n_seqs;
+    kargs.sq1         = nbq1 / fsz;
+    kargs.sq2         = nbq2 / fsz;
+    kargs.sq3         = nbq3 / fsz;
+    kargs.sv1         = nbv1 / fsz;
+    kargs.sv2         = nbv2 / fsz;
+    kargs.sv3         = nbv3 / fsz;
+    kargs.sb1         = nbb1 / fsz;
+    kargs.sb2         = nbb2 / fsz;
+    kargs.sb3         = nbb3 / fsz;
+    kargs.neq1        = neq1;
+    kargs.rq3         = nev3 / neq3;
+    kargs.off_dk      = off_dk;
+    kargs.off_dv      = off_dv;
+    kargs.off_dg      = off_dg;
+    kargs.off_db      = off_db;
+    kargs.off_ds      = off_ds;
+    kargs.off_scratch = off_scratch;
+    kargs.wg_stride   = n_tokens * (2 * S_v * S_v + 2 * S_v);
+    kargs.scale       = 1.0f / sqrtf((float) S_v);
     if (kda) {
         launch_gated_delta_net_back<true>(q_d, k_d, v_d, g_d, b_d, s_d, d_d, dst_d,
                                           S_v, neq3, kargs, stream);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -103,6 +103,8 @@
 
 static_assert(sizeof(half) == sizeof(ggml_fp16_t), "wrong fp16 size");
 
+static __global__ void ggml_cuda_arch_probe() {}
+
 #define GGML_LOG_WARN_ONCE(str) \
     { static std::once_flag warn_flag; std::call_once(warn_flag, []() { GGML_LOG_WARN(str); }); }
 
@@ -123,6 +125,70 @@ static int ggml_cuda_get_physical_device(int device) {
     const ggml_cuda_device_info & info = ggml_cuda_info();
     GGML_ASSERT(device >= 0 && device < info.device_count);
     return info.devices[device].physical_device;
+}
+
+static bool ggml_cuda_device_code_loadable_uncached(const int physical_device, const bool log_failure) {
+#if defined(GGML_USE_HIP) || defined(GGML_USE_MUSA)
+    GGML_UNUSED(physical_device);
+    return true;
+#else
+    int               previous_device   = 0;
+    const cudaError_t get_device_result = cudaGetDevice(&previous_device);
+    if (get_device_result != cudaSuccess) {
+        if (log_failure) {
+            GGML_LOG_WARN("%s: cudaGetDevice failed: %s\n", __func__, cudaGetErrorString(get_device_result));
+        }
+        (void) cudaGetLastError();
+        return false;
+    }
+
+    const cudaError_t set_device_result = cudaSetDevice(physical_device);
+    if (set_device_result != cudaSuccess) {
+        if (log_failure) {
+            GGML_LOG_WARN("%s: cudaSetDevice(%d) failed: %s\n", __func__, physical_device,
+                          cudaGetErrorString(set_device_result));
+        }
+        (void) cudaGetLastError();
+        return false;
+    }
+
+    cudaFuncAttributes attributes;
+    const cudaError_t  probe_result = cudaFuncGetAttributes(&attributes, ggml_cuda_arch_probe);
+    if (probe_result != cudaSuccess) {
+        (void) cudaGetLastError();
+    }
+    const cudaError_t restore_result = cudaSetDevice(previous_device);
+    if (restore_result != cudaSuccess) {
+        if (log_failure) {
+            GGML_LOG_WARN("%s: failed to restore CUDA device %d: %s\n", __func__, previous_device,
+                          cudaGetErrorString(restore_result));
+        }
+        (void) cudaGetLastError();
+    }
+    if (probe_result == cudaSuccess && restore_result == cudaSuccess) {
+        return true;
+    }
+
+    if (probe_result != cudaSuccess && log_failure) {
+        GGML_LOG_WARN("%s: CUDA code cannot load on physical device %d: %s\n", __func__, physical_device,
+                      cudaGetErrorString(probe_result));
+    }
+    return false;
+#endif
+}
+
+static bool ggml_cuda_device_code_loadable(const int physical_device, const bool log_failure = true) {
+    static std::mutex cache_mutex;
+    static int        cache[GGML_CUDA_MAX_DEVICES] = {};
+
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    if (cache[physical_device] == 0) {
+        cache[physical_device] = ggml_cuda_device_code_loadable_uncached(physical_device, log_failure) ? 1 : -1;
+    } else if (cache[physical_device] < 0 && log_failure) {
+        GGML_LOG_WARN("%s: CUDA code cannot load on physical device %d; using the cached probe result\n", __func__,
+                      physical_device);
+    }
+    return cache[physical_device] > 0;
 }
 
 // this is faster on Windows
@@ -564,6 +630,22 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
         granularity(ggml_cuda_info().devices[device].vmm_granularity) {
     }
 
+    bool reserve_address() {
+#    if defined(GGML_USE_HIP)
+        CU_CHECK(cuMemAddressReserve(&pool_addr, CUDA_POOL_VMM_MAX_SIZE, 0, 0, 0));
+        return true;
+#    else
+        const CUresult result = cuMemAddressReserve(&pool_addr, CUDA_POOL_VMM_MAX_SIZE, 0, 0, 0);
+        if (result == CUDA_SUCCESS) {
+            return true;
+        }
+        GGML_LOG_WARN("%s: failed to reserve the %zu MiB VMM pool on device %d: %s; falling back to cudaMalloc\n",
+                      __func__, CUDA_POOL_VMM_MAX_SIZE / (1024 * 1024), physical_device, cu_get_error_str(result));
+        pool_addr = 0;
+        return false;
+#    endif
+    }
+
     ~ggml_cuda_pool_vmm() {
         if (pool_addr != 0) {
 #if defined(GGML_USE_HIP)
@@ -572,7 +654,9 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
                 CU_CHECK(cuMemUnmap(mapping.first, mapping.second));
             }
 #else
-            CU_CHECK(cuMemUnmap(pool_addr, pool_size));
+            if (pool_size > 0) {
+                CU_CHECK(cuMemUnmap(pool_addr, pool_size));
+            }
 #endif
             CU_CHECK(cuMemAddressFree(pool_addr, CUDA_POOL_VMM_MAX_SIZE));
         }
@@ -599,11 +683,6 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
             prop.location.id = physical_device;
             CUmemGenericAllocationHandle handle;
             CU_CHECK(cuMemCreate(&handle, reserve_size, &prop, 0));
-
-            // reserve virtual address space (if not already reserved)
-            if (pool_addr == 0) {
-                CU_CHECK(cuMemAddressReserve(&pool_addr, CUDA_POOL_VMM_MAX_SIZE, 0, 0, 0));
-            }
 
             // map at the end of the pool
             CUdeviceptr start_ptr = (CUdeviceptr)((char *)(pool_addr) + pool_size);
@@ -692,13 +771,47 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
         GGML_ASSERT(ptr == (void *) ((char *)(pool_addr) + pool_used));
     }
 };
+
+static std::atomic<bool> ggml_cuda_vmm_failed[GGML_CUDA_MAX_DEVICES] = {};
+
+struct ggml_cuda_pool_vmm_fallback : public ggml_cuda_pool {
+    int                             device;
+    int                             physical_device;
+    std::unique_ptr<ggml_cuda_pool> pool;
+
+    explicit ggml_cuda_pool_vmm_fallback(int device) :
+        device(device),
+        physical_device(ggml_cuda_get_physical_device(device)) {}
+
+    void * alloc(size_t size, size_t * actual_size) override {
+        if (!pool) {
+            if (!ggml_cuda_vmm_failed[physical_device].load(std::memory_order_relaxed)) {
+                std::unique_ptr<ggml_cuda_pool_vmm> vmm_pool(new ggml_cuda_pool_vmm(device));
+                if (vmm_pool->reserve_address()) {
+                    pool = std::move(vmm_pool);
+                } else {
+                    ggml_cuda_vmm_failed[physical_device].store(true, std::memory_order_relaxed);
+                }
+            }
+            if (!pool) {
+                pool.reset(new ggml_cuda_pool_leg(device));
+            }
+        }
+        return pool->alloc(size, actual_size);
+    }
+
+    void free(void * ptr, size_t size) override {
+        GGML_ASSERT(pool != nullptr);
+        pool->free(ptr, size);
+    }
+};
 #endif // defined(GGML_USE_VMM)
 
 std::unique_ptr<ggml_cuda_pool> ggml_backend_cuda_context::new_pool_for_device(int                  device,
                                                                                [[maybe_unused]] int stream_no) {
 #if defined(GGML_USE_VMM)
     if (ggml_cuda_info().devices[device].vmm) {
-        return std::unique_ptr<ggml_cuda_pool>(new ggml_cuda_pool_vmm(device));
+        return std::unique_ptr<ggml_cuda_pool>(new ggml_cuda_pool_vmm_fallback(device));
     }
 #endif // defined(GGML_USE_VMM)
     return std::unique_ptr<ggml_cuda_pool>(new ggml_cuda_pool_leg(device));
@@ -945,11 +1058,19 @@ static const ggml_backend_buffer_type_i ggml_backend_cuda_buffer_type_interface 
     /* .is_host          = */ NULL,
 };
 
+// maps a raw CUDA device id to its registry entry, or null if it was skipped
+static ggml_backend_dev_t ggml_backend_cuda_reg_find_device(int device);
+
 ggml_backend_buffer_type_t ggml_backend_cuda_buffer_type(int device) {
     static std::mutex mutex;
     std::lock_guard<std::mutex> lock(mutex);
 
-    if (device >= ggml_backend_cuda_get_device_count()) {
+    // The lower bound is explicit rather than implied. The arch-availability
+    // check below also rejects a negative id, but it indexes the array to do
+    // so, and memory safety should not rest on a guard whose stated purpose is
+    // unrelated and which could reasonably be moved. Matches the bound
+    // ggml_backend_cuda_init already has.
+    if (device < 0 || device >= ggml_backend_cuda_get_device_count()) {
         return nullptr;
     }
 
@@ -959,13 +1080,35 @@ ggml_backend_buffer_type_t ggml_backend_cuda_buffer_type(int device) {
 
     if (!ggml_backend_cuda_buffer_type_initialized) {
         for (int i = 0; i < ggml_backend_cuda_get_device_count(); i++) {
+            ggml_backend_dev_t dev = ggml_backend_cuda_reg_find_device(i);
+            if (dev == nullptr) {
+                // Skipped at registration. Leave the slot zero-initialised
+                // rather than building a plausible-looking buffer type with a
+                // null device and a context nothing will ever free.
+                continue;
+            }
             ggml_backend_cuda_buffer_types[i] = {
                 /* .iface    = */ ggml_backend_cuda_buffer_type_interface,
-                /* .device   = */ ggml_backend_reg_dev_get(ggml_backend_cuda_reg(), i),
+                /* .device   = */ dev,
                 /* .context  = */ new ggml_backend_cuda_buffer_type_context{i, GGML_CUDA_NAME + std::to_string(i)},
             };
         }
         ggml_backend_cuda_buffer_type_initialized = true;
+    }
+
+    // Read the cached mapping rather than re-deriving it. The table above is
+    // filled for every device id below the unfiltered count, so a null .device
+    // is exactly "this id was skipped at registration".
+    //
+    // Deliberately after the init block, not before it: this function is called
+    // per tensor copy through the GGML_ASSERT in set_tensor_async and friends,
+    // and GGML_ASSERT is not compiled out, so calling
+    // ggml_backend_cuda_reg_find_device() here would take a second global mutex
+    // and rescan the registry on every host<->device transfer. The answer never
+    // changes once registration has run.
+    if (ggml_backend_cuda_buffer_types[device].device == nullptr) {
+        GGML_LOG_ERROR("%s: device %d has no kernels compiled for its compute capability\n", __func__, device);
+        return nullptr;
     }
 
     return &ggml_backend_cuda_buffer_types[device];
@@ -1319,6 +1462,24 @@ static ggml_backend_buffer_t ggml_backend_cuda_host_buffer_type_alloc_buffer(ggm
 }
 
 ggml_backend_buffer_type_t ggml_backend_cuda_host_buffer_type() {
+    // QVAC-23763: with an empty CUDA registry ggml_backend_reg_dev_get hits its
+    // GGML_ASSERT and aborts - the exact failure mode this change exists to
+    // remove. Returning null lets the caller fall back to an unpinned host
+    // buffer instead.
+    //
+    // Skipping every device is one way to get an empty registry, but not the
+    // first: ggml_cuda_init() already returns device_count == 0 when
+    // cudaGetDeviceCount fails, so a driverless host reached the same abort
+    // before this change. The guard is a pre-existing fix and belongs upstream
+    // rather than only here.
+    //
+    // Not reachable through ggml_backend_dev_host_buffer_type(), which needs a
+    // device and so implies the registry is non-empty; reachable through this
+    // function's own GGML_BACKEND_API export in a statically linked build.
+    if (ggml_backend_reg_dev_count(ggml_backend_cuda_reg()) == 0) {
+        return nullptr;
+    }
+
     static struct ggml_backend_buffer_type ggml_backend_cuda_buffer_type_host = {
         /* .iface    = */ {
             /* .get_name         = */ ggml_backend_cuda_host_buffer_type_name,
@@ -1328,6 +1489,10 @@ ggml_backend_buffer_type_t ggml_backend_cuda_host_buffer_type() {
             /* .get_alloc_size   = */ ggml_backend_cpu_buffer_type()->iface.get_alloc_size,
             /* .is_host          = */ ggml_backend_cpu_buffer_type()->iface.is_host,
         },
+        // registry index, not a CUDA device id: this is the first surviving
+        // device, which is what a process-wide pinned host buffer wants. Do not
+        // route it through ggml_backend_cuda_reg_find_device(), which maps raw
+        // ids and returns null when CUDA device 0 is the skipped one.
         /* .device   = */ ggml_backend_reg_dev_get(ggml_backend_cuda_reg(), 0),
         /* .context  = */ nullptr,
     };
@@ -4394,7 +4559,11 @@ static void ggml_backend_cuda_graph_optimize(ggml_backend_t backend, ggml_cgraph
     ggml_cuda_stream_context & stream_context = cuda_ctx->stream_context();
     stream_context.reset();
 
-    if (!use_cuda_graph || ggml_backend_cuda_get_device_count() != 1) {
+    // QVAC-23763: the registry, not ggml_backend_cuda_get_device_count(), which
+    // stays unfiltered and so still counts devices that were skipped for having
+    // no compiled kernels. On a host with one supported card behind an
+    // unsupported one the count reads 2 and this bails on the single usable GPU.
+    if (!use_cuda_graph || ggml_backend_reg_dev_count(ggml_backend_cuda_reg()) != 1) {
         return;
     }
 
@@ -5652,9 +5821,32 @@ ggml_backend_reg_t ggml_backend_cuda_reg() {
 
             const ggml_cuda_device_info & info = ggml_cuda_info();
             const bool virtual_devices = info.device_count > info.physical_device_count;
+            bool                          physical_code_checked[GGML_CUDA_MAX_DEVICES]  = {};
+            bool                          physical_code_loadable[GGML_CUDA_MAX_DEVICES] = {};
 
             for (int i = 0; i < info.device_count; i++) {
                 const int physical_id = info.devices[i].physical_device;
+                const int cc = info.devices[i].cc;
+
+                // QVAC-23763: skip a device when this build's CUDA code cannot
+                // load on it, so it never enumerates and the consumer can fall
+                // through instead of aborting at the first kernel launch.
+                //
+                // All virtual devices on one card read the same props, so they
+                // share a cc and are skipped or kept as a group.
+                if (!physical_code_checked[physical_id]) {
+                    physical_code_checked[physical_id] = true;
+                    const bool compiled_code_available = ggml_cuda_compiled_code_available(cc);
+                    physical_code_loadable[physical_id] =
+                        compiled_code_available && ggml_cuda_device_code_loadable(physical_id);
+                    if (!compiled_code_available) {
+                        GGML_LOG_WARN("%s: skipping physical device %d (%s): no kernels compiled for compute capability %d.%d\n",
+                                      __func__, physical_id, ggml_cuda_device_description(i).c_str(), cc / 100, (cc % 100) / 10);
+                    }
+                }
+                if (!physical_code_loadable[physical_id]) {
+                    continue;
+                }
 
                 ggml_backend_cuda_device_context * dev_ctx = new ggml_backend_cuda_device_context;
                 dev_ctx->device = i;
@@ -5694,9 +5886,28 @@ ggml_backend_reg_t ggml_backend_cuda_reg() {
     return &reg;
 }
 
+// never call this from inside the registration loop above: it re-enters
+// ggml_backend_cuda_reg(), whose mutex is not recursive
+static ggml_backend_dev_t ggml_backend_cuda_reg_find_device(int device) {
+    ggml_backend_cuda_reg_context * ctx = (ggml_backend_cuda_reg_context *) ggml_backend_cuda_reg()->context;
+    for (ggml_backend_dev_t dev : ctx->devices) {
+        if (((ggml_backend_cuda_device_context *) dev->context)->device == device) {
+            return dev;
+        }
+    }
+    return nullptr;
+}
+
 ggml_backend_t ggml_backend_cuda_init(int device) {
     if (device < 0 || device >= ggml_backend_cuda_get_device_count()) {
         GGML_LOG_ERROR("%s: invalid device %d\n", __func__, device);
+        return nullptr;
+    }
+
+    // the count above is unfiltered, so a skipped device gets this far
+    ggml_backend_dev_t dev = ggml_backend_cuda_reg_find_device(device);
+    if (dev == nullptr) {
+        GGML_LOG_ERROR("%s: device %d has no kernels compiled for its compute capability\n", __func__, device);
         return nullptr;
     }
 
@@ -5709,11 +5920,71 @@ ggml_backend_t ggml_backend_cuda_init(int device) {
     ggml_backend_t cuda_backend = new ggml_backend {
         /* .guid    = */ ggml_backend_cuda_guid(),
         /* .iface   = */ ggml_backend_cuda_interface,
-        /* .device  = */ ggml_backend_reg_dev_get(ggml_backend_cuda_reg(), device),
+        /* .device  = */ dev,
         /* .context = */ ctx,
     };
 
     return cuda_backend;
 }
 
+#ifdef GGML_BACKEND_DL
+static int ggml_cuda_backend_score() {
+#    if defined(GGML_USE_HIP) || defined(GGML_USE_MUSA)
+    const ggml_cuda_device_info & info                                 = ggml_cuda_info();
+    bool                          physical_seen[GGML_CUDA_MAX_DEVICES] = {};
+    int                           loadable_devices                     = 0;
+    int                           exact_devices                        = 0;
+
+    for (int i = 0; i < info.device_count; ++i) {
+        const int physical_id = info.devices[i].physical_device;
+        if (physical_seen[physical_id]) {
+            continue;
+        }
+        physical_seen[physical_id] = true;
+
+        const int cc = info.devices[i].cc;
+        if (ggml_cuda_compiled_code_available(cc) && ggml_cuda_device_code_loadable(physical_id, false)) {
+            ++loadable_devices;
+            exact_devices += ggml_cuda_arch_is_exact(cc) ? 1 : 0;
+        }
+    }
+#    else
+    int physical_device_count = 0;
+    if (cudaGetDeviceCount(&physical_device_count) != cudaSuccess) {
+        (void) cudaGetLastError();
+        return 0;
+    }
+    if (physical_device_count > GGML_CUDA_MAX_DEVICES) {
+        return 0;
+    }
+
+    int          scored_physical_device_count = physical_device_count;
+    const char * devices_env                  = getenv("GGML_CUDA_DEVICES");
+    if (devices_env != nullptr && physical_device_count > 0) {
+        const int requested = atoi(devices_env);
+        if (requested > 0) {
+            scored_physical_device_count = std::min(requested, physical_device_count);
+        }
+    }
+
+    int loadable_devices = 0;
+    int exact_devices    = 0;
+    for (int physical_id = 0; physical_id < scored_physical_device_count; ++physical_id) {
+        cudaDeviceProp prop;
+        if (cudaGetDeviceProperties(&prop, physical_id) != cudaSuccess) {
+            (void) cudaGetLastError();
+            return 0;
+        }
+        const int cc = 100 * prop.major + 10 * prop.minor;
+        if (ggml_cuda_compiled_code_available(cc) && ggml_cuda_device_code_loadable(physical_id, false)) {
+            ++loadable_devices;
+            exact_devices += ggml_cuda_arch_is_exact(cc) ? 1 : 0;
+        }
+    }
+#    endif
+    return ggml_cuda_arch_score_impl(loadable_devices, exact_devices);
+}
+
+GGML_BACKEND_DL_SCORE_IMPL(ggml_cuda_backend_score)
+#endif
 GGML_BACKEND_DL_IMPL(ggml_backend_cuda_reg)

--- a/ggml/src/ggml-cuda/mmid-back.cu
+++ b/ggml/src/ggml-cuda/mmid-back.cu
@@ -212,16 +212,16 @@ void ggml_cuda_op_mul_mat_id_back_a(ggml_backend_cuda_context & ctx, ggml_tensor
     const uint32_t n_expert = (uint32_t)dst->ne[2];
 
     const ggml_cuda_mul_mat_id_back_a_kargs args = {
-        .K       = (uint32_t)dst->ne[0],
-        .n_used  = (uint32_t)ids->ne[0],
-        .n_tok   = (uint32_t)ids->ne[1],
-        .g_nb1   = (uint32_t)(grad_out->nb[1] / g_type_size),
-        .g_nb2   = (uint32_t)(grad_out->nb[2] / g_type_size),
-        .b_nb1   = (uint32_t)(b->nb[1] / b_type_size),
-        .b_nb2   = (uint32_t)(b->nb[2] / b_type_size),
-        .ids_nb1 = (uint32_t)(ids->nb[1] / ids_type_size),
-        .d_nb1   = (uint32_t)(dst->nb[1] / d_type_size),
-        .d_nb2   = (uint32_t)(dst->nb[2] / d_type_size),
+        (uint32_t)dst->ne[0],
+        (uint32_t)ids->ne[0],
+        (uint32_t)ids->ne[1],
+        (uint32_t)(grad_out->nb[1] / g_type_size),
+        (uint32_t)(grad_out->nb[2] / g_type_size),
+        (uint32_t)(b->nb[1] / b_type_size),
+        (uint32_t)(b->nb[2] / b_type_size),
+        (uint32_t)(ids->nb[1] / ids_type_size),
+        (uint32_t)(dst->nb[1] / d_type_size),
+        (uint32_t)(dst->nb[2] / d_type_size),
     };
     cudaStream_t stream = ctx.stream();
 #define LAUNCH_MMID_BACK_A(broadcast_b) \
@@ -281,18 +281,18 @@ void ggml_cuda_op_mul_mat_id_back_b(ggml_backend_cuda_context & ctx, ggml_tensor
     }
 
     const ggml_cuda_mul_mat_id_back_b_kargs args = {
-        .K        = (uint32_t)dst->ne[0],
-        .N        = (uint32_t)as->ne[1],
-        .n_used   = (uint32_t)ids->ne[0],
-        .n_tok    = (uint32_t)ids->ne[1],
-        .dst_ne1  = (uint32_t)dst->ne[1],
-        .as_nb1   = as_nb1,
-        .as_nb2   = as_nb2,
-        .g_nb1    = (uint32_t)(grad_out->nb[1] / g_type_size),
-        .g_nb2    = (uint32_t)(grad_out->nb[2] / g_type_size),
-        .ids_nb1  = (uint32_t)(ids->nb[1] / ids_type_size),
-        .d_nb1    = (uint32_t)(dst->nb[1] / d_type_size),
-        .d_nb2    = (uint32_t)(dst->nb[2] / d_type_size),
+        (uint32_t)dst->ne[0],
+        (uint32_t)as->ne[1],
+        (uint32_t)ids->ne[0],
+        (uint32_t)ids->ne[1],
+        (uint32_t)dst->ne[1],
+        as_nb1,
+        as_nb2,
+        (uint32_t)(grad_out->nb[1] / g_type_size),
+        (uint32_t)(grad_out->nb[2] / g_type_size),
+        (uint32_t)(ids->nb[1] / ids_type_size),
+        (uint32_t)(dst->nb[1] / d_type_size),
+        (uint32_t)(dst->nb[2] / d_type_size),
     };
 #define LAUNCH_MMID_BACK_B(A_TYPE) \
     launch_mul_mat_id_back_b<A_TYPE>(data_a, data_grad, data_i, data_d, stream, args)

--- a/ggml/src/ggml-cuda/ssm-conv-back.cu
+++ b/ggml/src/ggml-cuda/ssm-conv-back.cu
@@ -15,8 +15,8 @@ static_assert(std::is_trivially_copyable_v<ggml_cuda_ssm_conv_back_sx_kargs>);
 struct ggml_cuda_ssm_conv_back_c_kargs {
     uint32_t nc, ncs, nr, n_t, n_s;
     uint32_t grad_nb0, grad_nb1, grad_nb2;
-    uint sx_nb0, sx_nb1, sx_nb2;
-    uint dst_nb1;
+    uint32_t sx_nb0, sx_nb1, sx_nb2;
+    uint32_t dst_nb1;
 };
 static_assert(std::is_trivially_copyable_v<ggml_cuda_ssm_conv_back_c_kargs>);
 
@@ -144,20 +144,19 @@ ggml_cuda_op_ssm_conv_back_sx(ggml_backend_cuda_context & ctx, ggml_tensor * dst
     const uint32_t n_t = (uint32_t)grad_out->ne[1];
     const uint32_t n_s = (uint32_t)dst->ne[2];
 
-    const ggml_cuda_ssm_conv_back_sx_kargs args = {
-        .nc       = nc,
-        .ncs      = ncs,
-        .nr       = nr,
-        .n_t      = n_t,
-        .n_s      = n_s,
-        .grad_nb0 = (uint32_t)grad_out->nb[0]/fsz,
-        .grad_nb1 = (uint32_t)grad_out->nb[1]/fsz,
-        .grad_nb2 = (uint32_t)grad_out->nb[2]/fsz,
-        .dst_nb0  = (uint32_t)dst->nb[0]/fsz,
-        .dst_nb1  = (uint32_t)dst->nb[1]/fsz,
-        .dst_nb2  = (uint32_t)dst->nb[2]/fsz,
-        .c_nb1    = (uint32_t)c->nb[1]/fsz,
-    };
+    ggml_cuda_ssm_conv_back_sx_kargs args{};
+    args.nc             = nc;
+    args.ncs            = ncs;
+    args.nr             = nr;
+    args.n_t            = n_t;
+    args.n_s            = n_s;
+    args.grad_nb0       = (uint32_t) grad_out->nb[0] / fsz;
+    args.grad_nb1       = (uint32_t) grad_out->nb[1] / fsz;
+    args.grad_nb2       = (uint32_t) grad_out->nb[2] / fsz;
+    args.dst_nb0        = (uint32_t) dst->nb[0] / fsz;
+    args.dst_nb1        = (uint32_t) dst->nb[1] / fsz;
+    args.dst_nb2        = (uint32_t) dst->nb[2] / fsz;
+    args.c_nb1          = (uint32_t) c->nb[1] / fsz;
     cudaStream_t stream = ctx.stream();
     launch_op_ssm_conv_back_sx(data_grad, data_c, data_dst, stream, args);
 }
@@ -185,20 +184,19 @@ ggml_cuda_op_ssm_conv_back_c(ggml_backend_cuda_context & ctx, ggml_tensor * dst)
     const uint32_t n_t = (uint32_t)grad_out->ne[1];
     const uint32_t n_s = (uint32_t)grad_out->ne[2];
 
-    const ggml_cuda_ssm_conv_back_c_kargs args = {
-        .nc       = nc,
-        .ncs      = ncs,
-        .nr       = nr,
-        .n_t      = n_t,
-        .n_s      = n_s,
-        .grad_nb0 = (uint32_t)grad_out->nb[0]/fsz,
-        .grad_nb1 = (uint32_t)grad_out->nb[1]/fsz,
-        .grad_nb2 = (uint32_t)grad_out->nb[2]/fsz,
-        .sx_nb0  = (uint32_t)sx->nb[0]/fsz,
-        .sx_nb1  = (uint32_t)sx->nb[1]/fsz,
-        .sx_nb2  = (uint32_t)sx->nb[2]/fsz,
-        .dst_nb1 = (uint32_t)dst->nb[1]/fsz,
-    };
+    ggml_cuda_ssm_conv_back_c_kargs args{};
+    args.nc             = nc;
+    args.ncs            = ncs;
+    args.nr             = nr;
+    args.n_t            = n_t;
+    args.n_s            = n_s;
+    args.grad_nb0       = (uint32_t) grad_out->nb[0] / fsz;
+    args.grad_nb1       = (uint32_t) grad_out->nb[1] / fsz;
+    args.grad_nb2       = (uint32_t) grad_out->nb[2] / fsz;
+    args.sx_nb0         = (uint32_t) sx->nb[0] / fsz;
+    args.sx_nb1         = (uint32_t) sx->nb[1] / fsz;
+    args.sx_nb2         = (uint32_t) sx->nb[2] / fsz;
+    args.dst_nb1        = (uint32_t) dst->nb[1] / fsz;
     cudaStream_t stream = ctx.stream();
     launch_op_ssm_conv_back_c(data_grad, data_sx, data_dst, stream, args);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -377,6 +377,20 @@ llama_build_and_test(test-copy-tbq-subgroups.cpp)
 # mtmd, so it is intentionally outside the LLAMA_MTMD block below.
 llama_build_and_test(test-opencl-fa-chunking.cpp)
 
+# QVAC-23763: the CUDA arch-availability registration guard. Self-skips with 77
+# when no CUDA registry is present, which today is every runner - there is no
+# CUDA hardware in CI, so both cases below skip and this is a fixture for manual
+# runs, not a gate. The second registration runs the same binary with virtual
+# devices on, which exercises the group-skip path; see the comment in the test
+# for what that check can and cannot detect (it catches a gross split, not the
+# one-device case).
+llama_build_and_test(test-cuda-arch-registration.cpp)
+set_tests_properties(test-cuda-arch-registration PROPERTIES SKIP_RETURN_CODE 77)
+llama_test(test-cuda-arch-registration NAME test-cuda-arch-registration-virtual)
+set_tests_properties(test-cuda-arch-registration-virtual PROPERTIES
+    SKIP_RETURN_CODE 77
+    ENVIRONMENT "GGML_CUDA_DEVICES=4")
+
 llama_build_and_test(test-model-load-cancel.cpp       LABEL "model")
 llama_build_and_test(test-model-load-disk.cpp         LABEL "model")
 llama_build_and_test(test-model-load-memory.cpp       LABEL "model")

--- a/tests/test-cuda-arch-registration.cpp
+++ b/tests/test-cuda-arch-registration.cpp
@@ -1,0 +1,203 @@
+// Pins CUDA availability registration: devices this build cannot serve are
+// skipped in ggml_backend_cuda_reg(), and downstream code must accept a subset.
+//
+// Regression fixture for QVAC-23763 / tetherto/qvac#4171. Before the guard, a
+// card below the compiled floor enumerated, won backend selection over Vulkan,
+// and then aborted at the first kernel launch instead of falling back.
+//
+// Skips with 77 when no CUDA registry is present, so it runs everywhere.
+
+#include "ggml-backend.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <string>
+
+// GGML_CUDA_NAME, and so the registry name, is "ROCm" on HIP and "MUSA" on MUSA.
+// The same source builds all three, and the guard is compiled into all three, so
+// matching only "CUDA" would make those builds skip with hardware present.
+static ggml_backend_reg_t find_cuda_reg() {
+    static const char * const names[] = { "CUDA", "ROCm", "MUSA" };
+    for (size_t i = 0; i < ggml_backend_reg_count(); i++) {
+        ggml_backend_reg_t reg = ggml_backend_reg_get(i);
+        for (const char * name : names) {
+            if (strcmp(ggml_backend_reg_name(reg), name) == 0) {
+                return reg;
+            }
+        }
+    }
+    return nullptr;
+}
+
+// virtual devices get "-v<n>" appended to the physical card's bus id
+static std::string physical_key(const char * device_id) {
+    std::string id = device_id ? device_id : "";
+    const size_t v = id.rfind("-v");
+    if (v != std::string::npos && v + 2 < id.size()) {
+        bool digits = true;
+        for (size_t i = v + 2; i < id.size(); i++) {
+            digits = digits && id[i] >= '0' && id[i] <= '9';
+        }
+        if (digits) {
+            id.resize(v);
+        }
+    }
+    return id;
+}
+
+static void print_archs(ggml_backend_reg_t reg) {
+    auto get_features = (ggml_backend_get_features_t)
+        ggml_backend_reg_get_proc_address(reg, "ggml_backend_get_features");
+    if (get_features == nullptr) {
+        printf("compiled archs: unavailable\n");
+        return;
+    }
+    for (ggml_backend_feature * f = get_features(reg); f && f->name; f++) {
+        if (strcmp(f->name, "ARCHS") == 0) {
+            printf("compiled archs: %s\n", f->value);
+            return;
+        }
+    }
+    printf("compiled archs: not reported\n");
+}
+
+int main() {
+    ggml_backend_load_all();
+
+    ggml_backend_reg_t cuda = find_cuda_reg();
+    if (cuda == nullptr) {
+        printf("no CUDA registry, skipping\n");
+        return 77;
+    }
+
+    print_archs(cuda);
+
+    const size_t n_cuda  = ggml_backend_reg_dev_count(cuda);
+    const size_t n_total = ggml_backend_dev_count();
+    printf("reg=CUDA devices=%zu total_devices=%zu\n", n_cuda, n_total);
+
+    int fails = 0;
+
+    // The whole point of skipping at registration: a host whose every CUDA
+    // device is uncovered must still have somewhere to run.
+    //
+    // Checking n_total == 0 would be dead code - the CPU backend registers
+    // unconditionally, so ggml_backend_dev_count() is never 0 and the assertion
+    // could not fail however badly registration broke. Look for a device that
+    // can actually take the work instead.
+    if (n_cuda == 0) {
+        bool have_fallback = false;
+        for (size_t i = 0; i < n_total; i++) {
+            // 'enum' tag required: the accessor function shadows the enum name.
+            const enum ggml_backend_dev_type t = ggml_backend_dev_type(ggml_backend_dev_get(i));
+            if (t == GGML_BACKEND_DEVICE_TYPE_CPU || t == GGML_BACKEND_DEVICE_TYPE_GPU) {
+                have_fallback = true;
+                break;
+            }
+        }
+        if (!have_fallback) {
+            fprintf(stderr, "FAIL: every CUDA device was skipped and no CPU or GPU device remains\n");
+            fails++;
+        } else {
+            // Deliberately not phrased as "all devices were skipped". An empty
+            // registry is also what a machine with no NVIDIA card at all
+            // produces, and nothing here can tell the two apart: skipped
+            // devices leave the registry entirely and the unfiltered count is
+            // not reachable from the public API. Passing this is not evidence
+            // the guard fired. See the note at the end of this file.
+            printf("CUDA registry is empty (no covered device, or no device at all); "
+                   "a non-CUDA fallback device is present\n");
+        }
+    }
+
+    std::map<std::string, size_t> per_card;
+
+    for (size_t i = 0; i < n_cuda; i++) {
+        ggml_backend_dev_t dev = ggml_backend_reg_dev_get(cuda, i);
+
+        ggml_backend_dev_props props;
+        ggml_backend_dev_get_props(dev, &props);
+        printf("  device %zu: name=%s id=%s desc=%s\n",
+            i, props.name, props.device_id ? props.device_id : "(none)", props.description);
+
+        per_card[physical_key(props.device_id)]++;
+
+        // A subset registry means raw CUDA ids no longer index it. If any site
+        // still resolves by index, the buffer type comes back null or bound to
+        // the wrong device.
+        ggml_backend_buffer_type_t buft = ggml_backend_dev_buffer_type(dev);
+        if (buft == nullptr) {
+            fprintf(stderr, "FAIL: device %zu (%s) has a null buffer type\n", i, props.name);
+            fails++;
+            continue;
+        }
+        if (ggml_backend_buft_get_device(buft) != dev) {
+            fprintf(stderr, "FAIL: device %zu (%s) buffer type is bound to a different device\n",
+                i, props.name);
+            fails++;
+        }
+
+        // The other index-resolving site, and the riskier one. Before the fix,
+        // ggml_backend_cuda_init() range-checked against the UNFILTERED device
+        // count and then indexed the filtered registry, so on a host with a
+        // skipped device 0 and a kept device 1 it passed the check and aborted
+        // inside ggml_backend_cuda_reg_get_device's GGML_ASSERT. A null buffer
+        // type would not have caught that.
+        ggml_backend_t backend = ggml_backend_dev_init(dev, nullptr);
+        if (backend == nullptr) {
+            fprintf(stderr, "FAIL: device %zu (%s) failed to initialise a backend\n", i, props.name);
+            fails++;
+        } else {
+            if (ggml_backend_get_device(backend) != dev) {
+                fprintf(stderr, "FAIL: device %zu (%s) backend is bound to a different device\n",
+                    i, props.name);
+                fails++;
+            }
+            ggml_backend_free(backend);
+        }
+    }
+
+    // GGML_CUDA_DEVICES splits each physical card into virtual devices. They all
+    // read the same properties, so they share a compute capability and must be
+    // skipped or kept as a group - never split. Round-robin assignment allows a
+    // difference of one between cards.
+    //
+    // Know what this does NOT catch, because the shape is weaker than it looks.
+    // Skipped devices leave the registry entirely, so only survivors are
+    // countable, and the check is a spread over those. With one physical card
+    // the map has a single key and lo == hi unconditionally, so it cannot fail -
+    // and one card is the ordinary dev and CI configuration. With two cards the
+    // round-robin tolerance of one is exactly the size of the smallest real
+    // failure (one card losing a single virtual device), so that case passes
+    // too. It catches a gross split, not a subtle one.
+    //
+    // Making this tight needs the skipped count to be observable rather than
+    // inferred - e.g. a SKIPPED_DEVICES entry in ggml_backend_get_features, so
+    // the test can assert n_cuda + skipped == ggml_backend_cuda_get_device_count()
+    // and check each card against its full expected count. Worth doing when
+    // there is CUDA hardware in CI to run it on; today both ctest cases skip
+    // with 77 on every runner (build-cuda-ubuntu.yml builds in a GPU-less
+    // container and runs no ctest step), so this fixture has no CI value yet
+    // and is here for the manual runs on the QVAC-23763 hosts.
+    if (!per_card.empty()) {
+        size_t lo = SIZE_MAX, hi = 0;
+        for (const auto & kv : per_card) {
+            lo = kv.second < lo ? kv.second : lo;
+            hi = kv.second > hi ? kv.second : hi;
+        }
+        printf("surviving cards=%zu virtual devices per card=%zu..%zu\n", per_card.size(), lo, hi);
+        if (hi - lo > 1) {
+            fprintf(stderr, "FAIL: one physical card was partially skipped (%zu..%zu per card)\n", lo, hi);
+            fails++;
+        }
+    }
+
+    if (fails > 0) {
+        return 1;
+    }
+
+    printf("OK\n");
+    return 0;
+}


### PR DESCRIPTION
> Draft. Based on the fabric 10549 release line. CUDA is deferred from the current QVAC release.

## What problem does this solve?

CUDA could register a device even when the compiled module could not load code for that GPU. The addon then selected CUDA and ggml aborted at the first kernel launch. Jetson Orin also aborted when its reported VMM support could not reserve ggml's fixed virtual address range.

Both failures must be handled inside fabric because consumers cannot catch a ggml abort.

## What changes?

1. Probe a small CUDA kernel before registering each device. This covers devices below the compiled floor, gaps in real-only architecture lists, devices above an all-real ceiling, and PTX rejected by an older driver.
2. Skip devices that cannot load the module's compiled code, so consumers can continue to Vulkan or CPU.
3. Score CUDA modules by usable device coverage and exact architecture matches. A module with no usable device returns score zero and is not loaded.
4. Keep raw CUDA device IDs separate from filtered registry indices.
5. Add `GGML_DISABLE_CUDA` for runtime fallback testing without hiding the same GPU from Vulkan.
6. Fall back to the legacy CUDA allocation pool when VMM address reservation fails.
7. Keep the CUDA source portable across the Windows compiler path used by qvac.

The module scoring is required for the two Linux arm64 modules. DGX Spark loads the CUDA 13 module and Jetson Orin loads the CUDA 12 module. A module that cannot load on the machine is skipped.

## Validation

The behavior was verified through qvac CI and runtime tests on Linux T4, Linux L4, RTX 5090, DGX Spark, Jetson Orin, and Windows T4. The tests covered CUDA selection, Vulkan fallback, module unload, the sm_75 PTX floor, sm_89, native sm_120a, native sm_121, native sm_87, and the Tegra VMM fallback.

The branch has now been updated from the current `temp-10549` base. Final CI against the updated fabric commit is pending.

## Dependencies

Registry #336 pins this fabric commit and publishes the cross-platform CUDA modules. The qvac addon stack starts at #4126.
