### PR TITLE
QVAC-24627 infra: cancel superseded CI runs on push and dispatch

### DIFF
--- a/.github/workflows/build-3rd-party.yml
+++ b/.github/workflows/build-3rd-party.yml
@@ -15,8 +15,10 @@ on:
       '**/*.cpp'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-3rd-party.yml
+++ b/.github/workflows/build-3rd-party.yml
@@ -15,10 +15,13 @@ on:
       '**/*.cpp'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — this workflow only ever runs post-merge,
+# so cancelling a master push would leave the 3rd-party build with no signal at
+# all. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-and-test-snapdragon.yml
+++ b/.github/workflows/build-and-test-snapdragon.yml
@@ -23,8 +23,10 @@ on:
       - 'scripts/snapdragon/**'
       - 'CMakePresets.json'
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-and-test-snapdragon.yml
+++ b/.github/workflows/build-and-test-snapdragon.yml
@@ -23,10 +23,12 @@ on:
       - 'scripts/snapdragon/**'
       - 'CMakePresets.json'
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -20,8 +20,10 @@ on:
       - '.github/workflows/build-android.yml'
       - 'examples/llama.android/**'
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -20,10 +20,12 @@ on:
       - '.github/workflows/build-android.yml'
       - 'examples/llama.android/**'
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -39,10 +39,12 @@ on:
       'scripts/vector-index-package-smoke.sh'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -39,8 +39,10 @@ on:
       'scripts/vector-index-package-smoke.sh'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -5,10 +5,13 @@ on:
   schedule:
     - cron: '0 * * * *'
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — this workflow is cron-only, and an hourly
+# run that outlives its hour must not be killed by the next one, or the cache it
+# exists to populate is never saved. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -5,8 +5,10 @@ on:
   schedule:
     - cron: '0 * * * *'
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-cann.yml
+++ b/.github/workflows/build-cann.yml
@@ -22,10 +22,12 @@ on:
       'ggml/src/ggml-cann/**'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-cann.yml
+++ b/.github/workflows/build-cann.yml
@@ -22,8 +22,10 @@ on:
       'ggml/src/ggml-cann/**'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-cpu.yml
+++ b/.github/workflows/build-cpu.yml
@@ -39,10 +39,12 @@ on:
       '**/*.inc'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-cpu.yml
+++ b/.github/workflows/build-cpu.yml
@@ -39,8 +39,10 @@ on:
       '**/*.inc'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -15,8 +15,10 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -15,10 +15,12 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 

--- a/.github/workflows/build-cuda-ubuntu.yml
+++ b/.github/workflows/build-cuda-ubuntu.yml
@@ -24,8 +24,10 @@ on:
       'ggml/src/ggml-cuda/**'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-cuda-ubuntu.yml
+++ b/.github/workflows/build-cuda-ubuntu.yml
@@ -24,10 +24,12 @@ on:
       'ggml/src/ggml-cuda/**'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-ibm.yml
+++ b/.github/workflows/build-ibm.yml
@@ -22,10 +22,12 @@ on:
       'ggml/src/ggml-cpu/**'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-ibm.yml
+++ b/.github/workflows/build-ibm.yml
@@ -22,8 +22,10 @@ on:
       'ggml/src/ggml-cpu/**'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-msys.yml
+++ b/.github/workflows/build-msys.yml
@@ -8,10 +8,12 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-msys.yml
+++ b/.github/workflows/build-msys.yml
@@ -8,8 +8,10 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-opencl.yml
+++ b/.github/workflows/build-opencl.yml
@@ -23,8 +23,10 @@ on:
       'ggml/src/ggml-opencl/**'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-opencl.yml
+++ b/.github/workflows/build-opencl.yml
@@ -23,10 +23,12 @@ on:
       'ggml/src/ggml-opencl/**'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-openvino.yml
+++ b/.github/workflows/build-openvino.yml
@@ -22,8 +22,10 @@ on:
       'ggml/src/ggml-openvino/**'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-openvino.yml
+++ b/.github/workflows/build-openvino.yml
@@ -22,10 +22,12 @@ on:
       'ggml/src/ggml-openvino/**'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-riscv.yml
+++ b/.github/workflows/build-riscv.yml
@@ -22,8 +22,10 @@ on:
       'ggml/src/ggml-cpu/arch/riscv/**'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-riscv.yml
