### PR TITLE
docs: document cluster inference, MoE caching, vector search, and VisionPsy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ With one RPC server running on each host, distribute the model across two stages
 
 See the [RPC Guide](tools/rpc/README.md) for build instructions, server setup, network requirements, and tuning.
 
+### MoE Expert Cache *(experimental)*
+
+Improve decoding speed on hybrid systems with limited GPU VRAM and ample system RAM by keeping MoE expert weights in system RAM and caching recently used experts on the GPU. Cache hits reuse GPU-resident weights, reducing repeated CPU-to-GPU transfers during token generation. The benefit depends on expert reuse, cache size, and transfer bandwidth.
+
+- **Configurable VRAM budget**: `--moe-cache-mib N` sets the persistent GPU expert cache budget in MiB; `0` disables it (the default).
+- **Hybrid placement**: combine GPU layer offload with `--cpu-moe` to keep all expert weights in system RAM, or `--n-cpu-moe N` to keep the first N layers' expert weights there.
+- **On-demand caching**: upload missing experts and evict least-recently-used entries when the cache fills. The cache supports single-GPU inference; OpenCL, tensor parallelism, multi-GPU execution, and training are not supported.
+
+For example, keep expert weights in system RAM and allocate a 1 GiB GPU cache:
+
+```bash
+./build/bin/llama-cli -m moe-model.gguf \
+    --n-gpu-layers all --cpu-moe --moe-cache-mib 1024 \
+    -p "Explain how mixture-of-experts models work"
+```
+
+Choose a cache budget that leaves VRAM for other model weights, the KV cache, and compute buffers. It must be large enough to hold the active experts for at least one routed layer.
+
 ### TurboVec / Local Vector Search *(experimental)*
 
 `ggml-vector-index` provides a standalone C API for local vector search, including compressed CPU indexes for applications that need on-device retrieval.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
-# qvac-fabric-llm.cpp
+<div align="center">
 
