### PR TITLE
common: auto-configure fitted weight acceleration

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -33,6 +33,7 @@
 #include <cstdarg>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <list>
 #include <regex>
 #include <set>
@@ -2843,13 +2844,22 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_CPU_MOE"));
     add_opt(common_arg(
-        {"--moe-cache-mib"}, "N",
-        "persistent GPU MoE expert cache size in MiB (default: 0, disabled)",
-        [](common_params & params, int value) {
-            if (value < 0) {
+        {"--moe-cache-mib"}, "N|auto",
+        "persistent GPU MoE expert cache size in MiB (default: auto with --fit)",
+        [](common_params & params, const std::string & value) {
+            if (value == "auto") {
+                params.moe_cache_auto = true;
+                params.moe_cache_size = 0;
+                return;
+            }
+            size_t pos = 0;
+            const long long size_mib = std::stoll(value, &pos);
+            if (size_mib < 0 || pos != value.size() ||
+                static_cast<unsigned long long>(size_mib) > std::numeric_limits<size_t>::max() / (1024ULL * 1024ULL)) {
                 throw std::invalid_argument("invalid value");
             }
-            params.moe_cache_size = size_t(value) * 1024 * 1024;
+            params.moe_cache_auto = false;
+            params.moe_cache_size = size_t(size_mib) * 1024 * 1024;
         }
     ).set_env("LLAMA_ARG_MOE_CACHE_MIB"));
     add_opt(common_arg(
@@ -3041,10 +3051,18 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ));
     add_opt(common_arg(
-        {"-pw", "--prefetch-weights"}, "0|1",
-        string_format("prefetch weight transfers to overlap CPU->GPU copies with compute (default: %d)", (int) params.prefetch_weights),
-        [](common_params & params, int value) {
-            params.prefetch_weights = value != 0;
+        {"-pw", "--prefetch-weights"}, "0|1|auto",
+        "prefetch weight transfers to overlap CPU->GPU copies with compute (default: auto for fitted dense models)",
+        [](common_params & params, const std::string & value) {
+            if (value == "auto") {
+                params.prefetch_weights_auto = true;
+                params.prefetch_weights = false;
+            } else if (value == "0" || value == "1") {
+                params.prefetch_weights_auto = false;
+                params.prefetch_weights = value == "1";
+            } else {
+                throw std::invalid_argument("invalid value");
+            }
         }
     ));
     add_opt(common_arg(

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1302,6 +1302,7 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
             params.tensor_buft_overrides.data(),
             params.fit_params_target.data(),
             params.fit_params_min_ctx,
+            params.prefetch_weights_auto,
             params.verbosity >= LOG_LEVEL_DEBUG ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
     }
 
@@ -1824,6 +1825,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.type_k         = params.cache_type_k;
     cparams.type_v         = params.cache_type_v;
     cparams.moe_cache_size = params.moe_cache_size;
+    cparams.moe_cache_auto = params.fit_params && params.moe_cache_auto;
 
     return cparams;
 }
@@ -2433,4 +2435,3 @@ void common_prompt_checkpoint::clear_dft() {
     data_dft.clear();
     data_spec.clear();
 }
-

--- a/common/common.h
+++ b/common/common.h
@@ -580,7 +580,8 @@ struct common_params {
     bool check_tensors     = false; // validate tensor data
     bool no_op_offload     = false; // globally disable offload host tensor operations to device
     bool training          = false; // enable training mode (affects LoRA K/V gradient flow)
-    bool prefetch_weights  = false; // prefetch weight transfers to overlap CPU->GPU copies with compute
+    bool prefetch_weights      = false; // prefetch weight transfers to overlap CPU->GPU copies with compute
+    bool prefetch_weights_auto = true;  // enable weight prefetch when fitting a dense model
     bool no_extra_bufts    = false; // disable extra buffer types (used for weight repacking)
     bool no_host           = false; // bypass host buffer allowing extra buffers to be used
 
@@ -588,7 +589,8 @@ struct common_params {
 
     ggml_type cache_type_k   = GGML_TYPE_F16; // KV cache data type for the K
     ggml_type cache_type_v   = GGML_TYPE_F16; // KV cache data type for the V
-    size_t    moe_cache_size = 0;             // persistent GPU MoE cache size in bytes
+    size_t moe_cache_size = 0; // persistent GPU MoE cache size in bytes
+    bool   moe_cache_auto = true;
 
     common_conversation_mode conversation_mode = COMMON_CONVERSATION_MODE_AUTO;
 

--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -247,7 +247,13 @@ static bool ggml_dev_shares_host_memory(ggml_backend_dev_t dev) {
 bool common_fit_auto_moe_cache(
         const llama_model_params & mparams, const llama_context_params & cparams,
         uint32_t n_expert, size_t n_devices, bool shares_host, bool cache_supported) {
-    (void) mparams;
+    // Cache sizing requires the placement probes in step 3. Explicit placement
+    // is rejected there, so it must not defer the ordinary context reduction.
+    if (mparams.n_gpu_layers != llama_model_default_params().n_gpu_layers ||
+        (mparams.tensor_buft_overrides &&
+         (mparams.tensor_buft_overrides->pattern || mparams.tensor_buft_overrides->buft))) {
+        return false;
+    }
     return cparams.moe_cache_auto && cparams.moe_cache_size == 0 && n_expert > 0 &&
         n_devices == 1 && !shares_host && cache_supported && cparams.op_offload && !cparams.training;
 }

--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -244,6 +244,21 @@ static bool ggml_dev_shares_host_memory(ggml_backend_dev_t dev) {
     return props.memory_unified;
 }
 
+bool common_fit_auto_moe_cache(
+        const llama_model_params & mparams, const llama_context_params & cparams,
+        uint32_t n_expert, size_t n_devices, bool shares_host, bool cache_supported) {
+    (void) mparams;
+    return cparams.moe_cache_auto && cparams.moe_cache_size == 0 && n_expert > 0 &&
+        n_devices == 1 && !shares_host && cache_supported && cparams.op_offload && !cparams.training;
+}
+
+bool common_fit_auto_prefetch_weights(
+        const llama_context_params & cparams, bool automatic,
+        uint32_t n_expert, size_t n_devices, bool shares_host, bool copy_stream) {
+    return automatic && !cparams.prefetch_weights && n_expert == 0 && n_devices == 1 &&
+        !shares_host && copy_stream && cparams.op_offload && !cparams.training;
+}
+
 static void common_params_fit_impl(
         const char * path_model, struct llama_model_params * mparams, struct llama_context_params * cparams,
         float * tensor_split, struct llama_model_tensor_buft_override * tensor_buft_overrides,
@@ -287,17 +302,19 @@ static void common_params_fit_impl(
         supports_copy_stream[id] = props.caps.copy_stream;
     }
 
-    bool auto_moe_cache = cparams->moe_cache_auto && cparams->moe_cache_size == 0 && hp_nex > 0 && nd == 1 && !shares_host[0] && cparams->op_offload && !cparams->training;
-    if (auto_moe_cache) {
+    bool cache_supported = true;
+    if (nd == 1) {
         const ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(devs[0]);
-        auto_moe_cache = reg == nullptr || std::string(ggml_backend_reg_name(reg)) != "OpenCL";
+        cache_supported = reg == nullptr || std::string(ggml_backend_reg_name(reg)) != "OpenCL";
     }
+    const bool auto_moe_cache = common_fit_auto_moe_cache(
+        *mparams, *cparams, hp_nex, nd, nd == 1 && shares_host[0], cache_supported);
     if (cparams->moe_cache_auto && cparams->moe_cache_size == 0 && hp_nex > 0 && !auto_moe_cache) {
         LOG_TRC("%s: automatic MoE cache is not supported by this configuration\n", __func__);
     }
 
-    const bool auto_prefetch = prefetch_weights_auto && !cparams->prefetch_weights && hp_nex == 0 && nd == 1 &&
-        !shares_host[0] && supports_copy_stream[0] && cparams->op_offload && !cparams->training;
+    const bool auto_prefetch = common_fit_auto_prefetch_weights(
+        *cparams, prefetch_weights_auto, hp_nex, nd, nd == 1 && shares_host[0], nd == 1 && supports_copy_stream[0]);
 
     std::vector<std::string> dev_names;
     {

--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -247,7 +247,7 @@ static bool ggml_dev_shares_host_memory(ggml_backend_dev_t dev) {
 static void common_params_fit_impl(
         const char * path_model, struct llama_model_params * mparams, struct llama_context_params * cparams,
         float * tensor_split, struct llama_model_tensor_buft_override * tensor_buft_overrides,
-        size_t * margins_s, uint32_t n_ctx_min, enum ggml_log_level log_level) {
+        size_t * margins_s, uint32_t n_ctx_min, bool prefetch_weights_auto, enum ggml_log_level log_level) {
     if (mparams->split_mode == LLAMA_SPLIT_MODE_TENSOR) {
         throw common_params_fit_exception("llama_params_fit is not implemented for SPLIT_MODE_TENSOR, abort");
     }
@@ -279,9 +279,25 @@ static void common_params_fit_impl(
     // Single registry touchpoint: the decision arithmetic below is pure over
     // these flags (and unit-testable without live devices, see fit.h).
     std::vector<bool> shares_host(nd);
+    std::vector<bool> supports_copy_stream(nd);
     for (size_t id = 0; id < nd; id++) {
         shares_host[id] = ggml_dev_shares_host_memory(devs[id]);
+        ggml_backend_dev_props props;
+        ggml_backend_dev_get_props(devs[id], &props);
+        supports_copy_stream[id] = props.caps.copy_stream;
     }
+
+    bool auto_moe_cache = cparams->moe_cache_auto && cparams->moe_cache_size == 0 && hp_nex > 0 && nd == 1 && !shares_host[0] && cparams->op_offload && !cparams->training;
+    if (auto_moe_cache) {
+        const ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(devs[0]);
+        auto_moe_cache = reg == nullptr || std::string(ggml_backend_reg_name(reg)) != "OpenCL";
+    }
+    if (cparams->moe_cache_auto && cparams->moe_cache_size == 0 && hp_nex > 0 && !auto_moe_cache) {
+        LOG_TRC("%s: automatic MoE cache is not supported by this configuration\n", __func__);
+    }
+
+    const bool auto_prefetch = prefetch_weights_auto && !cparams->prefetch_weights && hp_nex == 0 && nd == 1 &&
+        !shares_host[0] && supports_copy_stream[0] && cparams->op_offload && !cparams->training;
 
     std::vector<std::string> dev_names;
     {
@@ -414,6 +430,18 @@ static void common_params_fit_impl(
         }
     }
 
+    if (auto_prefetch) {
+        cparams->prefetch_weights = true;
+        common_params_fit_impl(
+            path_model, mparams, cparams, tensor_split, tensor_buft_overrides, margins_s, n_ctx_min, false, log_level);
+        if (mparams->n_gpu_layers == default_mparams.n_gpu_layers) {
+            cparams->prefetch_weights = false;
+        } else {
+            LOG_INF("%s: automatic weight prefetch enabled for fitted host weights\n", __func__);
+        }
+        return;
+    }
+
     // step 2: try reducing memory use by reducing the context size
 
     {
@@ -428,7 +456,7 @@ static void common_params_fit_impl(
             // rows individually have surplus.
             global_surplus -= host_shared_deficit;
         }
-        if (global_surplus < 0) {
+        if (global_surplus < 0 && !auto_moe_cache) {
             if (nd <= 1) {
                 LOG_TRC("%s: cannot meet free memory target of %" PRId64 " MiB, need to reduce device memory by %" PRId64 " MiB\n",
                     __func__, margins[0]/MiB, -global_surplus/MiB);
@@ -678,6 +706,7 @@ static void common_params_fit_impl(
     };
 
     int64_t global_surplus_cpu_moe = 0;
+    size_t auto_moe_cache_size = 0;
     if (hp_nex > 0) {
         const static std::string pattern_moe_all = "blk\\.\\d+\\.ffn_(up|down|gate_up|gate)_(ch|)exps"; // matches all MoE tensors
         ggml_backend_buffer_type_t cpu_buft = ggml_backend_cpu_buffer_type();
@@ -688,6 +717,16 @@ static void common_params_fit_impl(
         LOG_TRC("%s: getting device memory data with all MoE tensors moved to system memory:\n", __func__);
         const dmds_t dmds_cpu_moe = common_get_device_memory_data_impl(
             path_model, mparams, cparams, devs, hp_ngl, hp_nct, hp_nex, log_level);
+
+        if (auto_moe_cache) {
+            constexpr int64_t cache_percent = 10;
+            const int64_t expert_memory = dmds_full[0].mb.model - dmds_cpu_moe[0].mb.model;
+            if (expert_memory > 0) {
+                auto_moe_cache_size = size_t(expert_memory * cache_percent / 100);
+                LOG_INF("%s: automatic MoE cache = %.2f MiB (%" PRId64 "%% of %.2f MiB expert weights)\n",
+                    __func__, auto_moe_cache_size / double(MiB), cache_percent, expert_memory / double(MiB));
+            }
+        }
 
         for (size_t id = 0; id < nd; id++) {
             global_surplus_cpu_moe += dmds_cpu_moe[id].free;
@@ -705,6 +744,13 @@ static void common_params_fit_impl(
         // reset
         tensor_buft_overrides[0] = {nullptr, nullptr};
         mparams->tensor_buft_overrides = tensor_buft_overrides;
+    }
+
+    if (auto_moe_cache_size > 0) {
+        cparams->moe_cache_size = auto_moe_cache_size;
+        common_params_fit_impl(
+            path_model, mparams, cparams, tensor_split, tensor_buft_overrides, margins_s, n_ctx_min, prefetch_weights_auto, log_level);
+        return;
     }
 
     std::vector<int64_t> targets; // maximum acceptable memory use per device
@@ -968,6 +1014,7 @@ enum common_params_fit_status common_fit_params(
         llama_model_tensor_buft_override * tensor_buft_overrides,
         size_t * margins,
         uint32_t n_ctx_min,
+        bool prefetch_weights_auto,
         ggml_log_level log_level) {
     const int64_t t0_us = llama_time_us();
     common_params_fit_status status = COMMON_PARAMS_FIT_STATUS_SUCCESS;
@@ -978,7 +1025,8 @@ enum common_params_fit_status common_fit_params(
     const llama_model_params   mparams_original = *mparams;
     const llama_context_params cparams_original = *cparams;
     try {
-        common_params_fit_impl(path_model, mparams, cparams, tensor_split, tensor_buft_overrides, margins, n_ctx_min, log_level);
+        common_params_fit_impl(
+            path_model, mparams, cparams, tensor_split, tensor_buft_overrides, margins, n_ctx_min, prefetch_weights_auto, log_level);
         LOG_TRC("%s: successfully fit params to free device memory\n", __func__);
     } catch (const common_params_fit_exception & e) {
         LOG_WRN("%s: failed to fit params to free device memory: %s\n", __func__, e.what());

--- a/common/fit.h
+++ b/common/fit.h
@@ -24,6 +24,7 @@ common_params_fit_status common_fit_params(
    llama_model_tensor_buft_override * tensor_buft_overrides, // writable buffer for overrides, needs at least llama_max_tensor_buft_overrides elements
                              size_t * margins,               // margins of memory to leave per device in bytes
                            uint32_t   n_ctx_min,             // minimum context size to set when trying to reduce memory use
+                               bool   prefetch_weights_auto, // enable prefetch when fitting a dense model
                      ggml_log_level   log_level);            // minimum log level to print during fitting, lower levels go to debug log
 
 // Pure decision arithmetic, exposed for tests (tests/test-fit-params.cpp).

--- a/common/fit.h
+++ b/common/fit.h
@@ -27,6 +27,15 @@ common_params_fit_status common_fit_params(
                                bool   prefetch_weights_auto, // enable prefetch when fitting a dense model
                      ggml_log_level   log_level);            // minimum log level to print during fitting, lower levels go to debug log
 
+// Automatic acceleration policies, exposed for hardware-independent tests.
+bool common_fit_auto_moe_cache(
+        const llama_model_params & mparams, const llama_context_params & cparams,
+        uint32_t n_expert, size_t n_devices, bool shares_host, bool cache_supported);
+
+bool common_fit_auto_prefetch_weights(
+        const llama_context_params & cparams, bool automatic,
+        uint32_t n_expert, size_t n_devices, bool shares_host, bool copy_stream);
+
 // Pure decision arithmetic, exposed for tests (tests/test-fit-params.cpp).
 // The projected figures are resident demand per row; "shares_host" marks
 // devices whose memory is the same physical pool as the host's.

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -384,6 +384,7 @@ extern "C" {
 
     // Enable async weight prefetching to overlap CPU->GPU transfers with compute
     GGML_API void                 ggml_backend_sched_set_prefetch_weights(ggml_backend_sched_t sched, bool enabled);
+    GGML_API void                 ggml_backend_sched_set_prefetch_weights_active(ggml_backend_sched_t sched, bool active);
 
     //
     // Meta backend

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -866,6 +866,7 @@ struct ggml_backend_sched {
 
     bool op_offload;
     bool prefetch_weights;
+    bool prefetch_weights_configured;
 
     // prefetch support: copy backends and events for compute/transfer overlap
     ggml_backend_t       copy_backends[GGML_SCHED_MAX_BACKENDS];
@@ -2391,6 +2392,7 @@ void ggml_backend_sched_set_moe_cache(
 void ggml_backend_sched_set_prefetch_weights(ggml_backend_sched_t sched, bool enabled) {
     GGML_ASSERT(sched);
     sched->prefetch_weights = enabled;
+    sched->prefetch_weights_configured = enabled;
 
     if (enabled && sched->n_backends == 2) {
         for (int b = 0; b < sched->n_backends; b++) {
@@ -2421,6 +2423,12 @@ void ggml_backend_sched_set_prefetch_weights(ggml_backend_sched_t sched, bool en
             }
         }
     }
+}
+
+void ggml_backend_sched_set_prefetch_weights_active(ggml_backend_sched_t sched, bool active) {
+    GGML_ASSERT(sched);
+    GGML_ASSERT(!active || sched->prefetch_weights_configured);
+    sched->prefetch_weights = active;
 }
 
 int ggml_backend_sched_get_n_splits(ggml_backend_sched_t sched) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -409,6 +409,7 @@ extern "C" {
                           // ref: https://github.com/ggml-org/llama.cpp/pull/14363
 
         bool prefetch_weights; // prefetch weight transfers to overlap CPU->GPU copies with compute
+        bool moe_cache_auto;   // MoE cache size was selected automatically by --fit
 
         // [EXPERIMENTAL]
         // backend sampler chain configuration (make sure the caller keeps the sampler chains alive)

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -275,6 +275,7 @@ llama_context::llama_context(
     cparams.kv_unified       = params.kv_unified;
     cparams.prefetch_weights = params.prefetch_weights;
     cparams.moe_cache_size   = params.moe_cache_size;
+    cparams.moe_cache_auto   = params.moe_cache_auto;
 
     // initialized later
     cparams.pipeline_parallel = false;
@@ -496,7 +497,7 @@ llama_context::llama_context(
             if (cache_backend == nullptr) {
                 throw std::runtime_error("MoE cache requires a GPU backend");
             }
-            moe_cache.reset(new llama_moe_cache(model, cache_backend, cache_buft, cparams.moe_cache_size));
+            moe_cache.reset(new llama_moe_cache(model, cache_backend, cache_buft, cparams.moe_cache_size, cparams.moe_cache_auto));
         }
 
         sched_reserve();
@@ -1383,6 +1384,8 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         ret = GGML_STATUS_FAILED;
         return nullptr;
     }
+
+    ggml_backend_sched_set_prefetch_weights_active(sched.get(), cparams.prefetch_weights && ubatch.n_tokens >= 32);
 
     auto * res = gf_res_prev.get();
     auto * gf  = res->get_gf();
@@ -3802,6 +3805,7 @@ llama_context_params llama_context_default_params() {
         /*.swa_full                    =*/ true,
         /*.kv_unified                  =*/ false,
         /*.prefetch_weights            =*/ false,
+        /*.moe_cache_auto              =*/ false,
         /*.sampler                     =*/ nullptr,
         /*.n_sampler                   =*/ 0,
         /*.ctx_other                   =*/ nullptr,

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -58,6 +58,7 @@ struct llama_cparams {
 
     size_t moe_cache_size;
     bool prefetch_weights;
+    bool moe_cache_auto;
 
     std::vector<bool> embeddings_layer_inp; // [n_layer()] extract input embeddings for layer
 

--- a/src/llama-moe-cache.cpp
+++ b/src/llama-moe-cache.cpp
@@ -209,7 +209,8 @@ struct llama_moe_cache::impl {
             const llama_model & model,
             ggml_backend_t backend,
             ggml_backend_buffer_type_t buft,
-            size_t requested_size) :
+            size_t requested_size,
+            bool automatic) :
         backend(backend),
         no_alloc(model.hparams.no_alloc),
         lru(model.layers.size(), model.hparams.n_expert, 1),
@@ -336,6 +337,10 @@ struct llama_moe_cache::impl {
             n_slots = candidate;
         }
         if (n_slots < int32_t(model.hparams.n_expert_used)) {
+            if (automatic) {
+                LLAMA_LOG_INFO("llama_moe_cache: fitted budget is smaller than one routed layer working set; cache inactive\n");
+                return;
+            }
             throw std::runtime_error("MoE cache budget is smaller than one routed layer working set");
         }
         lru = llama_moe_cache_lru(model.layers.size(), model.hparams.n_expert, n_slots);
@@ -527,8 +532,9 @@ llama_moe_cache::llama_moe_cache(
         const llama_model & model,
         ggml_backend_t backend,
         ggml_backend_buffer_type_t buft,
-        size_t size) :
-    pimpl(new impl(model, backend, buft, size)) {
+        size_t size,
+        bool automatic) :
+    pimpl(new impl(model, backend, buft, size, automatic)) {
 }
 
 llama_moe_cache::~llama_moe_cache() = default;

--- a/src/llama-moe-cache.h
+++ b/src/llama-moe-cache.h
@@ -56,7 +56,8 @@ public:
             const llama_model & model,
             ggml_backend_t backend,
             ggml_backend_buffer_type_t buft,
-            size_t size);
+            size_t size,
+            bool automatic);
     ~llama_moe_cache();
 
     ggml_backend_t backend() const;

--- a/tests/test-fit-params.cpp
+++ b/tests/test-fit-params.cpp
@@ -1,8 +1,6 @@
-// Table-driven tests for the pure fit decision arithmetic in common/fit.cpp.
-// These are the sites of the review findings on qvac-fabric-llm.cpp#214: the
-// shared-pool fold and the step-2 context interpolation. Everything here is
-// provable from the algebra with no hardware, which is the point — the
-// context-inflation bug would have failed these fixtures on their first run.
+// Hardware-independent tests for fitting policy and memory arithmetic.
+// Covers automatic acceleration, placement overrides, shared-memory budgets,
+// and context interpolation without loading model weights or a GPU backend.
 
 #include "../common/fit.h"
 
@@ -28,7 +26,82 @@ static void expect_u32(const char * label, uint32_t got, uint32_t want) {
     }
 }
 
+static void test_automatic_acceleration() {
+    // Each row starts from the CLI's automatic defaults. Exercise both model
+    // types: MoE should select caching, dense should select prefetch.
+    enum scenario {
+        DEFAULTS, DISABLED, RESOLVED, CPU_ONLY, MULTI_GPU, UNIFIED,
+        UNSUPPORTED_CACHE, NO_COPY_STREAM, NO_OFFLOAD, TRAINING,
+    };
+    struct test_case {
+        const char * label;
+        scenario config;
+        bool want_cache;
+        bool want_prefetch;
+    };
+    const test_case cases[] = {
+        { "automatic defaults", DEFAULTS, true, true },
+        { "explicit disable", DISABLED, false, false },
+        { "already selected or explicit value", RESOLVED, false, false },
+        { "CPU only", CPU_ONLY, false, false },
+        { "multiple GPUs", MULTI_GPU, false, false },
+        { "unified memory", UNIFIED, false, false },
+        { "unsupported cache backend", UNSUPPORTED_CACHE, false, true },
+        { "no copy stream", NO_COPY_STREAM, true, false },
+        { "operation offload disabled", NO_OFFLOAD, false, false },
+        { "training", TRAINING, false, false },
+    };
+    const auto mparams = llama_model_default_params();
+    for (const auto & tc : cases) {
+        auto cparams = llama_context_default_params();
+        cparams.moe_cache_auto = tc.config != DISABLED;
+        cparams.moe_cache_size = tc.config == RESOLVED ? GiB : 0;
+        cparams.prefetch_weights = tc.config == RESOLVED;
+        cparams.op_offload = tc.config != NO_OFFLOAD;
+        cparams.training = tc.config == TRAINING;
+        const size_t nd = tc.config == CPU_ONLY ? 0 : tc.config == MULTI_GPU ? 2 : 1;
+        for (uint32_t n_expert : { 0U, 8U }) {
+            expect_i64(tc.label, common_fit_auto_moe_cache(
+                mparams, cparams, n_expert, nd, tc.config == UNIFIED, tc.config != UNSUPPORTED_CACHE),
+                n_expert > 0 && tc.want_cache);
+            expect_i64(tc.label, common_fit_auto_prefetch_weights(
+                cparams, tc.config != DISABLED, n_expert, nd, tc.config == UNIFIED, tc.config != NO_COPY_STREAM),
+                n_expert == 0 && tc.want_prefetch);
+        }
+    }
+}
+
+static void test_auto_cache_preserves_context_fitting() {
+    auto mparams = llama_model_default_params();
+    auto cparams = llama_context_default_params();
+    cparams.moe_cache_auto = true;
+
+    // Cache selection defers context reduction until a recursive fit. Explicit
+    // placement cannot reach that recursion: step 3 rejects it. Those callers
+    // must retain the ordinary context-reduction path instead.
+    for (int n_gpu_layers : { 0, 12, 999 }) {
+        mparams.n_gpu_layers = n_gpu_layers;
+        expect_i64("explicit -ngl must not defer context fitting",
+            common_fit_auto_moe_cache(mparams, cparams, 8, 1, false, true), false);
+    }
+    mparams = llama_model_default_params();
+    llama_model_tensor_buft_override overrides[] = {
+        { "blk\\.\\d+\\.ffn_.*_exps", nullptr },
+        { nullptr, nullptr },
+    };
+    mparams.tensor_buft_overrides = overrides;
+    expect_i64("--cpu-moe / -ot must not defer context fitting",
+        common_fit_auto_moe_cache(mparams, cparams, 8, 1, false, true), false);
+
+    // An allocated but empty overrides array is the normal CLI default.
+    mparams.tensor_buft_overrides = &overrides[1];
+    expect_i64("empty overrides still allow automatic cache",
+        common_fit_auto_moe_cache(mparams, cparams, 8, 1, false, true), true);
+}
+
 int main() {
+    test_automatic_acceleration();
+    test_auto_cache_preserves_context_fitting();
     // --- common_fit_shared_pool_deficit ---
 
     // nd == 1, discrete GPU: device demand never counts against the host pool.

--- a/tools/fit-params/fit-params.cpp
+++ b/tools/fit-params/fit-params.cpp
@@ -33,6 +33,7 @@ int llama_fit_params(int argc, char ** argv) {
     if (!params.fit_params_print) {
         const common_params_fit_status status = common_fit_params(params.model.path.c_str(), &mparams, &cparams,
                 params.tensor_split, params.tensor_buft_overrides.data(), params.fit_params_target.data(), params.fit_params_min_ctx,
+                params.prefetch_weights_auto,
                 params.verbosity >= LOG_LEVEL_DEBUG ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
         if (status != COMMON_PARAMS_FIT_STATUS_SUCCESS) {
             LOG_ERR("%s: failed to fit CLI arguments to free memory, exiting...\n", __func__);
@@ -42,6 +43,12 @@ int llama_fit_params(int argc, char ** argv) {
         LOG_INF("%s: printing fitted CLI arguments to stdout...\n", __func__);
         common_log_flush(common_log_main());
         printf("-c %" PRIu32 " -ngl %" PRIi32, cparams.n_ctx, mparams.n_gpu_layers);
+        if (cparams.moe_cache_size > 0) {
+            printf(" --moe-cache-mib %zu", cparams.moe_cache_size / (1024 * 1024));
+        }
+        if (cparams.prefetch_weights) {
+            printf(" -pw 1");
+        }
 
         size_t nd = llama_max_devices();
         while (nd > 1 && mparams.tensor_split[nd - 1] == 0.0f) {

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -2370,6 +2370,7 @@ int llama_bench(int argc, char ** argv) {
                 fit_overrides.data(),
                 margins.data(),
                 inst.fit_min_ctx,
+                false,
                 params.verbose ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
        }
 


### PR DESCRIPTION
Stacked on #233.

## Summary

- Automatically enable dense weight prefetch when `--fit` leaves dense FFN weights on the host and the single discrete GPU supports a copy stream.
- Automatically reserve 10% of total routed-expert memory for the MoE cache, then let the normal fit path use the remaining VRAM for full layers.
- Keep dense prefetch active for prompt-processing batches and disable it for small decode batches.
- Preserve explicit overrides through `--prefetch-weights 0|1` and `--moe-cache-mib N|0`.
- Print the resolved cache and prefetch settings from `llama-fit-params`.

## Usage

Automatic selection is enabled by `--fit`:

```sh
llama-cli -m model.gguf --fit on
```

To disable either policy explicitly:

```sh
llama-cli -m model.gguf --fit on --moe-cache-mib 0 --prefetch-weights 0
```

## MoE measurement

Measured on an RTX 5090 with Qwen3.8 Flash Next Q4_0, `--load-mode none`, `-c 2048`, `-fitc 2048`, and a correlated corpus containing 975 prompt tokens followed by 64 generated tokens. `GGML_OP_OFFLOAD_MIN_BATCH` was unset for both configurations.

| Configuration | Prompt tok/s | Decode tok/s | Cache hit rate |
| --- | ---: | ---: | ---: |
| `--fit` baseline, cache and prefetch disabled | 343.26 | 28.85 | - |
| Automatic 10% MoE cache | 298.16 | 50.64 | 77.82% |

The model contains 65,100 MiB of routed-expert weights. Automatic fitting requested 6,510 MiB and allocated 6,507 MiB across 2,467 cache slots.

## Validation

- Built `llama-server`, `llama-bench`, `llama-fit-params`, `test-moe-cache`, and `test-arg-parser`.
- Passed `test-arg-parser`, `test-fit-params`, and `test-moe-cache`.
- Repeated the automatic MoE configuration end-to-end on the RTX 5090 corpus run.