+++ b/.github/workflows/build-riscv.yml
@@ -22,10 +22,12 @@ on:
       'ggml/src/ggml-cpu/arch/riscv/**'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-rpc.yml
+++ b/.github/workflows/build-rpc.yml
@@ -26,10 +26,12 @@ on:
       'tools/rpc/**'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-rpc.yml
+++ b/.github/workflows/build-rpc.yml
@@ -26,8 +26,10 @@ on:
       'tools/rpc/**'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -29,8 +29,10 @@ on:
       '**/*.inc'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -29,10 +29,12 @@ on:
       '**/*.inc'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -43,10 +43,12 @@ on:
       '**/*.wgsl'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -43,8 +43,10 @@ on:
       '**/*.wgsl'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/build-sycl.yml
+++ b/.github/workflows/build-sycl.yml
@@ -22,8 +22,10 @@ on:
       'ggml/src/ggml-sycl/**'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-sycl.yml
+++ b/.github/workflows/build-sycl.yml
@@ -22,10 +22,12 @@ on:
       'ggml/src/ggml-sycl/**'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-virtgpu.yml
+++ b/.github/workflows/build-virtgpu.yml
@@ -22,8 +22,10 @@ on:
       'ggml/src/ggml-virtgpu/**'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-virtgpu.yml
+++ b/.github/workflows/build-virtgpu.yml
@@ -22,10 +22,12 @@ on:
       'ggml/src/ggml-virtgpu/**'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-vulkan.yml
+++ b/.github/workflows/build-vulkan.yml
@@ -24,10 +24,12 @@ on:
       'ggml/src/ggml-vulkan/**'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-vulkan.yml
+++ b/.github/workflows/build-vulkan.yml
@@ -24,8 +24,10 @@ on:
       'ggml/src/ggml-vulkan/**'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -36,10 +36,12 @@ on:
 permissions:
   contents: read
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -36,8 +36,10 @@ on:
 permissions:
   contents: read
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-webgpu.yml
+++ b/.github/workflows/build-webgpu.yml
@@ -25,10 +25,12 @@ on:
       'ggml/src/ggml-webgpu/**'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-webgpu.yml
+++ b/.github/workflows/build-webgpu.yml
@@ -25,8 +25,10 @@ on:
       'ggml/src/ggml-webgpu/**'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/check-vendor.yml
+++ b/.github/workflows/check-vendor.yml
@@ -17,6 +17,12 @@ on:
       'scripts/sync_vendor.py'
     ]
 
+# QVAC addition: one run per PR/branch; a newer push or dispatch supersedes the
+# in-flight run. See QVAC-24627.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   runner_names:
     permissions:

--- a/.github/workflows/check-vendor.yml
+++ b/.github/workflows/check-vendor.yml
@@ -17,10 +17,11 @@ on:
       'scripts/sync_vendor.py'
     ]
 
-# QVAC addition: one run per PR/branch; a newer push or dispatch supersedes the
-# in-flight run. See QVAC-24627.
+# QVAC addition: dedupe per PR and per branch, so a re-push or re-dispatch
+# supersedes the in-flight run. The default branch is exempt on purpose —
+# master pushes must not cancel each other. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -9,10 +9,12 @@ on:
     branches:
       - master
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -9,8 +9,10 @@ on:
     branches:
       - master
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -9,10 +9,12 @@ on:
     branches:
       - master
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -9,8 +9,10 @@ on:
     branches:
       - master
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/hip-quality-check.yml
+++ b/.github/workflows/hip-quality-check.yml
@@ -25,8 +25,10 @@ on:
       'scripts/hip/gcn-cdna-vgpr-check.py'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/hip-quality-check.yml
+++ b/.github/workflows/hip-quality-check.yml
@@ -25,10 +25,12 @@ on:
       'scripts/hip/gcn-cdna-vgpr-check.py'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/pre-tokenizer-hashes.yml
+++ b/.github/workflows/pre-tokenizer-hashes.yml
@@ -10,10 +10,12 @@ on:
             - 'conversion/base.py'
             - 'convert_hf_to_gguf_update.py'
 