-**AI inference and training engine for desktop and mobile platforms.**
+<h1>qvac-fabric-llm.cpp</h1>
 
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Based on llama.cpp](https://img.shields.io/badge/based%20on-llama.cpp%20b10549-orange.svg)](https://github.com/ggml-org/llama.cpp)
+<p><strong>AI inference and training engine for desktop and mobile platforms.</strong></p>
+
+<p>
+<a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
+<a href="https://github.com/ggml-org/llama.cpp"><img src="https://img.shields.io/badge/based%20on-llama.cpp%20b10549-orange.svg" alt="Based on llama.cpp"></a>
+</p>
+
+</div>
 
 `qvac-fabric-llm.cpp` is a specialized fork of [llama.cpp](https://github.com/ggml-org/llama.cpp) optimized for embedded systems, mobile devices, and enterprise deployment scenarios. It extends the excellent foundation of llama.cpp with additional capabilities focused on memory-based model loading, mobile GPU optimization, and flexible integration patterns.
 
+---
 
 ## Key Features
 
-The following capabilities are developed and maintained as part of qvac-fabric-llm.cpp. Features marked as *exclusive* are not available in upstream llama.cpp.
+The following capabilities are developed and maintained as part of qvac-fabric-llm.cpp.
 
 ### Cluster Inference
 
@@ -33,7 +40,7 @@ Split layers across GPUs and overlap prompt microbatches. Use one endpoint per s
     --device RPC0,RPC1 --split-mode layer -ngl all -b 2048 -ub 256
 ```
 
-#### Tensor Parallelism *(experimental)*
+#### Tensor Parallelism
 
 Split work within each layer across GPUs to accelerate decoding for supported models. Fast network links help because the GPUs exchange results frequently. Using the same servers:
 
@@ -41,8 +48,6 @@ Split work within each layer across GPUs to accelerate decoding for supported mo
 ./build/bin/llama-cli -m model.gguf --rpc 192.168.88.10:50052,192.168.88.11:50052 \
     --device RPC0,RPC1 --split-mode tensor -ngl all
 ```
-
-Direct all-reduce supports exactly two RPC devices on separate endpoints. In this example, allow host 2 to reach host 1 on port `51052` (RPC port plus 1000). See the [RPC Guide](tools/rpc/README.md) for network and tuning options.
 
 ### MoE Cache for Faster Decoding *(experimental)*
 
@@ -72,16 +77,7 @@ Choose a cache budget that leaves VRAM for other model weights, the KV cache, an
 
 The library is disabled by default. Enable it with `-DGGML_VECTOR_INDEX=ON` and link `ggml::vector-index` explicitly; it is not integrated into the llama runtime or server. See the [Vector Index Guide](docs/vector-index.md) for supported dimensions, API usage, persistence contracts, and benchmarks.
 
-### VisionPsy Nano / Flash Support
-
-Run VisionPsy Nano and Flash vision-language models through the multimodal subsystem using compatible GGUF models and projectors.
-
-- **Image sizing**: `--image-no-upscale on` enables the Flash preprocessing rule, rounding image sizes to the slice grid without always stretching smaller images to the maximum size. Use it for Flash projectors that do not declare this rule in GGUF metadata.
-- **Memory-aware vision attention**: automatic flash-attention selection accounts for image size and device memory on backends without efficient cooperative-matrix flash attention.
-
-See the [Multimodal Guide](tools/mtmd/README.md) for model and projector usage, and the [server CLI reference](tools/server/README.md) for image-processing options.
-
-### TurboQuant KV Cache Quantization *(exclusive)*
+### TurboQuant KV Cache Quantization
 
 TurboQuant adds low-bit KV-cache quantization formats for long-context inference while preserving token-generation quality close to higher-bit caches. It supports:
 
@@ -91,7 +87,7 @@ TurboQuant adds low-bit KV-cache quantization formats for long-context inference
 - **Backend support**: CPU quantization/dequantization and Vulkan inference kernels, including attention paths and mixed K/V cache configurations. CUDA and Metal do not include TurboQuant kernels in this release.
 - **Test coverage**: performance coverage via [test-kv-cache-quantization-perf.sh](tests/test-kv-cache-quantization-perf.sh), perplexity coverage via [test-kv-cache-quantization-perp.sh](tests/test-kv-cache-quantization-perp.sh), and eval coverage via [test-kv-cache-ruler.py](tests/test-kv-cache-ruler.py), [test-kv-cache-niah.py](tests/test-kv-cache-niah.py), [test-kv-cache-longbench.py](tests/test-kv-cache-longbench.py), [test-kv-cache-zeroscrolls.py](tests/test-kv-cache-zeroscrolls.py), and [test-kv-cache-leval.py](tests/test-kv-cache-leval.py).
 
-Qwen3.5-4B Q8_0 benchmark highlights:
+**Qwen3.5-4B Q8_0 benchmark highlights:**
 
 | Context | Cache config | BPW | RTX 5090 pp | RTX 5090 tg | Strix Halo pp | Strix Halo tg |
 | :-- | :-- | --: | --: | --: | --: | --: |
@@ -108,7 +104,7 @@ Qwen3.5-4B Q8_0 benchmark highlights:
 
 Quality checks on Qwen3.5-4B Q8_0 show `tbq4_0/pq4_0` at -0.03% perplexity delta versus `f16/f16`, with 94.8% RULER main score and 37.04 LongBench average versus 37.52 for `f16/f16`. See the full [TurboQuant benchmark report](docs/turboquant-benchmarks.md) for all measured models, contexts, and quality results.
 
-### LoRA Fine-Tuning *(exclusive)*
+### LoRA Fine-Tuning
 
 `qvac-fabric-llm.cpp` provides native [LoRA](https://arxiv.org/abs/2106.09685) (Low-Rank Adaptation) fine-tuning across CPU, Vulkan, and Metal backends. The training pipeline runs directly on consumer hardware, including mobile phones and integrated GPUs.
 
@@ -118,11 +114,11 @@ Quality checks on Qwen3.5-4B Q8_0 show `tbq4_0/pq4_0` at -0.03% perplexity delta
 - Checkpoint saving and resumable training
 - Learning rate schedulers (constant, cosine, linear) with warmup support
 - LoRA adapter merging into base models via **llama-export-lora**
-- Verified compatibility with Qwen3 and Gemma3 model architectures
+- Verified compatibility with Qwen3, Qwen3.5 and Qwen3.6 (dense and MoE), Gemma3, and Gemma4 (dense and MoE) model architectures
 
 For usage details and CLI reference, see the [Finetuning Guide](examples/training/README.md).
 
-### BitNet Inference and Fine-Tuning *(exclusive)*
+### BitNet Inference and Fine-Tuning
 
 Native support for [BitNet](https://arxiv.org/abs/2402.17764) ternary quantized models via the TQ2_0 data type, enabling efficient inference and LoRA fine-tuning of models such as [bitnet_b1_58-xl](https://huggingface.co/gianni-cor/bitnet_b1_58-xl-TQ2_0) on resource-constrained devices.
 
@@ -133,26 +129,14 @@ The official [microsoft/BitNet](https://github.com/microsoft/BitNet) inference f
 - **Conversion**: HuggingFace-to-GGUF conversion for BitNet model architectures
 - Cooperative matrix (coopmat) support for Vulkan devices that expose the extension
 
-### Memory-Based Model Loading *(exclusive)*
+### VisionPsy Nano / Flash Support
 
-Load models directly from memory buffers instead of the filesystem, enabling deployment in environments where disk access is restricted or unavailable.
+Run VisionPsy Nano and Flash vision-language models through the multimodal subsystem using compatible GGUF models and projectors.
 
-- Embedded systems with limited or no filesystem access
-- WebAssembly deployments where models are fetched over the network
-- Encrypted model storage where models are decrypted in memory
-- Streaming scenarios where models arrive over network connections
+- **Image sizing**: `--image-no-upscale on` enables the Flash preprocessing rule, rounding image sizes to the slice grid without always stretching smaller images to the maximum size. Use it for Flash projectors that do not declare this rule in GGUF metadata.
+- **Memory-aware vision attention**: automatic flash-attention selection accounts for image size and device memory on backends without efficient cooperative-matrix flash attention.
 
-```cpp
-#include "llama-cpp.h"
-
-std::vector<uint8_t> model_data = /* load from network, decrypt, etc. */;
-auto model = llama_model_load_from_buffer(std::move(model_data), params);
-
-auto model = llama_model_load_from_split_futures(paths, n_paths, context, tensor_list, params);
-llama_model_load_fulfill_split_future(path, context, std::move(streambuf));
-```
-
-### Mobile GPU Optimization *(exclusive)*
+### Mobile GPU Optimization
 
 Enhanced GPU support with targeted optimizations for Qualcomm Adreno GPUs.
 
@@ -161,6 +145,7 @@ Enhanced GPU support with targeted optimizations for Qualcomm Adreno GPUs.
 - Adreno-specific Vulkan shader variants for improved throughput.
 - Vulkan Memory Allocator (VMA) integration for efficient GPU memory management.
 
+---
 
 ## Quick Start
 
@@ -192,17 +177,19 @@ For more detailed build instructions, see [docs/build.md](docs/build.md).
 ./build/bin/llama-cli -m model.gguf -ngl 99 -c 4096 -p "Explain quantum computing in simple terms"
 ```
 
+---
 
 ## Supported Platforms
 
 | Platform | Backend | Status |
-|----------|---------|--------|
+| :-- | :-- | :--: |
 | Linux (x86_64, ARM64) | CPU, Vulkan, CUDA | ✅ Full support |
 | macOS (Intel, Apple Silicon) | CPU, Metal | ✅ Full support |
 | Windows (x86_64) | CPU, Vulkan, CUDA | ✅ Full support |
 | Android (ARM64) | CPU, Vulkan, OpenCL | ✅ Full support |
 | iOS | CPU, Metal | ✅ Full support |
 
+---
 
 ## Relationship with llama.cpp
 
@@ -210,25 +197,14 @@ qvac-fabric-llm.cpp is a maintained fork of [llama.cpp](https://github.com/ggml-
 
 **Current upstream baseline:** llama.cpp b10549
 
-### Exclusive Features
-
-The following features are developed in qvac-fabric-llm.cpp and are not available in upstream llama.cpp:
-
-| Feature | Description |
-|---------|-------------|
-| TurboQuant KV cache quantization | TBQ3_0/TBQ4_0 with QJL correction plus PQ3_0/PQ4_0 Stage 1 formats; CPU quantization/dequantization and Vulkan inference kernels for low-bit KV-cache inference |
-| LoRA fine-tuning | On-device training across CPU, Vulkan, and Metal with SFT, checkpointing, and LR scheduling |
-| BitNet inference and training | TQ2_0 quantization on Vulkan, Metal, and CPU for inference and LoRA fine-tuning; extends [microsoft/BitNet](https://github.com/microsoft/BitNet) beyond its CUDA-only GPU support |
-| Memory-based model loading | Load models from in-memory buffers with split-model and async fulfillment support |
-| Mobile GPU optimization | Adreno 800+ quantized inference (Q4_0, Q8), Adreno-specific Vulkan shader variants, VMA integration |
-
 ### Upstream Compatibility
 
 All standard llama.cpp functionality, models, and APIs remain fully compatible.
 
 - Any GGUF model supported by llama.cpp is supported by qvac-fabric-llm.cpp
-- Existing llama.cpp documentation applies to all non-exclusive features
+- Existing llama.cpp documentation applies to shared functionality
 
+---
 
 ## Contributing
 
@@ -238,6 +214,7 @@ We welcome contributions! Please see our development workflow:
 2. Create a feature branch from `master`
 3. Submit a pull request
 
+---
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,73 +14,37 @@ The following capabilities are developed and maintained as part of qvac-fabric-l
 
 ### Cluster Inference
 
-Run inference across local and remote GPUs using the RPC backend. Pipeline parallelism distributes layers across devices; tensor parallelism splits work within layers across devices.
+Run inference across GPUs on multiple machines using RPC. TCP is supported by default; **RDMA is Linux-only**, with compatible RoCEv2 adapters and `libibverbs`, and is negotiated automatically.
 
-RPC uses TCP by default. **RDMA support is available only on Linux**, with compatible RoCEv2 network adapters and `libibverbs` available at build time. Supported connections negotiate RDMA automatically; the commands below work with either transport.
-
-#### Quickstart Setup
-
-The examples use two GPU hosts and a main host that loads `model.gguf`. Replace the example IP addresses with your hosts' private addresses. Run the RPC servers on a trusted private network.
-
-On each GPU host, build RPC with the backend for that GPU. For NVIDIA CUDA:
+Build with `-DGGML_RPC=ON` and the GPU backend for each host (see the [RPC Guide](tools/rpc/README.md)). Start one server per GPU on a private network:
 
 ```bash
-cmake -B build -DGGML_RPC=ON -DGGML_CUDA=ON
-cmake --build build --config Release -j
-```
-
-On the main host, enable RPC:
-
-```bash
-cmake -B build -DGGML_RPC=ON
-cmake --build build --config Release -j
-```
-
-Start one server per GPU; these same servers work for both modes below:
-
-```bash
-# GPU host 1
+# Run on GPU host 1 and GPU host 2, respectively
 ./build/bin/ggml-rpc-server -H 192.168.88.10 -p 50052 --device CUDA0
-
-# GPU host 2
 ./build/bin/ggml-rpc-server -H 192.168.88.11 -p 50052 --device CUDA0
 ```
 
-Keep the model file on the main host and allow it to reach port `50052` on both GPU hosts.
-
 #### Pipeline Parallelism
 
-Assign successive layers to different GPUs and overlap microbatches across the pipeline. This is useful for processing larger prompt batches. Use one RPC server endpoint per stage; devices exposed by the same server process do not pipeline with each other.
-
-On the main host:
+Split layers across GPUs and overlap prompt microbatches. Use one endpoint per stage and a batch larger than the microbatch. On the main host:
 
 ```bash
-./build/bin/llama-cli -m model.gguf \
-    --rpc 192.168.88.10:50052,192.168.88.11:50052 \
-    --device RPC0,RPC1 --split-mode layer --tensor-split 1,1 \
-    --n-gpu-layers all --batch-size 2048 --ubatch-size 256
+./build/bin/llama-cli -m model.gguf --rpc 192.168.88.10:50052,192.168.88.11:50052 \
+    --device RPC0,RPC1 --split-mode layer -ngl all -b 2048 -ub 256
 ```
-
-A batch larger than the microbatch (`--ubatch-size`) provides independent work to overlap across stages. Adjust `--tensor-split` to match the devices' available memory; `1,1` assigns equal proportions.
 
 #### Tensor Parallelism *(experimental)*
 
-Split weights and KV-cache tensors across GPUs so the devices cooperate within each layer. This can accelerate token generation for supported models, but requires frequent communication and benefits from low-latency, high-bandwidth links.
-
-Using the same servers, run a model that supports tensor split on the main host:
+Split work within each layer across GPUs to accelerate decoding for supported models. Fast network links help because the GPUs exchange results frequently. Using the same servers:
 
 ```bash
-./build/bin/llama-cli -m model.gguf \
-    --rpc 192.168.88.10:50052,192.168.88.11:50052 \
-    --device RPC0,RPC1 --split-mode tensor --tensor-split 1,1 \
-    --n-gpu-layers all
+./build/bin/llama-cli -m model.gguf --rpc 192.168.88.10:50052,192.168.88.11:50052 \
+    --device RPC0,RPC1 --split-mode tensor -ngl all
 ```
 
-With exactly two RPC devices on separate endpoints, all-reduce can exchange results directly between the servers. Allow GPU host 2 to reach port `51052` on GPU host 1 (its RPC port plus 1000), or set `GGML_RPC_COMM_PORT` on the main host to choose another port. Large F32 all-reduce tensors use BF16 on the wire by default to reduce traffic; set `GGML_RPC_NO_WIRE_BF16=1` on the main host to retain F32 transfers.
+Direct all-reduce supports exactly two RPC devices on separate endpoints. In this example, allow host 2 to reach host 1 on port `51052` (RPC port plus 1000). See the [RPC Guide](tools/rpc/README.md) for network and tuning options.
 
-See the [RPC Guide](tools/rpc/README.md) for other GPU backends, RDMA setup, and troubleshooting.
-
-### MoE Expert Cache *(experimental)*
+### MoE Cache for Faster Decoding *(experimental)*
 
 Improve decoding speed on hybrid systems with limited GPU VRAM and ample system RAM by keeping MoE expert weights in system RAM and caching recently used experts on the GPU. Cache hits reuse GPU-resident weights, reducing repeated CPU-to-GPU transfers during token generation. The benefit depends on expert reuse, cache size, and transfer bandwidth.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For example, keep expert weights in system RAM and allocate a 1 GiB GPU cache:
 
 Choose a cache budget that leaves VRAM for other model weights, the KV cache, and compute buffers. It must be large enough to hold the active experts for at least one routed layer.
 
-### TurboVec / Local Vector Search *(experimental)*
+### TurboVec / Local Vector Search
 
 `ggml-vector-index` provides a standalone C API for local vector search, including compressed CPU indexes for applications that need on-device retrieval.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **AI inference and training engine for desktop and mobile platforms.**
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Based on llama.cpp](https://img.shields.io/badge/based%20on-llama.cpp%20b7248-orange.svg)](https://github.com/ggml-org/llama.cpp)
+[![Based on llama.cpp](https://img.shields.io/badge/based%20on-llama.cpp%20b10549-orange.svg)](https://github.com/ggml-org/llama.cpp)
 
 `qvac-fabric-llm.cpp` is a specialized fork of [llama.cpp](https://github.com/ggml-org/llama.cpp) optimized for embedded systems, mobile devices, and enterprise deployment scenarios. It extends the excellent foundation of llama.cpp with additional capabilities focused on memory-based model loading, mobile GPU optimization, and flexible integration patterns.
 
@@ -11,6 +11,44 @@
 ## Key Features
 
 The following capabilities are developed and maintained as part of qvac-fabric-llm.cpp. Features marked as *exclusive* are not available in upstream llama.cpp.
+
+### Cluster Inference
+
+Run inference across local and remote GPUs using the RPC backend, with pipeline and tensor parallelism for supported configurations.
+
+- **Pipeline parallelism**: overlap microbatches across remote devices with `--split-mode layer`. Use protocol 7 on the client and all servers, with one RPC server endpoint per pipeline stage.
+- **Direct all-reduce**: tensor split with exactly two RPC devices can exchange results directly between servers. Large F32 all-reduce tensors use BF16 on the wire by default to reduce network traffic.
+- **Transport**: TCP connectivity with automatically negotiated RDMA on supported Linux systems.
+
+With one RPC server running on each host, distribute the model across two stages:
+
+```bash
+./build/bin/llama-cli -m model.gguf \
+    --rpc 192.168.88.10:50052,192.168.88.11:50052 \
+    --device RPC0,RPC1 --split-mode layer --tensor-split 1,1 \
+    --n-gpu-layers all --batch-size 2048 --ubatch-size 256
+```
+
+See the [RPC Guide](tools/rpc/README.md) for build instructions, server setup, network requirements, and tuning.
+
+### TurboVec / Local Vector Search *(experimental)*
+
+`ggml-vector-index` provides a standalone C API for local vector search, including compressed CPU indexes for applications that need on-device retrieval.
+
+- **Storage**: full-precision f32, generic q8 and packed q4, plus TurboVec 2-bit and 4-bit modes with scalar, NEON, and AVX2 scoring paths.
+- **Search**: exact top-k scans, filtering by caller-provided IDs, reusable prepared filters, and optional IVF search for approximate candidate selection.
+- **Persistence**: index snapshots, with read-only mmap loading and incremental mutation logs for the generic storage modes. TurboVec supports snapshot save/load; mmap and logged mutations are not yet supported for TurboVec.
+
+The library is disabled by default. Enable it with `-DGGML_VECTOR_INDEX=ON` and link `ggml::vector-index` explicitly; it is not integrated into the llama runtime or server. See the [Vector Index Guide](docs/vector-index.md) for supported dimensions, API usage, persistence contracts, and benchmarks.
+
+### VisionPsy Nano / Flash Support
+
+Run VisionPsy Nano and Flash vision-language models through the multimodal subsystem using compatible GGUF models and projectors.
+
+- **Image sizing**: `--image-no-upscale on` enables the Flash preprocessing rule, rounding image sizes to the slice grid without always stretching smaller images to the maximum size. Use it for Flash projectors that do not declare this rule in GGUF metadata.
+- **Memory-aware vision attention**: automatic flash-attention selection accounts for image size and device memory on backends without efficient cooperative-matrix flash attention.
+
+See the [Multimodal Guide](tools/mtmd/README.md) for model and projector usage, and the [server CLI reference](tools/server/README.md) for image-processing options.
 
 ### TurboQuant KV Cache Quantization *(exclusive)*
 
@@ -139,7 +177,7 @@ For more detailed build instructions, see [docs/build.md](docs/build.md).
 
 qvac-fabric-llm.cpp is a maintained fork of [llama.cpp](https://github.com/ggml-org/llama.cpp). The project regularly synchronizes with upstream releases to incorporate improvements, bug fixes, and new model support, while extending the engine with capabilities not present in the upstream project.
 
-**Current upstream baseline:** llama.cpp b7248
+**Current upstream baseline:** llama.cpp b10549
 
 ### Exclusive Features
 
@@ -152,10 +190,6 @@ The following features are developed in qvac-fabric-llm.cpp and are not availabl
 | BitNet inference and training | TQ2_0 quantization on Vulkan, Metal, and CPU for inference and LoRA fine-tuning; extends [microsoft/BitNet](https://github.com/microsoft/BitNet) beyond its CUDA-only GPU support |
 | Memory-based model loading | Load models from in-memory buffers with split-model and async fulfillment support |
 | Mobile GPU optimization | Adreno 800+ quantized inference (Q4_0, Q8), Adreno-specific Vulkan shader variants, VMA integration |
-
-### Experimental Components
-
-- `ggml-vector-index` is a default-off standalone vector search library. See the [Vector Index Guide](docs/vector-index.md) for build, API, persistence, mmap, and benchmark details.
 
 ### Upstream Compatibility
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,45 @@ The following capabilities are developed and maintained as part of qvac-fabric-l
 
 ### Cluster Inference
 
-Run inference across local and remote GPUs using the RPC backend, with pipeline and tensor parallelism for supported configurations.
+Run inference across local and remote GPUs using the RPC backend. Pipeline parallelism distributes layers across devices; tensor parallelism splits work within layers across devices.
 
-- **Pipeline parallelism**: overlap microbatches across remote devices with `--split-mode layer`. Use protocol 7 on the client and all servers, with one RPC server endpoint per pipeline stage.
-- **Direct all-reduce**: tensor split with exactly two RPC devices can exchange results directly between servers. Large F32 all-reduce tensors use BF16 on the wire by default to reduce network traffic.
-- **Transport**: TCP connectivity with automatically negotiated RDMA on supported Linux systems.
+RPC uses TCP by default. **RDMA support is available only on Linux**, with compatible RoCEv2 network adapters and `libibverbs` available at build time. Supported connections negotiate RDMA automatically; the commands below work with either transport.
 
-With one RPC server running on each host, distribute the model across two stages:
+#### Quickstart Setup
+
+The examples use two GPU hosts and a main host that loads `model.gguf`. Replace the example IP addresses with your hosts' private addresses. Run the RPC servers on a trusted private network.
+
+On each GPU host, build RPC with the backend for that GPU. For NVIDIA CUDA:
+
+```bash
+cmake -B build -DGGML_RPC=ON -DGGML_CUDA=ON
+cmake --build build --config Release -j
+```
+
+On the main host, enable RPC:
+
+```bash
+cmake -B build -DGGML_RPC=ON
+cmake --build build --config Release -j
+```
+
+Start one server per GPU; these same servers work for both modes below:
+
+```bash
+# GPU host 1
+./build/bin/ggml-rpc-server -H 192.168.88.10 -p 50052 --device CUDA0
+
+# GPU host 2
+./build/bin/ggml-rpc-server -H 192.168.88.11 -p 50052 --device CUDA0
+```
+
+Keep the model file on the main host and allow it to reach port `50052` on both GPU hosts.
+
+#### Pipeline Parallelism
+
+Assign successive layers to different GPUs and overlap microbatches across the pipeline. This is useful for processing larger prompt batches. Use one RPC server endpoint per stage; devices exposed by the same server process do not pipeline with each other.
+
+On the main host:
 
 ```bash
 ./build/bin/llama-cli -m model.gguf \
@@ -29,7 +61,24 @@ With one RPC server running on each host, distribute the model across two stages
     --n-gpu-layers all --batch-size 2048 --ubatch-size 256
 ```
 
-See the [RPC Guide](tools/rpc/README.md) for build instructions, server setup, network requirements, and tuning.
+A batch larger than the microbatch (`--ubatch-size`) provides independent work to overlap across stages. Adjust `--tensor-split` to match the devices' available memory; `1,1` assigns equal proportions.
+
+#### Tensor Parallelism *(experimental)*
+
+Split weights and KV-cache tensors across GPUs so the devices cooperate within each layer. This can accelerate token generation for supported models, but requires frequent communication and benefits from low-latency, high-bandwidth links.
+
+Using the same servers, run a model that supports tensor split on the main host:
+
+```bash
+./build/bin/llama-cli -m model.gguf \
+    --rpc 192.168.88.10:50052,192.168.88.11:50052 \
+    --device RPC0,RPC1 --split-mode tensor --tensor-split 1,1 \
+    --n-gpu-layers all
+```
+
+With exactly two RPC devices on separate endpoints, all-reduce can exchange results directly between the servers. Allow GPU host 2 to reach port `51052` on GPU host 1 (its RPC port plus 1000), or set `GGML_RPC_COMM_PORT` on the main host to choose another port. Large F32 all-reduce tensors use BF16 on the wire by default to reduce traffic; set `GGML_RPC_NO_WIRE_BF16=1` on the main host to retain F32 transfers.
+
+See the [RPC Guide](tools/rpc/README.md) for other GPU backends, RDMA setup, and troubleshooting.
 
 ### MoE Expert Cache *(experimental)*
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following capabilities are developed and maintained as part of qvac-fabric-l
 
 Run inference across GPUs on multiple machines using RPC. TCP is supported by default; **RDMA is Linux-only**, with compatible RoCEv2 adapters and `libibverbs`, and is negotiated automatically.
 
-Build with `-DGGML_RPC=ON` and the GPU backend for each host (see the [RPC Guide](tools/rpc/README.md)). Start one server per GPU on a private network:
+Build with `-DGGML_RPC=ON` and the GPU backend for each host. For RDMA, also set `-DGGML_RPC_RDMA=ON` on the Linux client and servers, with `libibverbs` installed (see the [RPC Guide](tools/rpc/README.md)). Start one server per GPU on a private network:
 
 ```bash
 # Run on GPU host 1 and GPU host 2, respectively


### PR DESCRIPTION
## Overview

Document cluster inference, the experimental MoE expert cache for hybrid CPU/GPU decoding, TurboVec/local vector search, and VisionPsy Nano/Flash support in the README. Include compact pipeline and tensor parallelism quickstarts, server commands, Linux-only RDMA requirements, a MoE cache example, cache-budget guidance, and component limitations, and update the upstream badge and baseline to b10549 for `temp-10549`.

Validation: checked the descriptions against the target branch, verified new relative links and CLI options, and ran `git diff --check`. README-only change; no runtime tests needed.

## Requirements

- [ ] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Codex drafted and checked the documentation and prepared this PR from the maintainer's selected scope.
