### PR TITLE
QVAC-24156 fix: make mtmd temporal merge opt-in per bitmap (upstream #27348)

### DIFF
--- a/tools/mtmd/CMakeLists.txt
+++ b/tools/mtmd/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(mtmd
             mtmd-audio.cpp
             mtmd-image.cpp
             mtmd.h
+            mtmd-internal.h
             mtmd-helper.cpp
             mtmd-helper-gen.cpp
             mtmd-helper-common.h

--- a/tools/mtmd/README-dev.md
+++ b/tools/mtmd/README-dev.md
@@ -21,7 +21,7 @@ A typical pipeline of the core libmtmd is as follows:
 - A bitmap (RGB image or PCM audio) is created
 - Bitmap and the text prompt is provided to `mtmd_tokenize()` that breaks the input into chunks
     - The tokenizer function first expands a "lazy" bitmap if it finds one. Typically, this is used by video, so that one media token corresponds to one input bitmap
-    - For models that support "fused" temporal frames like Qwen-VL, the tokenizer tries to merge pair of consecutive frames into one batch
+    - For models that support "fused" temporal frames like Qwen-VL, the tokenizer tries to merge pair of consecutive frames into one batch. Only bitmaps marked by `mtmd_bitmap_set_mergeable()` are merged
     - The preprocessor will then be called, which produces a list of chunks
     - Depending on the model itself, special tokens will be injected to separate image chunks (i.e. llava-uhd-style models)
 - Multiple bitmaps may be batched together to form a larger `mtmd_batch()`

--- a/tools/mtmd/mtmd-helper.cpp
+++ b/tools/mtmd/mtmd-helper.cpp
@@ -755,7 +755,9 @@ struct mtmd_helper_video {
 
         LOG_DBG("%s: frame %d read OK\n", __func__, current_frame);
         current_frame++;
-        return mtmd_bitmap_init(info.width, info.height, frame_buf.data());
+        mtmd_bitmap * frame = mtmd_bitmap_init(info.width, info.height, frame_buf.data());
+        mtmd_bitmap_set_mergeable(frame, true);
+        return frame;
     }
 
     int32_t read_next(mtmd_bitmap ** out_bitmap, char ** out_text) {

--- a/tools/mtmd/mtmd-internal.h
+++ b/tools/mtmd/mtmd-internal.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "mtmd.h"
+
+#include <string>
+#include <vector>
+
+// !!! Internal header, to be used by mtmd and its unit tests only !!!
+
+#define MTMD_INTERNAL_HEADER
+
+// bitmap is null for text parts
+struct mtmd_input_part {
+    std::string text;
+    const mtmd_bitmap * bitmap;
+};
+
+// [QWEN_VIDEO] merged parts are erased from `parts`, so one group always maps to one part
+std::vector<std::vector<const mtmd_bitmap *>> mtmd_group_mergeable_bitmaps(std::vector<mtmd_input_part> & parts, int n_merge);

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -1,6 +1,7 @@
 #include "clip.h"
 #include "clip-impl.h"
 #include "mtmd.h"
+#include "mtmd-internal.h"
 #include "mtmd-audio.h"
 #include "mtmd-image.h"
 #include "debug/mtmd-debug.h"
@@ -36,6 +37,7 @@ struct mtmd_bitmap {
     uint32_t ny = 0;
     std::string id; // optional user-defined id, for ex: can be set to image hash, useful for KV cache tracking
     bool is_audio = false; // true if the bitmap is audio
+    bool mergeable = false; // [QWEN_VIDEO] set only on frames of the same video
 
     // lazy-loaded bitmap
     mtmd_bitmap_lazy_callback lazy_callback = nullptr;
@@ -73,7 +75,9 @@ struct mtmd_bitmap {
 
     bool can_merge_with(const mtmd_bitmap & other) const {
         // [QWEN_VIDEO] can (temporal) merge if both are images with same size
-        return !is_audio && !other.is_audio && nx == other.nx && ny == other.ny;
+        return mergeable && other.mergeable
+            && !is_audio && !other.is_audio
+            && nx == other.nx && ny == other.ny;
     }
 
   private:
@@ -925,6 +929,25 @@ void mtmd_log_set_llama_callback(ggml_log_callback llama_cb, void * llama_user_d
     clip_log_set_callback(llama_cb, llama_user_data);
 }
 
+std::vector<std::vector<const mtmd_bitmap *>> mtmd_group_mergeable_bitmaps(std::vector<mtmd_input_part> & parts, int n_merge) {
+    std::vector<std::vector<const mtmd_bitmap *>> output;
+    for (size_t i = 0; i < parts.size(); i++) {
+        if (parts[i].bitmap == nullptr) {
+            continue; // text part
+        }
+        const bool has_next = n_merge > 1 && i + 1 < parts.size() && parts[i + 1].bitmap != nullptr;
+        if (has_next && parts[i].bitmap->can_merge_with(*parts[i + 1].bitmap)) {
+            LOG_DBG("%s: merging 2 frames at part index %zu and %zu\n", __func__, i, i + 1);
+            output.push_back({parts[i].bitmap, parts[i + 1].bitmap});
+            parts.erase(parts.begin() + i + 1);
+            continue;
+        }
+        LOG_DBG("%s: no merging for part index %zu\n", __func__, i);
+        output.push_back({parts[i].bitmap});
+    }
+    return output;
+}
+
 struct mtmd_tokenizer {
     mtmd_context * ctx;
 
@@ -933,10 +956,7 @@ struct mtmd_tokenizer {
     bool parse_special;
     const llama_vocab * vocab;
 
-    struct part {
-        std::string text;
-        const mtmd_bitmap * bitmap;
-    };
+    using part = mtmd_input_part;
     std::vector<part> parts;
     // these will be freed when mtmd_tokenizer finishes
     std::vector<mtmd::bitmap> bm_from_lazy; // TODO @ngxson : refactor, free bm_from_lazy progressively
@@ -1041,34 +1061,7 @@ struct mtmd_tokenizer {
             GGML_ASSERT(n_merge_frames <= 2 && "we only support merging maximum 2 images for now; open an issue if this model supports merging more");
         }
 
-        // Build merged_bitmaps: each entry is a group of 1 or 2 bitmaps.
-        // For consecutive mergeable bitmap parts, merge them and collapse the second part out of this->parts.
-        std::vector<std::vector<const mtmd_bitmap *>> merged_bitmaps;
-        if (n_merge_frames > 1) {
-            for (size_t i = 0; i < parts.size(); ++i) {
-                if (parts[i].bitmap == nullptr) {
-                    continue;
-                }
-                if (i + 1 < parts.size() && parts[i + 1].bitmap != nullptr) {
-                    const mtmd_bitmap * bm_a = parts[i].bitmap;
-                    const mtmd_bitmap * bm_b = parts[i + 1].bitmap;
-                    if (bm_a->can_merge_with(*bm_b)) {
-                        LOG_DBG("%s: merging 2 frames at part index %zu and %zu\n", __func__, i, i + 1);
-                        merged_bitmaps.push_back({bm_a, bm_b});
-                        parts.erase(parts.begin() + i + 1); // collapse the second bitmap part
-                        continue;
-                    }
-                }
-                LOG_DBG("%s: no merging for part index %zu\n", __func__, i);
-                merged_bitmaps.push_back({parts[i].bitmap});
-            }
-        } else {
-            for (const auto & p : parts) {
-                if (p.bitmap != nullptr) {
-                    merged_bitmaps.push_back({p.bitmap});
-                }
-            }
-        }
+        auto merged_bitmaps = mtmd_group_mergeable_bitmaps(parts, n_merge_frames);
 
         size_t i_bm = 0;
         for (const auto & p : parts) {
@@ -2043,6 +2036,10 @@ void mtmd_bitmap_set_id(mtmd_bitmap * bitmap, const char * id) {
     } else {
         bitmap->id.clear();
     }
+}
+
+void mtmd_bitmap_set_mergeable(mtmd_bitmap * bitmap, bool mergeable) {
+    bitmap->mergeable = mergeable;
 }
 
 mtmd_bitmap * mtmd_bitmap_init_lazy(mtmd_context * ctx,

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -191,7 +191,8 @@ MTMD_API const char * mtmd_get_marker(const mtmd_context * ctx);
 //     length of data must be nx * ny * 3
 //     the data is in RGBRGBRGB... format
 //     note: some video-capable models (i.e. qwen-vl) can merge consecutive bitmaps
-//           into one chunk, mtmd_tokenize() will automatically handle this
+//           into one chunk; mtmd_tokenize() handles this, but remember to set
+//           mtmd_bitmap_set_mergeable(true) for every frame
 // if bitmap is audio:
 //     length of data must be n_samples * sizeof(float)
 //     the data is in float format (PCM F32)
@@ -212,6 +213,8 @@ MTMD_API void                  mtmd_bitmap_free       (mtmd_bitmap * bitmap);
 // these getters/setters are dedicated functions, so you can for example calculate the hash of the image based on mtmd_bitmap_get_data()
 MTMD_API const char * mtmd_bitmap_get_id(const mtmd_bitmap * bitmap);
 MTMD_API void         mtmd_bitmap_set_id(mtmd_bitmap * bitmap, const char * id);
+// if true, this bitmap can be merged (temporal merge) with an adjacent mergeable bitmap by certain video input models
+MTMD_API void         mtmd_bitmap_set_mergeable(mtmd_bitmap * bitmap, bool mergeable);
 
 // mtmd_bitmap lazy
 //


### PR DESCRIPTION
## 🎯 Problem

Two separate still images of equal size are grouped by mtmd as a two-frame video chunk on temporal-merge-capable models (Qwen-VL). `clip_encode` then produces a `[1024, 2028, 2]` embedding into a buffer sized for one frame and aborts the process:

```
tokenize: merging 2 frames at part index 1 and 2
clip_encode: output embedding shape [1024, 2028, 2]
clip_encode: output buffer has 2076672 elements but expected 4153344
tools/mtmd/clip.cpp:5934: Output buffer size mismatch
[exited with code 134]        # SIGABRT
```

`can_merge_with()` merged any two adjacent non-audio bitmaps of equal size, with no way to tell a real video frame from an unrelated image. Any consumer passing two same-size images in one request loses the process, not just the request.

Upstream: [ggml-org/llama.cpp#27313](https://github.com/ggml-org/llama.cpp/issues/27313) (issue), [ggml-org/llama.cpp#27348](https://github.com/ggml-org/llama.cpp/pull/27348) (fix, merged).

## 📝 How

Cherry-pick of upstream `85dfd2a292f3f04c1a9dd77a90c3f57958a69068`.

Temporal merge becomes opt-in per bitmap:

- `mtmd_bitmap` gains `mergeable`, defaulting to **false**, with a new public setter `mtmd_bitmap_set_mergeable()`.
- `can_merge_with()` now additionally requires `mergeable` on both sides.
- `mtmd_helper_video`'s frame reader sets it to true, so real video frames still merge.
- The grouping loop moves out of `mtmd_tokenizer::tokenize()` into `mtmd_group_mergeable_bitmaps()`, declared in the new internal header `tools/mtmd/mtmd-internal.h` (which also hosts the `mtmd_input_part` struct that used to be `mtmd_tokenizer::part`).

Applied directly on top of the current `temp-10297` tip — `03b0b758f`, *configurable MoE cache for hot experts* (#232) — so this branch is a **strict superset of the release line**, and a `v10297.1.2` tag cut here drops nothing.

<sub>An earlier revision of this PR was branched from tag `v10297.1.1` instead, which excluded #232. That would have made a tag cut at this branch a silent regression of `temp-10297`, so it was rebased onto the release tip. The cherry-pick applies identically either way — #232 does not touch `tools/mtmd`, and the resulting `tools/mtmd` tree is byte-identical between the two bases.</sub>

### Deviations from upstream — please review

- **`tests/test-mtmd-impl.cpp` is not applied.** That file does not exist on this line (we have `tests/test-mtmd-preproc-sizing.cpp` instead), so upstream's 70-line unit test for `mtmd_group_mergeable_bitmaps` — the grouping table asserting `"vv" → "2"`, `"ii" → "11"`, `"vw" → "11"`, `"aa" → "11"` and so on — is **missing here**. Worth porting into our own mtmd test file rather than dropping.
- **`mtmd_group_mergeable_bitmaps()` placement is mine.** Upstream's hunk rejected because we carry an extra `mtmd_log_set_llama_callback()` between `mtmd_free()` and `struct mtmd_tokenizer`. The function body is verbatim upstream; only its position differs.

## 🧪 Tested

Built for `arm64-osx` (Metal) and driven through `@qvac/llm-llamacpp` with `Qwen3.5-0.8B-Q8_0` + `mmproj-F16`, using the regression test added in tetherto/qvac#4271.

Clean build of **this branch head (`1f6fe7ef4`)**, no reuse: `buildtrees/qvac-fabric` and `packages/qvac-fabric_arm64-osx` wiped, `VCPKG_BINARY_SOURCES=clear`, so fabric compiled from source — 306 ninja targets, from vcpkg source dir `32a6029fe6-…` (the head SHA's tail). `nm libmtmd.a` confirms `_mtmd_bitmap_set_mergeable` and `__Z28mtmd_group_mergeable_bitmaps…`.

Worth stating because it matters for a cache-restored "green": vcpkg reuses `buildtrees/qvac-fabric/arm64-osx-rel` across refs, so an incremental fabric build finishes in ~40 s and recompiles only the changed mtmd objects. Every build reported here was verified to be a real one via the `Building qvac-fabric` log line and a distinct package ABI hash.

**Before (published `v10297.1.1`):** aborts, exit 134, as quoted above — the run dies during the two-image request, inside `clip_encode` → `mtmd_encode_chunk` → `MtmdLlmContext::evalMessageWithTools`.

**After (this branch):**

```
mtmd_group_mergeable_bitmaps: no merging for part index 1
mtmd_group_mergeable_bitmaps: no merging for part index 2
batch_f32 size = 1                                   (twice)
clip_encode: output embedding shape [1024, 2028, 1]   (twice)
# one image:  promptTokens=2050 tiles=1
# two images: promptTokens=4080 tiles=2
# asserts = 6/6 pass, exit 0
```

Two images now encode as two separate one-frame chunks with a buffer that matches, and prompt tokens scale 2050 → 4080. Identical numbers on both bases tried (with and without #232), which is what you'd expect from a change confined to `tools/mtmd`.

Video path checked by inspection rather than by a video fixture: a video buffer takes the `mtmd_bitmap_init_lazy` branch in `mtmd-helper.cpp`, whose lazy callback goes through `mtmd_helper_video_read_next`, which is exactly the call site this patch marks `mergeable(true)`. So frame merging is preserved where it is intended. **A video-input smoke run on a merge-capable model would be worth having before this ships** — I did not run one.

## ⚠️ Breaking

Public header change, additive: new `mtmd_bitmap_set_mergeable()` in `mtmd.h`. No signature changes, so existing consumers keep compiling.

Behavioural change for anyone who was relying on the old implicit merge: callers that hand mtmd a sequence of same-size frames as plain bitmaps and expect temporal fusion must now call `mtmd_bitmap_set_mergeable(bm, true)` on each. The in-tree video helper is updated; out-of-tree callers doing their own frame decoding are not. Token counts and KV usage change for such callers (two frames stop collapsing into one chunk). The QVAC llm-llamacpp addon is unaffected — it builds bitmaps via `mtmd_helper_bitmap_init_from_buf` and never merged deliberately.

---

Companion PR: tetherto/qvac#4271 adds the regression test, and is red until a `qvac-fabric` bump carrying this change lands.