-# QVAC addition: one run per PR/branch; a newer push or dispatch supersedes the
-# in-flight run. See QVAC-24627.
+# QVAC addition: dedupe per PR and per branch, so a newer push supersedes the
+# in-flight run (this workflow has no workflow_dispatch trigger). The default
+# branch is exempt on purpose — master pushes must not cancel each other.
+# See QVAC-24627.
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pre-tokenizer-hashes.yml
+++ b/.github/workflows/pre-tokenizer-hashes.yml
@@ -10,6 +10,12 @@ on:
             - 'conversion/base.py'
             - 'convert_hf_to_gguf_update.py'
 
+# QVAC addition: one run per PR/branch; a newer push or dispatch supersedes the
+# in-flight run. See QVAC-24627.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     pre-tokenizer-hashes:
         runs-on: [self-hosted, fast]

--- a/.github/workflows/python-check-requirements.yml
+++ b/.github/workflows/python-check-requirements.yml
@@ -14,10 +14,12 @@ on:
       - 'convert*.py'
       - '**/requirements*.txt'
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/python-check-requirements.yml
+++ b/.github/workflows/python-check-requirements.yml
@@ -14,8 +14,10 @@ on:
       - 'convert*.py'
       - '**/requirements*.txt'
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -15,10 +15,12 @@ on:
       '**/*.py'
     ]
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -15,8 +15,10 @@ on:
       '**/*.py'
     ]
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/python-type-check.yml
+++ b/.github/workflows/python-type-check.yml
@@ -16,10 +16,12 @@ on:
       - '**/requirements*.txt'
       # - 'pyrightconfig.json'
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# or a merged commit can end with no CI verdict. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/python-type-check.yml
+++ b/.github/workflows/python-type-check.yml
@@ -16,8 +16,10 @@ on:
       - '**/requirements*.txt'
       # - 'pyrightconfig.json'
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/server-sanitize.yml
+++ b/.github/workflows/server-sanitize.yml
@@ -31,10 +31,13 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — this workflow's dispatch takes a `sha`
+# input, and bisecting a sanitizer regression means dispatching several commits
+# from master at once; those must not cancel each other. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/server-sanitize.yml
+++ b/.github/workflows/server-sanitize.yml
@@ -31,8 +31,10 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/server-sanitize.yml
+++ b/.github/workflows/server-sanitize.yml
@@ -33,19 +33,23 @@ env:
 
 # QVAC divergence from upstream. Reachable outcomes:
 #
-#   workflow_dispatch with `sha` -> per sha  (re-dispatching the SAME commit
-#                                   supersedes; two bisection commits coexist)
-#   push to master               -> per run  (run_id; never cancels)
-#   dispatch on another ref, no sha -> per ref (supersedes)
+#   dispatch with `sha`             -> per (sha, slow_tests) (an identical
+#                                      re-dispatch supersedes; a different
+#                                      commit OR a different slow_tests
+#                                      coexists)
+#   push to master                  -> per run  (run_id; never cancels)
+#   dispatch on another ref, no sha -> per ref   (supersedes)
 #
 # This workflow declares no `pull_request` trigger, so the first arm is inert
 # here; it is kept so this block matches the other lanes.
 #
