### PR TITLE
ggml: overlap dense FFN weight transfers with prompt processing

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2859,14 +2859,20 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             if (value < 0) {
                 throw std::invalid_argument("invalid value");
             }
-            for (int i = 0; i < value; ++i) {
-                // keep strings alive and avoid leaking memory by storing them in a static vector
-                static std::list<std::string> buft_overrides;
-                buft_overrides.push_back(llm_ffn_exps_block_regex(i));
-                params.tensor_buft_overrides.push_back({buft_overrides.back().c_str(), ggml_backend_cpu_buffer_type()});
-            }
+            llm_add_n_cpu_ffn_overrides(value, LLM_FFN_EXPS_REGEX, params.tensor_buft_overrides);
         }
     ).set_env("LLAMA_ARG_N_CPU_MOE"));
+    add_opt(common_arg(
+        {"-ncffn", "--n-cpu-ffn"}, "N",
+        "keep the dense FFN weights of the first N layers in the CPU\n"
+        "(dense models; for MoE expert weights use --n-cpu-moe)",
+        [](common_params & params, int value) {
+            if (value < 0) {
+                throw std::invalid_argument("invalid value");
+            }
+            llm_add_n_cpu_ffn_overrides(value, LLM_FFN_DENSE_REGEX, params.tensor_buft_overrides);
+        }
+    ).set_env("LLAMA_ARG_N_CPU_FFN"));
     GGML_ASSERT(params.n_gpu_layers < 0); // string_format would need to be extended for a default >= 0
     add_opt(common_arg(
         {"-ngl", "--gpu-layers", "--n-gpu-layers"}, "N",
@@ -4200,11 +4206,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             if (value < 0) {
                 throw std::invalid_argument("invalid value");
             }
-            for (int i = 0; i < value; ++i) {
-                static std::list<std::string> buft_overrides_draft;
-                buft_overrides_draft.push_back(llm_ffn_exps_block_regex(i));
-                params.speculative.draft.tensor_buft_overrides.push_back({buft_overrides_draft.back().c_str(), ggml_backend_cpu_buffer_type()});
-            }
+            llm_add_n_cpu_ffn_overrides(value, LLM_FFN_EXPS_REGEX, params.speculative.draft.tensor_buft_overrides);
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SPEC_DRAFT_N_CPU_MOE"));
 

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3035,6 +3035,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ));
     add_opt(common_arg(
+        {"-pw", "--prefetch-weights"}, "0|1",
+        string_format("prefetch weight transfers to overlap CPU->GPU copies with compute (default: %d)", (int) params.prefetch_weights),
+        [](common_params & params, int value) {
+            params.prefetch_weights = value != 0;
+        }
+    ));
+    add_opt(common_arg(
         {"--lora"}, "FNAME",
         "path to LoRA adapter (use comma-separated values to load multiple adapters)",
         [](common_params & params, const std::string & value) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1819,6 +1819,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.swa_full          = params.swa_full;
     cparams.training          = params.training;
     cparams.kv_unified        = params.kv_unified;
+    cparams.prefetch_weights  = params.prefetch_weights;
 
     cparams.type_k         = params.cache_type_k;
     cparams.type_v         = params.cache_type_v;

--- a/common/common.h
+++ b/common/common.h
@@ -8,6 +8,7 @@
 #include "ggml.h"
 #include "llama.h"
 
+#include <list>
 #include <set>
 #include <sstream>
 #include <string>
@@ -1137,17 +1138,28 @@ const char * const LLM_KV_SPLIT_TENSORS_COUNT = "split.tensors.count";
 }
 
 //
-// MoE utils
+// FFN offload utils
 //
 
 const char * const LLM_FFN_EXPS_REGEX = "\\.ffn_(up|down|gate|gate_up)_(ch|)exps";
 
-inline std::string llm_ffn_exps_block_regex(int idx) {
-    return string_format("blk\\.%d%s", idx, LLM_FFN_EXPS_REGEX);
+const char * const LLM_FFN_DENSE_REGEX = "\\.ffn_(up|down|gate)\\.";
+
+inline std::string llm_ffn_block_regex(int idx, const char * ffn_regex) {
+    return string_format("blk\\.%d%s", idx, ffn_regex);
 }
 
 inline llama_model_tensor_buft_override llm_ffn_exps_cpu_override() {
     return { LLM_FFN_EXPS_REGEX, ggml_backend_cpu_buffer_type() };
+}
+
+inline void llm_add_n_cpu_ffn_overrides(int n, const char * ffn_regex, std::vector<llama_model_tensor_buft_override> & overrides) {
+    // keep strings alive and avoid leaking memory by storing them in a static list
+    static std::list<std::string> buft_override_strings;
+    for (int i = 0; i < n; ++i) {
+        buft_override_strings.push_back(llm_ffn_block_regex(i, ffn_regex));
+        overrides.push_back({buft_override_strings.back().c_str(), ggml_backend_cpu_buffer_type()});
+    }
 }
 
 //

--- a/common/common.h
+++ b/common/common.h
@@ -579,6 +579,7 @@ struct common_params {
     bool check_tensors     = false; // validate tensor data
     bool no_op_offload     = false; // globally disable offload host tensor operations to device
     bool training          = false; // enable training mode (affects LoRA K/V gradient flow)
+    bool prefetch_weights  = false; // prefetch weight transfers to overlap CPU->GPU copies with compute
     bool no_extra_bufts    = false; // disable extra buffer types (used for weight repacking)
     bool no_host           = false; // bypass host buffer allowing extra buffers to be used
 

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -156,6 +156,8 @@ extern "C" {
         bool events;
         // mmap is supported for loading
         bool mmap_support;
+        // dedicated copy stream for compute/transfer overlap
+        bool copy_stream;
     };
 
     // all the device properties
@@ -379,6 +381,9 @@ extern "C" {
             ggml_backend_sched_moe_cache_begin_callback    begin,
             ggml_backend_sched_moe_cache_prepare_callback  prepare,
             void *                                         user_data);
+
+    // Enable async weight prefetching to overlap CPU->GPU transfers with compute
+    GGML_API void                 ggml_backend_sched_set_prefetch_weights(ggml_backend_sched_t sched, bool enabled);
 
     //
     // Meta backend

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -133,6 +133,7 @@ static void ggml_backend_meta_device_get_props(ggml_backend_dev_t dev, ggml_back
         /* .buffer_from_host_ptr  = */ false, // Not implemented.
         /* .events                = */ false, // Not implemented.
         /* .mmap_support          = */ true,
+        /* .copy_stream           = */ false, // Not available
     };
     for (ggml_backend_dev_t simple_dev : meta_dev_ctx->simple_devs) {
         ggml_backend_dev_props tmp_props;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1952,6 +1952,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                     ggml_backend_buffer_get_usage(input->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS &&
                     ggml_backend_buffer_is_host(input->buffer) && (
                     (node->src[0] == input_cpy && node->op == GGML_OP_MUL_MAT_ID)
+                    //|| (node->src[1] == input_cpy && node->op == GGML_OP_ADD_ID) /* GGML_OP_ADD_ID weights are small and not worth splitting */
                     )) {
 
                     const int64_t n_expert   = node->op == GGML_OP_MUL_MAT_ID ? input->ne[2] : input->ne[1];

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1431,7 +1431,7 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
             // too far past the last offloading node.
             int fuse_end = i; // inclusive end index in graph
             // Persistent MoE cache preparation currently relies on one expert operation per split.
-            if (sched->prefetch_weights && need_new_split && sched->callback_moe_cache_resolve == NULL) {
+            if (sched->prefetch_weights && sched->copy_backends[node_backend_id] != NULL && need_new_split && sched->callback_moe_cache_resolve == NULL) {
                 const int max_lookahead = 8;
                 int last_offload_k = i;
                 for (int k = i + 1; k < graph->n_nodes; k++) {
@@ -1684,7 +1684,7 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
 
         // prefetch double-buffer: reserve next split's weight copy memory BEFORE compute
         // so the allocator doesn't reuse it for intermediates in this split
-        if (sched->prefetch_weights && i + 1 < sched->n_splits) {
+        if (sched->prefetch_weights && sched->copy_backends[split->backend_id] != NULL && i + 1 < sched->n_splits) {
             struct ggml_backend_sched_split * next = &sched->splits[i + 1];
             if (next->backend_id == split->backend_id) {
                 for (int j = 0; j < next->n_inputs; j++) {
@@ -1711,7 +1711,7 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
         }
 
         // extend current split's weight copies lifetime to here (after next's are allocated above)
-        if (sched->prefetch_weights) {
+        if (sched->prefetch_weights && sched->copy_backends[split->backend_id] != NULL) {
             for (int j = 0; j < split->n_inputs; j++) {
                 struct ggml_tensor * input = split->inputs[j];
                 if (input->buffer != NULL &&
@@ -1877,7 +1877,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
         prefetched_inputs.swap(next_prefetched_inputs);
         next_prefetched_inputs.clear();
 
-        if (sched->prefetch_weights) {
+        if (sched->prefetch_weights && sched->copy_backends[split_backend_id] != NULL) {
             ggml_backend_t copy_backend = sched->copy_backends[split_backend_id];
             if (copy_backend != NULL) {
                 // compute stream waits for previous prefetch to complete
@@ -2391,7 +2391,7 @@ void ggml_backend_sched_set_prefetch_weights(ggml_backend_sched_t sched, bool en
     GGML_ASSERT(sched);
     sched->prefetch_weights = enabled;
 
-    if (enabled) {
+    if (enabled && sched->n_backends == 2) {
         for (int b = 0; b < sched->n_backends; b++) {
             if (sched->copy_backends[b] != NULL) {
                 continue;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -865,6 +865,12 @@ struct ggml_backend_sched {
     size_t context_buffer_size;
 
     bool op_offload;
+    bool prefetch_weights;
+
+    // prefetch support: copy backends and events for compute/transfer overlap
+    ggml_backend_t       copy_backends[GGML_SCHED_MAX_BACKENDS];
+    ggml_backend_event_t copy_events[GGML_SCHED_MAX_BACKENDS];    // copy -> compute sync
+    ggml_backend_event_t compute_events[GGML_SCHED_MAX_BACKENDS]; // compute -> copy sync
 
     int debug;
 
@@ -1378,8 +1384,6 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
         int cur_backend_id = split->backend_id;
         for (; i < graph->n_nodes; i++) {
             struct ggml_tensor * node = graph->nodes[i];
-            struct ggml_backend_sched_moe_cache_entry * cache_entry = NULL;
-            struct ggml_tensor * original_ids = node->op == GGML_OP_MUL_MAT_ID ? node->src[2] : NULL;
 
             if (ggml_is_view_op(node->op)) {
                 continue;
@@ -1420,6 +1424,48 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
                 }
             }
 
+            // when prefetch is enabled and a new split is needed, progressively fuse
+            // consecutive nodes that also require weight offloading to the same backend.
+            // intermediate nodes without weight offload (e.g. GLU between up and down in MoE)
+            // are included in the fused range. a max lookahead distance prevents scanning
+            // too far past the last offloading node.
+            int fuse_end = i; // inclusive end index in graph
+            // Persistent MoE cache preparation currently relies on one expert operation per split.
+            if (sched->prefetch_weights && need_new_split && sched->callback_moe_cache_resolve == NULL) {
+                const int max_lookahead = 8;
+                int last_offload_k = i;
+                for (int k = i + 1; k < graph->n_nodes; k++) {
+                    struct ggml_tensor * next = graph->nodes[k];
+                    if (ggml_is_view_op(next->op)) {
+                        continue;
+                    }
+                    if (tensor_backend_id(next) != node_backend_id) {
+                        break;
+                    }
+                    if (k - last_offload_k > max_lookahead) {
+                        break;
+                    }
+                    bool has_weight_offload = false;
+                    for (int j = 0; j < GGML_MAX_SRC; j++) {
+                        struct ggml_tensor * src = next->src[j];
+                        if (src == NULL) {
+                            continue;
+                        }
+                        if (src->buffer != NULL && src->buffer->usage == GGML_BACKEND_BUFFER_USAGE_WEIGHTS) {
+                            int src_backend_id = tensor_backend_id(src);
+                            if (src_backend_id != node_backend_id && !ggml_backend_sched_buffer_supported(sched, src, node_backend_id)) {
+                                has_weight_offload = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (has_weight_offload) {
+                        fuse_end = k;
+                        last_offload_k = k;
+                    }
+                }
+            }
+
             if (node_backend_id != cur_backend_id || need_new_split) {
                 split->i_end = i;
                 i_split++;
@@ -1441,110 +1487,120 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
             }
 
             // find inputs that are not on the same backend
-            for (int j = 0; j < GGML_MAX_SRC; j++) {
-                struct ggml_tensor * src = node->src[j];
-                if (src == NULL) {
+            for (int fi = i; fi <= fuse_end; fi++) {
+                struct ggml_tensor * fnode = graph->nodes[fi];
+                if (ggml_is_view_op(fnode->op)) {
                     continue;
                 }
-
-                size_t src_id = hash_id(src);
-                const int src_backend_id = sched->hv_tensor_backend_ids[src_id];
-                GGML_ASSERT(src_backend_id != -1); // all inputs should be assigned by now
-
-                if (src->flags & GGML_TENSOR_FLAG_INPUT && sched->n_copies > 1) {
-                    if (tensor_id_copy(src_id, src_backend_id, 0) == NULL) {
-                        ggml_backend_t backend = sched->backends[src_backend_id];
-                        for (int c = 0; c < sched->n_copies; c++) {
-                            struct ggml_tensor * tensor_copy;
-                            if (c == sched->cur_copy) {
-                                tensor_copy = src; // use the original tensor as the current copy
-                            } else {
-                                tensor_copy = ggml_dup_tensor_layout(sched->ctx, src);
-                                ggml_format_name(tensor_copy, "%s#%s#%d", ggml_backend_name(backend), src->name, c);
-                            }
-                            ggml_set_input(tensor_copy);
-                            ggml_set_output(tensor_copy); // prevent ggml-alloc from overwriting the tensor
-                            tensor_id_copy(src_id, src_backend_id, c) = tensor_copy;
-                            SET_CAUSE(tensor_copy, "4.cpy");
-                        }
-                        int n_graph_inputs = sched->n_graph_inputs++;
-                        if (n_graph_inputs >= sched->graph_inputs_capacity) {
-                            ggml_backend_sched_graph_inputs_grow(sched);
-                        }
-                        sched->graph_inputs[n_graph_inputs] = src;
+                struct ggml_backend_sched_moe_cache_entry * cache_entry = NULL;
+                struct ggml_tensor * original_ids = fnode->op == GGML_OP_MUL_MAT_ID ? fnode->src[2] : NULL;
+                for (int j = 0; j < GGML_MAX_SRC; j++) {
+                    struct ggml_tensor * src = fnode->src[j];
+                    if (src == NULL) {
+                        continue;
                     }
-                }
 
-                if (src_backend_id != cur_backend_id && !ggml_backend_sched_buffer_supported(sched, src, cur_backend_id)) {
-                    // create a copy of the input in the split's backend
-                    ggml_backend_t backend = sched->backends[cur_backend_id];
-                    struct ggml_tensor * cached_tensor = NULL;
-                    void * cache_handle = NULL;
-                    bool cache_bound =
-                        j == 0 &&
-                        node->op == GGML_OP_MUL_MAT_ID &&
-                        original_ids != NULL &&
-                        sched->n_copies == 1 &&
-                        sched->callback_moe_cache_resolve != NULL &&
-                        sched->callback_moe_cache_resolve(
-                            sched->callback_moe_cache_user_data, src, backend,
-                            &cached_tensor, &cache_handle);
+                    size_t src_id = hash_id(src);
+                    const int src_backend_id = sched->hv_tensor_backend_ids[src_id];
+                    GGML_ASSERT(src_backend_id != -1); // all inputs should be assigned by now
 
-                    // A batched MUL_MAT_ID can select any expert in the bank. Only use the
-                    // persistent cache when it can pin a complete layer working set; smaller
-                    // caches retain the selected-slice fallback used before cache support.
-                    const bool cache_active = cache_bound &&
-                        !(original_ids->ne[1] > 1 && cached_tensor->ne[2] < src->ne[2]);
-
-                    GGML_ASSERT(!cache_bound || cached_tensor != NULL);
-                    GGML_ASSERT(!cache_bound || cached_tensor->buffer != NULL);
-                    GGML_ASSERT(!cache_bound || cached_tensor->ne[0] == src->ne[0]);
-                    GGML_ASSERT(!cache_bound || cached_tensor->ne[1] == src->ne[1]);
-                    GGML_ASSERT(!cache_bound || cached_tensor->ne[2] >= original_ids->ne[0]);
-                    GGML_ASSERT(!cache_bound || tensor_id_copy(src_id, cur_backend_id, 0) == NULL);
-                    if (tensor_id_copy(src_id, cur_backend_id, 0) == NULL) {
-                        if (cache_active) {
-                            tensor_id_copy(src_id, cur_backend_id, 0) = cached_tensor;
-                            SET_CAUSE(cached_tensor, "4.moe");
-                        } else {
+                    if (src->flags & GGML_TENSOR_FLAG_INPUT && sched->n_copies > 1) {
+                        if (tensor_id_copy(src_id, src_backend_id, 0) == NULL) {
+                            ggml_backend_t backend = sched->backends[src_backend_id];
                             for (int c = 0; c < sched->n_copies; c++) {
-                                struct ggml_tensor * tensor_copy = ggml_dup_tensor_layout(sched->ctx, src);
-                                ggml_format_name(tensor_copy, "%s#%s#%d", ggml_backend_name(backend), src->name, c);
-                                if (sched->n_copies > 1) {
-                                    ggml_set_input(tensor_copy);
-                                    ggml_set_output(tensor_copy); // prevent ggml-alloc from overwriting the tensor
+                                struct ggml_tensor * tensor_copy;
+                                if (c == sched->cur_copy) {
+                                    tensor_copy = src; // use the original tensor as the current copy
+                                } else {
+                                    tensor_copy = ggml_dup_tensor_layout(sched->ctx, src);
+                                    ggml_format_name(tensor_copy, "%s#%s#%d", ggml_backend_name(backend), src->name, c);
                                 }
-                                tensor_id_copy(src_id, cur_backend_id, c) = tensor_copy;
+                                ggml_set_input(tensor_copy);
+                                ggml_set_output(tensor_copy); // prevent ggml-alloc from overwriting the tensor
+                                tensor_id_copy(src_id, src_backend_id, c) = tensor_copy;
                                 SET_CAUSE(tensor_copy, "4.cpy");
                             }
-                        }
-                        int n_inputs = split->n_inputs++;
-                        if (n_inputs >= split->inputs_capacity) {
-                            ggml_backend_sched_split_inputs_grow(split);
-                        }
-                        split->inputs[n_inputs] = src;
-                    }
-                    if (cache_bound) {
-                        GGML_ASSERT(cache_entry == NULL);
-                        cache_entry = ggml_backend_sched_moe_cache_entry_add(sched);
-                        cache_entry->split_id = i_split;
-                        cache_entry->input = src;
-                        cache_entry->ids = original_ids;
-                        cache_entry->handle = cache_handle;
-                        cache_entry->active = cache_active;
-                        cache_entry->ids_copy = ggml_dup_tensor_layout(sched->ctx, original_ids);
-                        ggml_format_name(cache_entry->ids_copy, "%s#%s#moe_cache",
-                            ggml_backend_name(backend), original_ids->name);
-                        if (cache_active) {
-                            ggml_set_output(original_ids); // keep logical IDs alive until scheduler remapping
+                            int n_graph_inputs = sched->n_graph_inputs++;
+                            if (n_graph_inputs >= sched->graph_inputs_capacity) {
+                                ggml_backend_sched_graph_inputs_grow(sched);
+                            }
+                            sched->graph_inputs[n_graph_inputs] = src;
                         }
                     }
-                    node->src[j] = tensor_id_copy(src_id, cur_backend_id, sched->cur_copy);
+
+                    if (src_backend_id != cur_backend_id && !ggml_backend_sched_buffer_supported(sched, src, cur_backend_id)) {
+                        // create a copy of the input in the split's backend
+                        ggml_backend_t backend = sched->backends[cur_backend_id];
+                        struct ggml_tensor * cached_tensor = NULL;
+                        void * cache_handle = NULL;
+                        bool cache_bound =
+                            j == 0 &&
+                            fnode->op == GGML_OP_MUL_MAT_ID &&
+                            original_ids != NULL &&
+                            sched->n_copies == 1 &&
+                            sched->callback_moe_cache_resolve != NULL &&
+                            sched->callback_moe_cache_resolve(
+                                sched->callback_moe_cache_user_data, src, backend,
+                                &cached_tensor, &cache_handle);
+
+                        // A batched MUL_MAT_ID can select any expert in the bank. Only use the
+                        // persistent cache when it can pin a complete layer working set; smaller
+                        // caches retain the selected-slice fallback used before cache support.
+                        const bool cache_active = cache_bound &&
+                            !(original_ids->ne[1] > 1 && cached_tensor->ne[2] < src->ne[2]);
+
+                        GGML_ASSERT(!cache_bound || cached_tensor != NULL);
+                        GGML_ASSERT(!cache_bound || cached_tensor->buffer != NULL);
+                        GGML_ASSERT(!cache_bound || cached_tensor->ne[0] == src->ne[0]);
+                        GGML_ASSERT(!cache_bound || cached_tensor->ne[1] == src->ne[1]);
+                        GGML_ASSERT(!cache_bound || cached_tensor->ne[2] >= original_ids->ne[0]);
+                        GGML_ASSERT(!cache_bound || tensor_id_copy(src_id, cur_backend_id, 0) == NULL);
+                        if (tensor_id_copy(src_id, cur_backend_id, 0) == NULL) {
+                            if (cache_active) {
+                                tensor_id_copy(src_id, cur_backend_id, 0) = cached_tensor;
+                                SET_CAUSE(cached_tensor, "4.moe");
+                            } else {
+                                for (int c = 0; c < sched->n_copies; c++) {
+                                    struct ggml_tensor * tensor_copy = ggml_dup_tensor_layout(sched->ctx, src);
+                                    ggml_format_name(tensor_copy, "%s#%s#%d", ggml_backend_name(backend), src->name, c);
+                                    if (sched->n_copies > 1) {
+                                        ggml_set_input(tensor_copy);
+                                        ggml_set_output(tensor_copy); // prevent ggml-alloc from overwriting the tensor
+                                    }
+                                    tensor_id_copy(src_id, cur_backend_id, c) = tensor_copy;
+                                    SET_CAUSE(tensor_copy, "4.cpy");
+                                }
+                            }
+                            int n_inputs = split->n_inputs++;
+                            if (n_inputs >= split->inputs_capacity) {
+                                ggml_backend_sched_split_inputs_grow(split);
+                            }
+                            split->inputs[n_inputs] = src;
+                        }
+                        if (cache_bound) {
+                            GGML_ASSERT(cache_entry == NULL);
+                            cache_entry = ggml_backend_sched_moe_cache_entry_add(sched);
+                            cache_entry->split_id = i_split;
+                            cache_entry->input = src;
+                            cache_entry->ids = original_ids;
+                            cache_entry->handle = cache_handle;
+                            cache_entry->active = cache_active;
+                            cache_entry->ids_copy = ggml_dup_tensor_layout(sched->ctx, original_ids);
+                            ggml_format_name(cache_entry->ids_copy, "%s#%s#moe_cache",
+                                ggml_backend_name(backend), original_ids->name);
+                            if (cache_active) {
+                                ggml_set_output(original_ids); // keep logical IDs alive until scheduler remapping
+                            }
+                        }
+                        fnode->src[j] = tensor_id_copy(src_id, cur_backend_id, sched->cur_copy);
+                    }
+                }
+                if (cache_entry != NULL && cache_entry->active) {
+                    fnode->src[2] = cache_entry->ids_copy;
                 }
             }
-            if (cache_entry != NULL && cache_entry->active) {
-                node->src[2] = cache_entry->ids_copy;
-            }
+
+            i = fuse_end;
         }
         split->i_end = graph->n_nodes;
         sched->n_splits = i_split + 1;
@@ -1569,8 +1625,9 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
     for (int i = 0; i < sched->n_splits; i++) {
         total_inputs += sched->splits[i].n_inputs;
     }
+    const int nodes_per_input = sched->prefetch_weights ? 4 : 2;
     int graph_size = std::max(graph->n_nodes, graph->n_leafs) +
-        total_inputs * 2 * sched->n_copies +
+        total_inputs * nodes_per_input * sched->n_copies +
         sched->n_moe_cache_entries;
 
     // remember the actual graph_size for performing reallocation checks later [GGML_SCHED_DEBUG_REALLOC]
@@ -1625,10 +1682,50 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
             graph_copy->nodes[graph_copy->n_nodes++] = input_cpy;
         }
 
+        // prefetch double-buffer: reserve next split's weight copy memory BEFORE compute
+        // so the allocator doesn't reuse it for intermediates in this split
+        if (sched->prefetch_weights && i + 1 < sched->n_splits) {
+            struct ggml_backend_sched_split * next = &sched->splits[i + 1];
+            if (next->backend_id == split->backend_id) {
+                for (int j = 0; j < next->n_inputs; j++) {
+                    struct ggml_tensor * next_input = next->inputs[j];
+                    if (next_input->buffer != NULL &&
+                        ggml_backend_buffer_get_usage(next_input->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS &&
+                        ggml_backend_buffer_is_host(next_input->buffer)) {
+                        const size_t id = hash_id(next_input);
+                        struct ggml_tensor * next_cpy = tensor_id_copy(id, next->backend_id, sched->cur_copy);
+                        assert(graph_copy->size > graph_copy->n_nodes);
+                        struct ggml_tensor * keepalive = ggml_view_tensor(sched->ctx, next_cpy);
+                        keepalive->src[0] = next_cpy;
+                        sched->node_backend_ids[graph_copy->n_nodes] = next->backend_id;
+                        graph_copy->nodes[graph_copy->n_nodes++] = keepalive;
+                    }
+                }
+            }
+        }
+
         for (int j = split->i_start; j < split->i_end; j++) {
             assert(graph_copy->size > graph_copy->n_nodes);
             sched->node_backend_ids[graph_copy->n_nodes] = tensor_backend_id(graph->nodes[j]);
             graph_copy->nodes[graph_copy->n_nodes++] = graph->nodes[j];
+        }
+
+        // extend current split's weight copies lifetime to here (after next's are allocated above)
+        if (sched->prefetch_weights) {
+            for (int j = 0; j < split->n_inputs; j++) {
+                struct ggml_tensor * input = split->inputs[j];
+                if (input->buffer != NULL &&
+                    ggml_backend_buffer_get_usage(input->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS &&
+                    ggml_backend_buffer_is_host(input->buffer)) {
+                    const size_t id = hash_id(input);
+                    struct ggml_tensor * curr_cpy = tensor_id_copy(id, split->backend_id, sched->cur_copy);
+                    assert(graph_copy->size > graph_copy->n_nodes);
+                    struct ggml_tensor * keepalive = ggml_view_tensor(sched->ctx, curr_cpy);
+                    keepalive->src[0] = curr_cpy;
+                    sched->node_backend_ids[graph_copy->n_nodes] = split->backend_id;
+                    graph_copy->nodes[graph_copy->n_nodes++] = keepalive;
+                }
+            }
         }
     }
 
@@ -1716,6 +1813,9 @@ static bool ggml_backend_sched_alloc_splits(ggml_backend_sched_t sched) {
         // synchronize without ggml_backend_sched_synchronize to avoid changing cur_copy
         for (int i = 0; i < sched->n_backends; i++) {
             ggml_backend_synchronize(sched->backends[i]);
+            if (sched->copy_backends[i] != NULL) {
+                ggml_backend_synchronize(sched->copy_backends[i]);
+            }
         }
 
         ggml_gallocr_reserve_n(sched->galloc, &sched->graph, sched->node_backend_ids, sched->leaf_backend_ids);
@@ -1756,6 +1856,9 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
         sched->callback_moe_cache_begin(sched->callback_moe_cache_user_data);
     }
 
+    std::vector<ggml_tensor *> prefetched_inputs;
+    std::vector<ggml_tensor *> next_prefetched_inputs;
+
     for (int split_id = 0; split_id < sched->n_splits; split_id++) {
         struct ggml_backend_sched_split * split = &splits[split_id];
         int split_backend_id = split->backend_id;
@@ -1771,6 +1874,49 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
             }
         }
 
+        prefetched_inputs.swap(next_prefetched_inputs);
+        next_prefetched_inputs.clear();
+
+        if (sched->prefetch_weights) {
+            ggml_backend_t copy_backend = sched->copy_backends[split_backend_id];
+            if (copy_backend != NULL) {
+                // compute stream waits for previous prefetch to complete
+                if (!prefetched_inputs.empty()) {
+                    ggml_backend_event_wait(split_backend, sched->copy_events[split_backend_id]);
+                }
+
+                // prefetch next split's weights on the copy stream
+                if (split_id + 1 < sched->n_splits) {
+                    struct ggml_backend_sched_split * next = &splits[split_id + 1];
+                    // only prefetch when next split is on the same device
+                    if (next->backend_id == split_backend_id) {
+                        for (int input_id = 0; input_id < next->n_inputs; input_id++) {
+                            struct ggml_tensor * input = next->inputs[input_id];
+                            if (ggml_backend_sched_moe_cache_entry_find(sched, split_id + 1, input) != NULL) {
+                                continue;
+                            }
+                            if (input->buffer != NULL &&
+                                ggml_backend_buffer_get_usage(input->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS &&
+                                ggml_backend_buffer_is_host(input->buffer)) {
+                                if (next_prefetched_inputs.empty()) {
+                                    // Copy stream waits until the previous use of this staging buffer is done.
+                                    ggml_backend_event_wait(copy_backend, sched->compute_events[split_backend_id]);
+                                }
+                                struct ggml_tensor * input_cpy = tensor_copy(input, next->backend_id, sched->cur_copy);
+                                ggml_backend_tensor_set_async(copy_backend, input_cpy, input->data, 0, ggml_nbytes(input));
+                                next_prefetched_inputs.push_back(input);
+                            }
+                        }
+
+                        // signal that prefetch is done
+                        if (!next_prefetched_inputs.empty()) {
+                            ggml_backend_event_record(sched->copy_events[split_backend_id], copy_backend);
+                        }
+                    }
+                }
+            }
+        }
+
         // copy the input tensors to the split backend
         for (int input_id = 0; input_id < split->n_inputs; input_id++) {
             ggml_backend_t input_backend = ggml_backend_sched_get_tensor_backend(sched, split->inputs[input_id]);
@@ -1778,6 +1924,11 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
             struct ggml_tensor * input_cpy = tensor_copy(input, split_backend_id, sched->cur_copy);
             struct ggml_backend_sched_moe_cache_entry * cache_entry =
                 ggml_backend_sched_moe_cache_entry_find(sched, split_id, input);
+
+            // skip weight inputs that were already prefetched by the previous split
+            if (std::find(prefetched_inputs.begin(), prefetched_inputs.end(), input) != prefetched_inputs.end()) {
+                continue;
+            }
 
             if (input->flags & GGML_TENSOR_FLAG_INPUT) {
                 // inputs from the user must be copied immediately to prevent the user overwriting the data before the copy is done
@@ -1801,7 +1952,6 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                     ggml_backend_buffer_get_usage(input->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS &&
                     ggml_backend_buffer_is_host(input->buffer) && (
                     (node->src[0] == input_cpy && node->op == GGML_OP_MUL_MAT_ID)
-                    //|| (node->src[1] == input_cpy && node->op == GGML_OP_ADD_ID) /* GGML_OP_ADD_ID weights are small and not worth splitting */
                     )) {
 
                     const int64_t n_expert   = node->op == GGML_OP_MUL_MAT_ID ? input->ne[2] : input->ne[1];
@@ -1980,6 +2130,11 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
             }
         }
 
+        // record compute done for copy stream sync
+        if (sched->compute_events[split_backend_id] != NULL) {
+            ggml_backend_event_record(sched->compute_events[split_backend_id], split_backend);
+        }
+
         // record the event of this split
         if (sched->events[split_backend_id][sched->cur_copy] != NULL) {
             ggml_backend_event_record(sched->events[split_backend_id][sched->cur_copy], split_backend);
@@ -2028,7 +2183,7 @@ ggml_backend_sched_t ggml_backend_sched_new(
     sched->hv_tensor_copies      = (ggml_tensor **) malloc(sched->hash_set.size * sched->n_backends * sched->n_copies * sizeof(struct ggml_tensor *));
 
     const size_t ggml_sched_max_splits = graph_size; // at most there is one split for each node in the graph
-    const size_t nodes_size = graph_size + ggml_sched_max_splits*GGML_SCHED_MAX_SPLIT_INPUTS*2;
+    const size_t nodes_size = graph_size + ggml_sched_max_splits*GGML_SCHED_MAX_SPLIT_INPUTS*4;
     sched->node_backend_ids = (int *) calloc(nodes_size, sizeof(sched->node_backend_ids[0]));
     sched->leaf_backend_ids = (int *) calloc(nodes_size, sizeof(sched->leaf_backend_ids[0]));
     sched->prev_node_backend_ids = (int *) calloc(nodes_size, sizeof(sched->prev_node_backend_ids[0]));
@@ -2038,7 +2193,7 @@ ggml_backend_sched_t ggml_backend_sched_new(
     sched->debug_prev_graph_size = 0;
 
     sched->context_buffer_size =
-        (ggml_sched_max_splits*GGML_SCHED_MAX_SPLIT_INPUTS*2 + graph_size*sched->n_copies) * sizeof(struct ggml_tensor) +
+        (ggml_sched_max_splits*GGML_SCHED_MAX_SPLIT_INPUTS*4 + graph_size*sched->n_copies) * sizeof(struct ggml_tensor) +
         ggml_graph_overhead_custom(graph_size, false);
     sched->context_buffer = (char *) malloc(sched->context_buffer_size);
 
@@ -2076,6 +2231,11 @@ void ggml_backend_sched_free(ggml_backend_sched_t sched) {
     for (int b = 0; b < sched->n_backends; b++) {
         for (int c = 0; c < sched->n_copies; c++) {
             ggml_backend_event_free(sched->events[b][c]);
+        }
+        ggml_backend_event_free(sched->copy_events[b]);
+        ggml_backend_event_free(sched->compute_events[b]);
+        if (sched->copy_backends[b] != NULL) {
+            ggml_backend_free(sched->copy_backends[b]);
         }
     }
     ggml_gallocr_free(sched->galloc);
@@ -2190,6 +2350,9 @@ void ggml_backend_sched_synchronize(ggml_backend_sched_t sched) {
     GGML_ASSERT(sched);
     for (int i = 0; i < sched->n_backends; i++) {
         ggml_backend_synchronize(sched->backends[i]);
+        if (sched->copy_backends[i] != NULL) {
+            ggml_backend_synchronize(sched->copy_backends[i]);
+        }
     }
     if (!sched->is_alloc) {
         // if the graph is not already allocated, always use copy 0 after a synchronization
@@ -2222,6 +2385,41 @@ void ggml_backend_sched_set_moe_cache(
     sched->callback_moe_cache_begin = begin;
     sched->callback_moe_cache_prepare = prepare;
     sched->callback_moe_cache_user_data = user_data;
+}
+
+void ggml_backend_sched_set_prefetch_weights(ggml_backend_sched_t sched, bool enabled) {
+    GGML_ASSERT(sched);
+    sched->prefetch_weights = enabled;
+
+    if (enabled) {
+        for (int b = 0; b < sched->n_backends; b++) {
+            if (sched->copy_backends[b] != NULL) {
+                continue;
+            }
+            ggml_backend_dev_t dev = ggml_backend_get_device(sched->backends[b]);
+            if (dev == NULL) {
+                continue;
+            }
+            struct ggml_backend_dev_props props;
+            ggml_backend_dev_get_props(dev, &props);
+            if (props.caps.copy_stream) {
+                sched->copy_backends[b]  = ggml_backend_dev_init(dev, NULL);
+                sched->copy_events[b]    = ggml_backend_event_new(dev);
+                sched->compute_events[b] = ggml_backend_event_new(dev);
+            }
+        }
+    } else {
+        for (int b = 0; b < sched->n_backends; b++) {
+            ggml_backend_event_free(sched->copy_events[b]);
+            sched->copy_events[b] = NULL;
+            ggml_backend_event_free(sched->compute_events[b]);
+            sched->compute_events[b] = NULL;
+            if (sched->copy_backends[b] != NULL) {
+                ggml_backend_free(sched->copy_backends[b]);
+                sched->copy_backends[b] = NULL;
+            }
+        }
+    }
 }
 
 int ggml_backend_sched_get_n_splits(ggml_backend_sched_t sched) {

--- a/ggml/src/ggml-blas/ggml-blas.cpp
+++ b/ggml/src/ggml-blas/ggml-blas.cpp
@@ -368,6 +368,7 @@ static void ggml_backend_blas_device_get_props(ggml_backend_dev_t dev, struct gg
         /* .buffer_from_host_ptr  = */ true,
         /* .events                = */ false,
         /* .mmap_support          = */ true,
+        /* .copy_stream           = */ false,
     };
 }
 

--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -2819,6 +2819,7 @@ static void ggml_backend_cann_device_get_props(ggml_backend_dev_t dev, ggml_back
         /* .buffer_from_host_ptr  = */ false,
         /* .events                = */ true,
         /* .mmap_support          = */ true,
+        /* .copy_stream           = */ false,
     };
 }
 

--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -439,6 +439,7 @@ static void ggml_backend_cpu_device_get_props(ggml_backend_dev_t dev, struct ggm
         /* .buffer_from_host_ptr  = */ true,
         /* .events                = */ false,
         /* .mmap_support          = */ true,
+        /* .copy_stream           = */ false,
     };
 }
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4886,6 +4886,7 @@ static void ggml_backend_cuda_device_get_props(ggml_backend_dev_t dev, ggml_back
         /* .buffer_from_host_ptr  = */ false,
         /* .events                = */ events,
         /* .mmap_support          = */ props->type != GGML_BACKEND_DEVICE_TYPE_IGPU,
+        /* .copy_stream           = */ true,
     };
 }
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4886,7 +4886,7 @@ static void ggml_backend_cuda_device_get_props(ggml_backend_dev_t dev, ggml_back
         /* .buffer_from_host_ptr  = */ false,
         /* .events                = */ events,
         /* .mmap_support          = */ props->type != GGML_BACKEND_DEVICE_TYPE_IGPU,
-        /* .copy_stream           = */ true,
+        /* .copy_stream           = */ events,
     };
 }
 

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -3936,6 +3936,7 @@ static void ggml_backend_hexagon_device_get_props(ggml_backend_dev_t dev, struct
         /* .buffer_from_host_ptr  = */ false,
         /* .events                = */ false,
         /* .mmap_support          = */ false,
+        /* .copy_stream           = */ false,
     };
 }
 

--- a/ggml/src/ggml-metal/ggml-metal.cpp
+++ b/ggml/src/ggml-metal/ggml-metal.cpp
@@ -705,6 +705,7 @@ static void ggml_backend_metal_device_get_props(ggml_backend_dev_t dev, ggml_bac
         /* .buffer_from_host_ptr = */ true,
         /* .events               = */ true,
         /* .mmap_support         = */ true,
+        /* .copy_stream          = */ false,
     };
 }
 

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -11473,6 +11473,7 @@ static void ggml_backend_opencl_device_get_props(ggml_backend_dev_t dev, struct 
         /* .buffer_from_host_ptr  = */ false,
         /* .events                = */ false,
         /* .mmap_support          = */ false,
+        /* .copy_stream           = */ false,
     };
 }
 

--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -864,6 +864,7 @@ static void ggml_backend_openvino_device_get_props(ggml_backend_dev_t dev, ggml_
         /* .buffer_from_host_ptr  = */ false,
         /* .events                = */ false,
         /* .mmap_support          = */ true,
+        /* .copy_stream           = */ false,
     };
 }
 

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -3345,6 +3345,7 @@ static void ggml_backend_rpc_device_get_props(ggml_backend_dev_t dev, struct ggm
         /* .buffer_from_host_ptr  = */ false,
         /* .events                = */ true,
         /* .mmap_support          = */ true,
+        /* .copy_stream           = */ false,
     };
 }
 

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -5898,6 +5898,7 @@ static void ggml_backend_sycl_device_get_props(ggml_backend_dev_t dev, ggml_back
         /* .buffer_from_host_ptr  = */ false,
         /* .events                = */ events,
         /* .mmap_support          = */ true,
+        /* .copy_stream           = */ false,
     };
 }
 

--- a/ggml/src/ggml-virtgpu/ggml-backend-device.cpp
+++ b/ggml/src/ggml-virtgpu/ggml-backend-device.cpp
@@ -70,6 +70,7 @@ static void ggml_backend_remoting_device_get_props(ggml_backend_dev_t dev, ggml_
     props->caps.buffer_from_host_ptr = false;
     props->caps.async                = false;
     props->caps.events               = false;
+    props->caps.copy_stream          = false;
 }
 
 ggml_backend_buffer_type_t ggml_backend_remoting_device_get_buffer_type(ggml_backend_dev_t dev) {

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -21034,6 +21034,7 @@ static void ggml_backend_vk_device_get_props(ggml_backend_dev_t dev, struct ggml
         /* .buffer_from_host_ptr  = */ false,
         /* .events                = */ true,
         /* .mmap_support          = */ !ctx->is_integrated_gpu,
+        /* .copy_stream           = */ false,
     };
 }
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -21034,7 +21034,7 @@ static void ggml_backend_vk_device_get_props(ggml_backend_dev_t dev, struct ggml
         /* .buffer_from_host_ptr  = */ false,
         /* .events                = */ true,
         /* .mmap_support          = */ !ctx->is_integrated_gpu,
-        /* .copy_stream           = */ false,
+        /* .copy_stream           = */ ggml_vk_get_device(ctx->device)->async_use_transfer_queue,
     };
 }
 

--- a/ggml/src/ggml-webgpu/ggml-webgpu.cpp
+++ b/ggml/src/ggml-webgpu/ggml-webgpu.cpp
@@ -3963,6 +3963,7 @@ static void ggml_backend_webgpu_device_get_props(ggml_backend_dev_t dev, struct 
         /* .buffer_from_host_ptr  = */ false,
         /* .events                = */ false,
         /* .mmap_support          = */ true,
+        /* .copy_stream           = */ false,
     };
 }
 

--- a/ggml/src/ggml-zdnn/ggml-zdnn.cpp
+++ b/ggml/src/ggml-zdnn/ggml-zdnn.cpp
@@ -419,22 +419,22 @@ static enum ggml_status ggml_backend_zdnn_graph_compute(ggml_backend_t backend, 
 }
 
 static ggml_backend_i ggml_backend_zdnn_i = {
-    /* .get_name               = */ ggml_backend_zdnn_name,
-    /* .free                   = */ ggml_backend_zdnn_free,
-    /* .set_tensor_async       = */ NULL,
-    /* .get_tensor_async       = */ NULL,
-    /* .set_tensor_2d_async    = */ NULL,
-    /* .get_tensor_2d_async    = */ NULL,
-    /* .cpy_tensor_async       = */ NULL,
-    /* .synchronize            = */ NULL,
-    /* .graph_plan_create      = */ NULL,
-    /* .graph_plan_free        = */ NULL,
-    /* .graph_plan_update      = */ NULL,
-    /* .graph_plan_compute     = */ NULL,
-    /* .graph_compute          = */ ggml_backend_zdnn_graph_compute,
-    /* .event_record           = */ NULL,
-    /* .event_wait             = */ NULL,
-    /* .graph_optimize         = */ NULL,
+    /* .get_name                = */ ggml_backend_zdnn_name,
+    /* .free                    = */ ggml_backend_zdnn_free,
+    /* .set_tensor_async        = */ NULL,
+    /* .get_tensor_async        = */ NULL,
+    /* .set_tensor_2d_async     = */ NULL,
+    /* .get_tensor_2d_async     = */ NULL,
+    /* .cpy_tensor_async        = */ NULL,
+    /* .synchronize             = */ NULL,
+    /* .graph_plan_create       = */ NULL,
+    /* .graph_plan_free         = */ NULL,
+    /* .graph_plan_update       = */ NULL,
+    /* .graph_plan_compute      = */ NULL,
+    /* .graph_compute           = */ ggml_backend_zdnn_graph_compute,
+    /* .event_record            = */ NULL,
+    /* .event_wait              = */ NULL,
+    /* .graph_optimize          = */ NULL,
 };
 
 static ggml_guid_t ggml_backend_zdnn_guid(void) {
@@ -489,6 +489,7 @@ static void ggml_backend_zdnn_device_get_props(ggml_backend_dev_t dev, ggml_back
         /* .buffer_from_host_ptr = */ false,
         /* .events               = */ false,
         /* .mmap_support         = */ true,
+        /* .copy_stream          = */ false,
     };
 }
 

--- a/ggml/src/ggml-zendnn/ggml-zendnn.cpp
+++ b/ggml/src/ggml-zendnn/ggml-zendnn.cpp
@@ -656,6 +656,7 @@ static void ggml_backend_zendnn_device_get_props(ggml_backend_dev_t dev, struct 
         /* .buffer_from_host_ptr = */ true,
         /* .events               = */ false,
         /* .mmap_support         = */ true,
+        /* .copy_stream          = */ false,
     };
 }
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -408,6 +408,8 @@ extern "C" {
                           // try to disable when n_seq_max > 1 for improved performance when the sequences do not share a large prefix
                           // ref: https://github.com/ggml-org/llama.cpp/pull/14363
 
+        bool prefetch_weights; // prefetch weight transfers to overlap CPU->GPU copies with compute
+
         // [EXPERIMENTAL]
         // backend sampler chain configuration (make sure the caller keeps the sampler chains alive)
         // note: the samplers must be sampler chains (i.e. use llama_sampler_chain_init)

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -271,9 +271,10 @@ llama_context::llama_context(
         }
     }
 
-    cparams.op_offload     = params.op_offload;
-    cparams.kv_unified     = params.kv_unified;
-    cparams.moe_cache_size = params.moe_cache_size;
+    cparams.op_offload       = params.op_offload;
+    cparams.kv_unified       = params.kv_unified;
+    cparams.prefetch_weights = params.prefetch_weights;
+    cparams.moe_cache_size   = params.moe_cache_size;
 
     // initialized later
     cparams.pipeline_parallel = false;
@@ -644,6 +645,7 @@ void llama_context::sched_reserve() {
     auto create_sched = [&](bool parallel) {
         sched.reset(ggml_backend_sched_new(
             backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, parallel, cparams.op_offload));
+        ggml_backend_sched_set_prefetch_weights(sched.get(), cparams.prefetch_weights);
         if (moe_cache) {
             ggml_backend_sched_set_moe_cache(
                 sched.get(),
@@ -3799,6 +3801,7 @@ llama_context_params llama_context_default_params() {
         /*.op_offload                  =*/ true,
         /*.swa_full                    =*/ true,
         /*.kv_unified                  =*/ false,
+        /*.prefetch_weights            =*/ false,
         /*.sampler                     =*/ nullptr,
         /*.n_sampler                   =*/ 0,
         /*.ctx_other                   =*/ nullptr,

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -57,6 +57,7 @@ struct llama_cparams {
     bool training;
 
     size_t moe_cache_size;
+    bool prefetch_weights;
 
     std::vector<bool> embeddings_layer_inp; // [n_layer()] extract input embeddings for layer
 

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -1313,7 +1313,7 @@ struct cmd_params_instance {
             merged.reserve(merged.size() + (size_t) n_cpu_moe + 1);
 
             for (int i = 0; i < n_cpu_moe; ++i) {
-                patterns.push_back(llm_ffn_exps_block_regex(i));
+                patterns.push_back(llm_ffn_block_regex(i, LLM_FFN_EXPS_REGEX));
                 merged.push_back({ patterns.back().c_str(),
                                 ggml_backend_cpu_buffer_type() });
             }

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -382,6 +382,7 @@ struct cmd_params {
     std::vector<std::vector<llama_model_tensor_buft_override>> tensor_buft_overrides;
     std::vector<bool>                embeddings;
     std::vector<bool>                no_op_offload;
+    std::vector<bool>                prefetch_weights;
     std::vector<bool>                no_host;
     std::vector<size_t>              fit_params_target;
     std::vector<uint32_t>            fit_params_min_ctx;
@@ -426,6 +427,7 @@ static const cmd_params cmd_params_defaults = {
     /* tensor_buft_overrides*/ { std::vector<llama_model_tensor_buft_override>{ { nullptr, nullptr } } },
     /* embeddings           */ { false },
     /* no_op_offload        */ { false },
+    /* prefetch_weights     */ { false },
     /* no_host              */ { false },
     /* fit_params_target    */ { 0 },
     /* fit_params_min_ctx   */ { 0 },
@@ -500,6 +502,7 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  -ot --override-tensor <tensor name pattern>=<buffer type>;...\n");
     printf("                                                    (default: disabled)\n");
     printf("  -nopo, --no-op-offload <0|1>                      (default: 0)\n");
+    printf("  -pw, --prefetch-weights <0|1>                     (default: 0)\n");
     printf("  --no-host <0|1>                                   (default: %s)\n", join(cmd_params_defaults.no_host, ",").c_str());
     printf("\n");
     printf(
@@ -938,6 +941,13 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                 }
                 auto p = string_split<bool>(argv[i], split_delim);
                 params.no_op_offload.insert(params.no_op_offload.end(), p.begin(), p.end());
+            } else if (arg == "-pw" || arg == "--prefetch-weights") {
+                if (++i >= argc) {
+                    invalid_param = true;
+                    break;
+                }
+                auto p = string_split<bool>(argv[i], split_delim);
+                params.prefetch_weights.insert(params.prefetch_weights.end(), p.begin(), p.end());
             } else if (arg == "--no-host") {
                 if (++i >= argc) {
                     invalid_param = true;
@@ -1206,6 +1216,9 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     if (params.no_op_offload.empty()) {
         params.no_op_offload = cmd_params_defaults.no_op_offload;
     }
+    if (params.prefetch_weights.empty()) {
+        params.prefetch_weights = cmd_params_defaults.prefetch_weights;
+    }
     if (params.no_host.empty()) {
         params.no_host = cmd_params_defaults.no_host;
     }
@@ -1256,6 +1269,7 @@ struct cmd_params_instance {
     std::vector<llama_model_tensor_buft_override> tensor_buft_overrides;
     bool               embeddings;
     bool               no_op_offload;
+    bool               prefetch_weights;
     bool               no_host;
     size_t             fit_target;
     uint32_t           fit_min_ctx;
@@ -1332,6 +1346,7 @@ struct cmd_params_instance {
         cparams.flash_attn_type = flash_attn;
         cparams.embeddings      = embeddings;
         cparams.op_offload      = !no_op_offload;
+        cparams.prefetch_weights = prefetch_weights;
         cparams.swa_full        = false;
 
         return cparams;
@@ -1357,6 +1372,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
     for (const auto & noh : params.no_host)
     for (const auto & embd : params.embeddings)
     for (const auto & nopo : params.no_op_offload)
+    for (const auto & pw : params.prefetch_weights)
     for (const auto & nb : params.n_batch)
     for (const auto & nub : params.n_ubatch)
     for (const auto & tk : params.type_k)
@@ -1397,6 +1413,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .tensor_buft_overrides = */ ot,
                 /* .embeddings            = */ embd,
                 /* .no_op_offload         = */ nopo,
+                /* .prefetch_weights      = */ pw,
                 /* .no_host               = */ noh,
                 /* .fit_target            = */ fpt,
                 /* .fit_min_ctx           = */ fpc,
@@ -1433,6 +1450,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .tensor_buft_overrides = */ ot,
                 /* .embeddings            = */ embd,
                 /* .no_op_offload         = */ nopo,
+                /* .prefetch_weights      = */ pw,
                 /* .no_host               = */ noh,
                 /* .fit_target            = */ fpt,
                 /* .fit_min_ctx           = */ fpc,
@@ -1469,6 +1487,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .tensor_buft_overrides = */ ot,
                 /* .embeddings            = */ embd,
                 /* .no_op_offload         = */ nopo,
+                /* .prefetch_weights      = */ pw,
                 /* .no_host               = */ noh,
                 /* .fit_target            = */ fpt,
                 /* .fit_min_ctx           = */ fpc,
@@ -1510,6 +1529,7 @@ struct test {
     std::vector<llama_model_tensor_buft_override> tensor_buft_overrides;
     bool                     embeddings;
     bool                     no_op_offload;
+    bool                     prefetch_weights;
     bool                     no_host;
     size_t                   fit_target;
     uint32_t                 fit_min_ctx;
@@ -1549,6 +1569,7 @@ struct test {
         tensor_buft_overrides = inst.tensor_buft_overrides;
         embeddings     = inst.embeddings;
         no_op_offload  = inst.no_op_offload;
+        prefetch_weights = inst.prefetch_weights;
         no_host        = inst.no_host;
         fit_target     = inst.fit_target;
         fit_min_ctx    = inst.fit_min_ctx;
@@ -1609,7 +1630,7 @@ struct test {
             "type_k",         "type_v",         "n_gpu_layers",  "n_cpu_moe",      "split_mode",
             "main_gpu",       "no_kv_offload",  "flash_attn",    "devices",        "tensor_split",
             "tensor_buft_overrides",            "load_mode",     "embeddings",
-            "no_op_offload",  "no_host",        "fit_target",    "fit_min_ctx",
+            "no_op_offload",  "prefetch_weights", "no_host",      "fit_target",    "fit_min_ctx",
             "n_prompt",       "n_gen",          "n_depth",
             "test_time",      "avg_ns",         "stddev_ns",     "avg_ts",         "stddev_ts"
         };
@@ -1622,7 +1643,7 @@ struct test {
         if (field == "build_number" || field == "n_batch" || field == "n_ubatch" || field == "n_threads" ||
             field == "poll" || field == "model_size" || field == "model_n_params" || field == "n_gpu_layers" ||
             field == "main_gpu" || field == "n_prompt" || field == "n_gen" || field == "n_depth" || field == "avg_ns" ||
-            field == "stddev_ns" || field == "no_op_offload" || field == "n_cpu_moe" ||
+            field == "stddev_ns" || field == "no_op_offload" || field == "prefetch_weights" || field == "n_cpu_moe" ||
             field == "fit_target" || field == "fit_min_ctx" || field == "flash_attn") {
             return INT;
         }
@@ -1705,6 +1726,7 @@ struct test {
                                             llama_load_mode_name(load_mode),
                                             std::to_string(embeddings),
                                             std::to_string(no_op_offload),
+                                            std::to_string(prefetch_weights),
                                             std::to_string(no_host),
                                             std::to_string(fit_target),
                                             std::to_string(fit_min_ctx),
@@ -1896,6 +1918,9 @@ struct markdown_printer : public printer {
         if (field == "no_op_offload") {
             return 4;
         }
+        if (field == "prefetch_weights") {
+            return 2;
+        }
         if (field == "no_host") {
             return 4;
         }
@@ -1932,6 +1957,9 @@ struct markdown_printer : public printer {
         }
         if (field == "no_op_offload") {
             return "nopo";
+        }
+        if (field == "prefetch_weights") {
+            return "pw";
         }
         if (field == "no_host") {
             return "noh";
@@ -2022,6 +2050,9 @@ struct markdown_printer : public printer {
         }
         if (params.no_op_offload.size() > 1 || params.no_op_offload != cmd_params_defaults.no_op_offload) {
             fields.emplace_back("no_op_offload");
+        }
+        if (params.prefetch_weights.size() > 1 || params.prefetch_weights != cmd_params_defaults.prefetch_weights) {
+            fields.emplace_back("prefetch_weights");
         }
         if (params.no_host.size() > 1 || params.no_host != cmd_params_defaults.no_host) {
             fields.emplace_back("no_host");


### PR DESCRIPTION
## Overview

Stacked on #232.

This pipelines CPU-to-GPU transfers of dense FFN weights with prompt processing. Together with `--n-cpu-ffn`, it can use host-resident FFN weights to leave more VRAM for context while keeping attention and other layer tensors on the GPU.

The branch also picks up the mainline `--n-cpu-ffn` option from ggml-org/llama.cpp#26622.

## Additional information

Qwen3.5-27B Q4_K_M was tested with 36 of 64 dense FFNs on the CPU, `pp2048`, flash attention, `-lm none`, and three repetitions:

| GPU | ubatch | Baseline | Prefetch | Change |
| --- | ---: | ---: | ---: | ---: |
| RTX 5090 | 512 | 1511 t/s | 1912 t/s | +26.5% |
| RTX 5090 | 1024 | 2183 t/s | 3092 t/s | +41.6% |
| RTX 5090 | 2048 | 2743 t/s | 3663 t/s | +33.6% |
| RTX 3090 | 512 | 817 t/s | 1077 t/s | +31.8% |
| RTX 3090 | 1024 | 967 t/s | 1109 t/s | +14.7% |
| RTX 3090 | 2048 | 1051 t/s | 1118 t/s | +6.4% |

A separate RTX 5090 memory check used `--n-cpu-ffn 36 -c 65536 -ub 1024 -pw 1`. All 65/65 model layers remained assigned to CUDA, with 9736 MiB of CUDA model buffers, 4096 MiB of KV cache, 751 MiB of CUDA compute buffers, and 15300 MiB observed device usage.

The performance comparison used the equivalent llama-bench tensor override:

```sh
./build/bin/llama-bench \
  -m Qwen3.5-27B-Q4_K_M.gguf \
  -fa 1 -p 2048 -ub 512,1024,2048 -n 0 \
  -lm none \
  -ot 'blk\.([0-9]|[12][0-9]|3[0-5])\.ffn_(up|down|gate)\.=CPU' \
  -pw 0,1 -r 3
```

Validation also included:

```sh
cmake --build build --target llama-bench llama-cli llama-server
ctest --test-dir build -R 'test-(arg-parser|fit-params)' --output-on-failure
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Codex assisted with code adaptation, benchmarking, testing, and preparing this description.