-# The `sha` arm is load-bearing: bisecting a sanitizer regression means
-# dispatching several commits, and without it two dispatches from the same
-# non-master ref share a group and cancel each other. See QVAC-24627.
+# The dispatch arm keys on every input that changes what the run DOES.
+# Bisecting a sanitizer regression means dispatching several commits, so
+# without `sha` those would cancel each other; and without `slow_tests`, a
+# quick re-dispatch of the same commit would kill an in-flight slow-test run.
+# See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.sha || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.event.inputs.sha && format('{0}-slow{1}', github.event.inputs.sha, github.event.inputs.slow_tests)) || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/server-sanitize.yml
+++ b/.github/workflows/server-sanitize.yml
@@ -31,13 +31,21 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
-# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
-# re-dispatch supersedes the in-flight run. The default branch deliberately
-# keeps upstream's run_id behaviour — this workflow's dispatch takes a `sha`
-# input, and bisecting a sanitizer regression means dispatching several commits
-# from master at once; those must not cancel each other. See QVAC-24627.
+# QVAC divergence from upstream. Reachable outcomes:
+#
+#   workflow_dispatch with `sha` -> per sha  (re-dispatching the SAME commit
+#                                   supersedes; two bisection commits coexist)
+#   push to master               -> per run  (run_id; never cancels)
+#   dispatch on another ref, no sha -> per ref (supersedes)
+#
+# This workflow declares no `pull_request` trigger, so the first arm is inert
+# here; it is kept so this block matches the other lanes.
+#
+# The `sha` arm is load-bearing: bisecting a sanitizer regression means
+# dispatching several commits, and without it two dispatches from the same
+# non-master ref share a group and cancel each other. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.sha || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/server-self-hosted.yml
+++ b/.github/workflows/server-self-hosted.yml
@@ -36,10 +36,15 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour. Two reasons here: the dispatch takes a
+# `sha` input for bisecting, and these jobs run pytest against llama-server
+# subprocesses on persistent self-hosted runners with no `if: always()`
+# teardown — a cancel mid-pytest can orphan a server holding its port and GPU
+# memory and break the next run on that runner. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/server-self-hosted.yml
+++ b/.github/workflows/server-self-hosted.yml
@@ -36,8 +36,10 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/server-self-hosted.yml
+++ b/.github/workflows/server-self-hosted.yml
@@ -36,15 +36,24 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
-# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
-# re-dispatch supersedes the in-flight run. The default branch deliberately
-# keeps upstream's run_id behaviour. Two reasons here: the dispatch takes a
-# `sha` input for bisecting, and these jobs run pytest against llama-server
+# QVAC divergence from upstream. Reachable outcomes:
+#
+#   workflow_dispatch with `sha` -> per sha  (re-dispatching the SAME commit
+#                                   supersedes; two bisection commits coexist)
+#   push to master               -> per run  (run_id; never cancels)
+#   dispatch on another ref, no sha -> per ref (supersedes)
+#
+# This workflow declares no `pull_request` trigger, so the first arm is inert
+# here; it is kept so this block matches the other lanes.
+#
+# The `sha` arm is load-bearing: without it, two dispatches of different
+# commits from the same non-master ref share a group and cancel each other.
+# That matters most here, because these jobs run pytest against llama-server
 # subprocesses on persistent self-hosted runners with no `if: always()`
 # teardown — a cancel mid-pytest can orphan a server holding its port and GPU
-# memory and break the next run on that runner. See QVAC-24627.
+# memory. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.sha || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -49,8 +49,10 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -49,10 +49,13 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# and this workflow's dispatch takes a `sha` input, so two builds of different
+# commits from master must not cancel each other either. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -49,13 +49,19 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
-# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
-# re-dispatch supersedes the in-flight run. The default branch deliberately
-# keeps upstream's run_id behaviour — master pushes must not cancel each other,
-# and this workflow's dispatch takes a `sha` input, so two builds of different
-# commits from master must not cancel each other either. See QVAC-24627.
+# QVAC divergence from upstream. Reachable outcomes:
+#
+#   pull_request                 -> per PR   (supersedes)
+#   workflow_dispatch with `sha` -> per sha  (re-dispatching the SAME commit
+#                                   supersedes; two commits coexist)
+#   push to master               -> per run  (run_id; never cancels)
+#   dispatch on another ref, no sha -> per ref (supersedes)
+#
+# The `sha` arm is load-bearing: without it, two dispatches of different
+# commits from the same non-master ref share a group and cancel each other.
+# See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.sha || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -51,17 +51,22 @@ env:
 
 # QVAC divergence from upstream. Reachable outcomes:
 #
-#   pull_request                 -> per PR   (supersedes)
-#   workflow_dispatch with `sha` -> per sha  (re-dispatching the SAME commit
-#                                   supersedes; two commits coexist)
-#   push to master               -> per run  (run_id; never cancels)
-#   dispatch on another ref, no sha -> per ref (supersedes)
+#   pull_request                    -> per PR              (supersedes)
+#   dispatch with `sha`             -> per (sha, slow_tests) (an identical
+#                                      re-dispatch supersedes; a different
+#                                      commit OR a different slow_tests
+#                                      coexists)
+#   push to master                  -> per run  (run_id; never cancels)
+#   dispatch on another ref, no sha -> per ref   (supersedes)
 #
-# The `sha` arm is load-bearing: without it, two dispatches of different
-# commits from the same non-master ref share a group and cancel each other.
+# The dispatch arm keys on every input that changes what the run DOES. Without
+# `sha`, two dispatches of different commits from the same non-master ref would
+# cancel each other. Without `slow_tests`, a quick re-dispatch of the same
+# commit would kill an in-flight slow-test run — the steps it gates (5th/7th of
+# `ubuntu`, 5th of `windows`) are exactly the long ones.
 # See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.sha || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.event.inputs.sha && format('{0}-slow{1}', github.event.inputs.sha, github.event.inputs.slow_tests)) || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ui-self-hosted.yml
+++ b/.github/workflows/ui-self-hosted.yml
@@ -35,8 +35,10 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ui-self-hosted.yml
+++ b/.github/workflows/ui-self-hosted.yml
@@ -35,10 +35,13 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# and this workflow's dispatch takes a `sha` input, so two builds of different
+# commits from master must not cancel each other either. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ui-self-hosted.yml
+++ b/.github/workflows/ui-self-hosted.yml
@@ -35,13 +35,19 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
-# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
-# re-dispatch supersedes the in-flight run. The default branch deliberately
-# keeps upstream's run_id behaviour — master pushes must not cancel each other,
-# and this workflow's dispatch takes a `sha` input, so two builds of different
-# commits from master must not cancel each other either. See QVAC-24627.
+# QVAC divergence from upstream. Reachable outcomes:
+#
+#   pull_request                 -> per PR   (supersedes)
+#   workflow_dispatch with `sha` -> per sha  (re-dispatching the SAME commit
+#                                   supersedes; two commits coexist)
+#   push to master               -> per run  (run_id; never cancels)
+#   dispatch on another ref, no sha -> per ref (supersedes)
+#
+# The `sha` arm is load-bearing: without it, two dispatches of different
+# commits from the same non-master ref share a group and cancel each other.
+# See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.sha || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -31,8 +31,10 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
+# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
+# dispatches supersede each other too. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -31,10 +31,13 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
-# QVAC divergence from upstream: group per PR/branch, not run_id, so pushes and
-# dispatches supersede each other too. See QVAC-24627.
+# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
+# re-dispatch supersedes the in-flight run. The default branch deliberately
+# keeps upstream's run_id behaviour — master pushes must not cancel each other,
+# and this workflow's dispatch takes a `sha` input, so two builds of different
+# commits from master must not cancel each other either. See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -31,13 +31,19 @@ env:
   LLAMA_ARG_LOG_TIMESTAMPS: 1
   LLAMA_ARG_LOG_VERBOSITY: 10
 
-# QVAC divergence from upstream: dedupe per PR and per branch, so a re-push or
-# re-dispatch supersedes the in-flight run. The default branch deliberately
-# keeps upstream's run_id behaviour — master pushes must not cancel each other,
-# and this workflow's dispatch takes a `sha` input, so two builds of different
-# commits from master must not cancel each other either. See QVAC-24627.
+# QVAC divergence from upstream. Reachable outcomes:
+#
+#   pull_request                 -> per PR   (supersedes)
+#   workflow_dispatch with `sha` -> per sha  (re-dispatching the SAME commit
+#                                   supersedes; two commits coexist)
+#   push to master               -> per run  (run_id; never cancels)
+#   dispatch on another ref, no sha -> per ref (supersedes)
+#
+# The `sha` arm is load-bearing: without it, two dispatches of different
+# commits from the same non-master ref share a group and cancel each other.
+# See QVAC-24627.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.sha || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

Every CI workflow baked `github.run_id` into the push/dispatch path of its concurrency group:

```yaml
# 28 files
group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
# 5 files (server*.yml, ui*.yml)
group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.run_id }}
```

`head_ref` is only set on `pull_request`. So on a push or a `workflow_dispatch` the group was unique per run, no two runs shared a group, and `cancel-in-progress: true` had nothing to act on.

## Fix

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
  cancel-in-progress: true
```

The five workflows that accept a `sha` dispatch input — `server.yml`, `server-sanitize.yml`, `server-self-hosted.yml`, `ui.yml`, `ui-self-hosted.yml` — key on that sha first:

```yaml
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.sha || (github.ref == 'refs/heads/master' && github.run_id) || github.ref }}
```

| event | group | behaviour |
|---|---|---|
| `pull_request` | PR number | supersedes |
| dispatch with `sha` (those 5) | the sha | same commit supersedes, different commits coexist |
| push / dispatch on `master` | `github.run_id` | never cancels |
| dispatch elsewhere, no `sha` | `github.ref` | supersedes |

33 workflows change group; `check-vendor.yml` and `pre-tokenizer-hashes.yml` had no block and gain one. **35 files.**

## Why the two exemptions exist

**`master`** — back-to-back merges would otherwise leave the earlier commit with no CI verdict (upstream's reason for the `run_id` fallback), `build-cache.yml`'s hourly cron would kill its own previous run before `actions/cache` saves, and `server-self-hosted.yml` runs `pytest` against `llama-server` subprocesses on persistent self-hosted runners with **no `if: always()` teardown** — a cancel mid-test can orphan a server holding its port and GPU memory.

**`sha`** — added in review. Keying only on `master` left the bisection hazard live on every non-master dispatch: `server-self-hosted.yml` and `server-sanitize.yml` declare no `pull_request` trigger and limit `push` to `master`, which makes a non-master dispatch the *only* cancellation path they have. Two dispatches of different commits from the same ref shared a group and cancelled each other, because the `sha` that distinguishes them was not in the key. `sha` is optional, so an omitted value is an empty string and falls through; `github.event.inputs` is null on push and PR events.

## Proof

Both halves of the `sha` behaviour, verified live on this branch with `ui.yml`:

**Same commit supersedes**

| run | `sha` input | result |
|---|---|---|
| [34119849862](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/34119849862) | `84b2241` | **cancelled** by the next dispatch |
| [34119863121](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/34119863121) | `84b2241` | took over |

**Different commits coexist** — all three in flight simultaneously, none cancelling another:

| run | `sha` input |
|---|---|
| [34119863121](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/34119863121) | `84b2241` |
| [34119876772](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/34119876772) | `85431b6` |
| [34119888985](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/34119888985) | `452504c` |

Before the `sha` arm all four would have shared `UI-refs/heads/QVAC-24627/ci-concurrency` and only the last would have survived.

The plain per-ref path is proven separately with two `check-vendor` dispatches: [33903716084](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/33903716084) **cancelled** by [33903738670](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/33903738670).

Static: all 53 workflow files parse, `validate-runner-names.mjs` ok (5 targets, 9 workflows), `docker.yml` the only remaining plain-`run_id` group.

The `master` arm cannot be exercised pre-merge — a dispatch on `master` runs master's copy of the file, not this branch's.

## Not changed

`docker.yml` (publishes to a registry), `release.yml` + `build-cuda-windows.yml` (already `group: release` / `queue: max`), `check-approvals.yml` (`cancel-in-progress: false`), `security-baseline.yml` (already correct), `bench.yml.disabled` (inert).

`reusable-runner-names.yml`, `ui-build.yml`, `ui-build-self-hosted.yml`, `build-cmake-pkg.yml` get **no** block — they are `workflow_call` and inherit the caller's group; their own would serialize every caller.

## Red checks — neither is from this change

**`ubuntu-24-virtgpu`** also fails on master — runs [33864872732](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/33864872732), [33159324392](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/33159324392).

**`macos` in `CI (webgpu)`** fails on `42 - test-backend-ops (Timeout)`. The identical signature is on an unrelated PR branch, `freetoken-moe-cache-dense-prefill`, in [job 101618466600](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/34081842359/job/101618466600). It is duration-sensitive and passes on other branches, so it is an intermittent timeout on this repo's hosted macOS runner. This PR's diff cannot affect how long a ctest takes.

**Cancelled checks** (`ctest (ADDRESS/UNDEFINED/THREAD)`, `ubuntu-24-s390x`, `ubuntu-24-ppc64le`, `riscv`, `openvino`) were created `17:57:01Z` and cancelled `17:57:03Z` — exactly 24 hours later, i.e. GitHub's queue timeout for runs that never get a runner. Same lanes, same way, on other branches (`qvac-b10549`, 09-04 and 09-06).

QVAC-24627. Siblings: qvac-fabric-speech.cpp#219, qvac-ext-ggml#83, qvac-ext-stable-diffusion.cpp#38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
