### PR TITLE
QVAC-24501 infra: point the stuck upstream CI jobs at the qvac fleet, gate the rest

### DIFF
--- a/.github/workflows/build-ibm.yml
+++ b/.github/workflows/build-ibm.yml
@@ -36,6 +36,10 @@ env:
 jobs:
 
   ubuntu-24-s390x:
+    # QVAC-24501: ubuntu-24.04-s390x is a GitHub-hosted arch image available on
+    # public repos only, so it never gets a runner here - the job queued for 24h
+    # and was killed as "cancelled" on every run since this fork was created.
+    if: false  # QVAC-23796: no matching hardware
     runs-on: ubuntu-24.04-s390x
 
     steps:
@@ -95,6 +99,9 @@ jobs:
           ./bin/llama-completion -m stories260K-be.gguf -p "One day, Lily met a Shoggoth" -n 500 -c 256
 
   ubuntu-24-ppc64le:
+    # QVAC-24501: see ubuntu-24-s390x above - ubuntu-24.04-ppc64le is public-repo
+    # only and never gets a runner in this fork.
+    if: false  # QVAC-23796: no matching hardware
     runs-on: ubuntu-24.04-ppc64le
 
     steps:

--- a/.github/workflows/build-openvino.yml
+++ b/.github/workflows/build-openvino.yml
@@ -35,6 +35,12 @@ env:
 
 jobs:
   ubuntu-24-openvino:
+    # QVAC-24501: needs Intel + OpenVINO hardware, not present in the fleet, so
+    # this queued for 24h and was killed on every run. Same convention as the
+    # gated jobs in build-self-hosted.yml. Note openvino-windows-2022 below is
+    # deliberately left running - it is on a GitHub image and passes, so it
+    # keeps our only OpenVINO build coverage.
+    if: false  # QVAC-23796: no matching hardware
     runs-on: [self-hosted, Linux, Intel, OpenVINO]
 
     env:

--- a/.github/workflows/build-riscv.yml
+++ b/.github/workflows/build-riscv.yml
@@ -35,6 +35,10 @@ env:
 
 jobs:
   ubuntu-cpu-riscv64-native:
+    # QVAC-24501: ubuntu-24.04-riscv is a GitHub-hosted arch image available on
+    # public repos only, so it never gets a runner here - the job queued for 24h
+    # and was killed as "cancelled" on every run since this fork was created.
+    if: false  # QVAC-23796: no matching hardware
     runs-on: ubuntu-24.04-riscv
 
     steps:
@@ -106,6 +110,9 @@ jobs:
           ./bin/llama-completion -m stories260K.gguf -p "One day, Lily met a Shoggoth" -n 500 -c 256
 
   ubuntu-riscv64-native-sanitizer:
+    # QVAC-24501: see ubuntu-cpu-riscv64-native above. This is a 3-way sanitizer
+    # matrix, so it accounted for 3 of the 12 permanently-queued jobs.
+    if: false  # QVAC-23796: no matching hardware
     runs-on: ubuntu-24.04-riscv
 
     continue-on-error: true

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -42,7 +42,12 @@ env:
 
 jobs:
   ctest:
-    runs-on: [self-hosted, X64, CPU, Linux]
+    # QVAC-24501: upstream's [self-hosted, X64, CPU, Linux] needs a custom `CPU`
+    # label that the qvac fleet does not carry, so every job queued for 24h and
+    # was then killed as "cancelled" - it has never produced a result in this
+    # fork. qvac-ubuntu2204-x64 is the fleet CPU box that already runs
+    # build-self-hosted.yml's cpu-x64-high-perf.
+    runs-on: qvac-ubuntu2204-x64
 
     continue-on-error: ${{ matrix.sanitizer == 'THREAD' }}
 

--- a/.github/workflows/pre-tokenizer-hashes.yml
+++ b/.github/workflows/pre-tokenizer-hashes.yml
@@ -1,12 +1,18 @@
 name: Check Pre-Tokenizer Hashes
 
+# QVAC-24501: this workflow's own file is in the paths filters below, which
+# update-ops-docs.yml and every build-*.yml already do but upstream omitted
+# here. Without it a change to this file cannot trigger the job it defines, so
+# the runner repoint in this branch was unverifiable by CI.
 on:
     push:
         paths:
+            - '.github/workflows/pre-tokenizer-hashes.yml'
             - 'conversion/base.py'
             - 'convert_hf_to_gguf_update.py'
     pull_request:
         paths:
+            - '.github/workflows/pre-tokenizer-hashes.yml'
             - 'conversion/base.py'
             - 'convert_hf_to_gguf_update.py'
 

--- a/.github/workflows/pre-tokenizer-hashes.yml
+++ b/.github/workflows/pre-tokenizer-hashes.yml
@@ -12,7 +12,10 @@ on:
 
 jobs:
     pre-tokenizer-hashes:
-        runs-on: [self-hosted, fast]
+        # QVAC-24501: upstream's [self-hosted, fast] needs a custom `fast` label
+        # the qvac fleet does not carry. This job is Python plus a diff, so the
+        # general-purpose fleet CPU box is ample.
+        runs-on: qvac-ubuntu2404-x64
 
         steps:
         - name: Checkout repository

--- a/.github/workflows/pre-tokenizer-hashes.yml
+++ b/.github/workflows/pre-tokenizer-hashes.yml
@@ -31,18 +31,24 @@ jobs:
               python3 -m venv .venv
               .venv/bin/pip install -r requirements/requirements-convert_hf_to_gguf_update.txt
 
+        # QVAC-24501: upstream stashed the pristine copy at a fixed /tmp/base.py.
+        # Our fleet hosts run several runner accounts side by side and share
+        # /tmp, so that path can be owned by another account (EACCES on cp) or,
+        # worse, hold a stale copy from a different job - which would diff this
+        # branch against someone else's file and report the wrong answer.
+        # $RUNNER_TEMP is per-job, so neither can happen.
         - name: Update pre-tokenizer hashes
           run: |
-              cp conversion/base.py /tmp
+              cp conversion/base.py "$RUNNER_TEMP/base.py"
               .venv/bin/python convert_hf_to_gguf_update.py --check-missing
 
         - name: Check if committed pre-tokenizer hashes matches generated version
           run: |
-              if ! diff -q conversion/base.py /tmp/base.py; then
+              if ! diff -q conversion/base.py "$RUNNER_TEMP/base.py"; then
                   echo "Model pre-tokenizer hashes (in conversion/base.py) do not match generated hashes (from convert_hf_to_gguf_update.py)."
                   echo "To fix: run ./convert_hf_to_gguf_update.py and commit the updated conversion/base.py along with your changes"
                   echo "Differences found:"
-                  diff conversion/base.py /tmp/base.py || true
+                  diff conversion/base.py "$RUNNER_TEMP/base.py" || true
                   exit 1
               fi
               echo "Model pre-tokenizer hashes are up to date."

--- a/.github/workflows/update-ops-docs.yml
+++ b/.github/workflows/update-ops-docs.yml
@@ -31,18 +31,25 @@ jobs:
           with:
               python-version: '3.x'
 
+        # QVAC-24501: upstream wrote this against a fixed /tmp/ops_check path.
+        # Our fleet hosts run several runner accounts side by side, so /tmp is
+        # shared: the first job to run creates the directory, and the next job
+        # on a different runner account gets EACCES writing into it. Observed
+        # exactly that - runner5 created it, runner9 then failed with
+        # "PermissionError: [Errno 13] Permission denied: '/tmp/ops_check/ops.md'".
+        # $RUNNER_TEMP is per-job and cleaned up, so it cannot collide.
         - name: Generate operations documentation to temporary file
           run: |
-              mkdir -p /tmp/ops_check
-              ./scripts/create_ops_docs.py /tmp/ops_check/ops.md
+              mkdir -p "$RUNNER_TEMP/ops_check"
+              ./scripts/create_ops_docs.py "$RUNNER_TEMP/ops_check/ops.md"
 
         - name: Check if docs/ops.md matches generated version
           run: |
-              if ! diff -q docs/ops.md /tmp/ops_check/ops.md; then
+              if ! diff -q docs/ops.md "$RUNNER_TEMP/ops_check/ops.md"; then
                   echo "Operations documentation (docs/ops.md) is not up to date with the backend CSV files."
                   echo "To fix: run ./scripts/create_ops_docs.py and commit the updated docs/ops.md along with your changes"
                   echo "Differences found:"
-                  diff docs/ops.md /tmp/ops_check/ops.md || true
+                  diff docs/ops.md "$RUNNER_TEMP/ops_check/ops.md" || true
                   exit 1
               fi
               echo "Operations documentation is up to date."

--- a/.github/workflows/update-ops-docs.yml
+++ b/.github/workflows/update-ops-docs.yml
@@ -16,7 +16,11 @@ on:
 
 jobs:
     update-ops-docs:
-        runs-on: [self-hosted, fast, ARM64]
+        # QVAC-24501: upstream's [self-hosted, fast, ARM64] needs a custom `fast`
+        # label the qvac fleet does not carry. The job only runs
+        # scripts/create_ops_docs.py and diffs the result, so it does not need
+        # ARM64 either - the general-purpose fleet CPU box is enough.
+        runs-on: qvac-ubuntu2404-x64
 
         steps:
         - name: Checkout repository


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Twelve jobs across six workflows in this fork have **never produced a single result**. Each asks for a runner label that nothing in our fleet answers to, so GitHub queues the job for 24 hours and then reports it as `cancelled`.

Evidence:

- Run [33159324553](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/33159324553) started `2026-08-28T09:25:46Z`, completed `2026-08-29T09:25:46Z`. Exactly 24h.
- On #215, ten jobs all started `2026-08-25T14:35:22Z` and completed `2026-08-26T14:35:22Z`.
- Still live: on #237 `ctest (THREAD)` ([job](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/34200762020/job/101978769137)) and `pre-tokenizer-hashes` ([job](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/34200757105/job/101978750512)) are queued with no runner.

QVAC-23796 (#209) fixed exactly this class of problem, but only inside `build-self-hosted.yml`. These six workflows were out of scope and were missed.

## 📝 How does it solve it?

Two groups, handled differently.

**Repointed at the fleet** (jobs our runners can take today):

| Workflow | Job | Was | Now |
|---|---|---|---|
| `build-sanitize.yml` | `ctest` ×3 | `[self-hosted, X64, CPU, Linux]` | `qvac-ubuntu2204-x64` |
| `pre-tokenizer-hashes.yml` | `pre-tokenizer-hashes` | `[self-hosted, fast]` | `qvac-ubuntu2404-x64` |
| `update-ops-docs.yml` | `update-ops-docs` | `[self-hosted, fast, ARM64]` | `qvac-ubuntu2404-x64` |

The blocking label in each case is a **custom** one upstream added to their own fleet (`CPU`, `fast`) that nobody put on the qvac boxes. GitHub auto-assigns `self-hosted`, the OS and the arch to every self-hosted runner, so those parts already match ours — which is why only these fail. Confirmed empirically in `qvac-ext-ggml`, where a job asking for `[self-hosted, macOS, ARM64]` was picked up by `qvac-macos26-arm64-gpu-runner2`.

Targets chosen from what already works here: `qvac-ubuntu2204-x64` runs `build-self-hosted.yml`'s `cpu-x64-high-perf`; `qvac-ubuntu2404-x64` runs `python-lint`, `python-type-check`, `code-style`, `check-vendor` and `editorconfig`. The two doc/hash jobs are Python plus a `diff` and don't need ARM64, so they go to the general-purpose box.

**Gated** (hardware we don't have), using the same `if: false  # QVAC-23796: no matching hardware` convention #209 established:

| Workflow | Jobs | Why |
|---|---|---|
| `build-ibm.yml` | `ubuntu-24-s390x`, `ubuntu-24-ppc64le` | `ubuntu-24.04-s390x` / `-ppc64le` are GitHub-hosted arch images, public repos only |
| `build-riscv.yml` | `ubuntu-cpu-riscv64-native`, `ubuntu-riscv64-native-sanitizer` (3-way matrix) | `ubuntu-24.04-riscv`, same reason |
| `build-openvino.yml` | `ubuntu-24-openvino` | no Intel/OpenVINO box in the fleet |

`CI (ibm)` and `CI (riscv)` have additionally been set to `disabled_manually` at repo level (2026-09-08), which stops them on every branch and PR immediately without waiting for this to merge. The `if: false` gates here are the durable, readable half of that: repo state is invisible from the code, and it is keyed to the workflow's file path, so an upstream sync that renames a file silently re-arms it.

## 🔎 Scope notes

**`openvino-windows-2022` is deliberately left running.** It sits on a GitHub image and it passes ([latest run](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/33494761306)), and it's our only remaining OpenVINO build coverage. Only the Linux job is gated. This is why the fix here is job-level rather than disabling the `CI (openvino)` workflow wholesale.

**`server-sanitize.yml` and `server-self-hosted.yml` are deliberately untouched.** Their labels (`[self-hosted, CPU, Linux, llama-server]`, `[self-hosted, llama-server, macOS, ARM64]`, `[self-hosted, llama-server, Linux, NVIDIA]`, `ah-ubuntu_22_04-c8g_8x`) are broken the same way and they hang 24h on every push to `master`, but @Gianfranco asked to leave their behaviour as-is for now, and repointing them would start running jobs that haven't executed since July. Tracked separately.

**Labels are hardcoded rather than routed through `.github/runners.yaml`.** QVAC-14347 (#230) deliberately scoped the catalog to QVAC-authored files, on the grounds that centralizing upstream-synced workflows would diverge this fork from `ggml-org/llama.cpp` on every sync. All six files here are upstream-synced, so a one-line `runs-on:` change is the smallest possible divergence; adding a `runner_names` caller job to each would be a much larger diff in exactly the files #230 avoided.

## 🧪 How was it tested?

Every changed workflow was actually executed against this branch before opening the PR, via `workflow_dispatch` or the branch push. Results:

| Workflow | Run | Result |
|---|---|---|
| Update Operations Documentation | [34212473133](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/34212473133) | ✅ **success in 11s** on `qvac-ubuntu2404-x64-runner5`. All 5 steps green including the real docs diff check. |
| CI (ibm) | [34214385455](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/34214385455) | ✅ both jobs `skipped`, run concluded immediately |
| CI (riscv) | [34214392107](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/34214392107) | ✅ both jobs `skipped` |
| CI (openvino) | [34214404019](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/34214404019) | ✅ `ubuntu-24-openvino` `skipped`, **`openvino-windows-2022` success** — the working half is preserved |
| CI (sanitize) | [34214571518](https://github.com/tetherto/qvac-fabric-llm.cpp/actions/runs/34214571518) | ⚠️ runner fix works, build fails on a pre-existing defect. See below. |

`Check Pre-Tokenizer Hashes` **cannot be exercised by this PR**. It has no `workflow_dispatch`, and its only path filters are `conversion/base.py` and `convert_hf_to_gguf_update.py`, neither of which this PR touches. It lands on the strength of `update-ops-docs` above, which proves the identical label on an identical shape of job. Flagging rather than implying coverage it does not have.

### ⚠️ CI (sanitize) surfaces a real build break in `tests/test-vector-index.cpp`

The label fix worked exactly as intended — all three `ctest` arms were picked up within seconds by `qvac-ubuntu2204-x64-runner7`, `-2-runner9` and `-2-runner12`, instead of queueing for 24h. The *build* then failed, for a reason unrelated to this PR:

```
tests/test-vector-index.cpp:2950:40: error: comparison of integer expressions of
different signedness: 'int' and 'size_t' [-Werror=sign-compare]
 2950 |     CHECK(ggml_vec_index_len(writer_a) == static_cast<size_t>(ids.size()));
tests/test-vector-index.cpp:2957:38: (same, `loaded`)
cc1plus: all warnings being treated as errors
```

`ggml_vec_index_len` is declared `GGML_API int` (`ggml/include/ggml-vector-index.h:339`) and `ids` is a `std::array<uint64_t, 4>`, so `ids.size()` is already `size_t`. The `static_cast<size_t>` is applied to the operand that was already unsigned, leaving the signed return value to trip `-Wsign-compare`. Every one of the ~30 other `ggml_vec_index_len` comparisons in that file compares against an `int`; these two lines are the only ones that don't.

This is only fatal in the `UNDEFINED` arm, the sole arm that sets `-DLLAMA_FATAL_WARNINGS=ON`. `THREAD` and `ADDRESS` were `cancelled` by matrix fail-fast rather than failing on their own merits, so they remain unproven.

Provenance: `tests/test-vector-index.cpp` does not exist upstream (404 on `ggml-org/llama.cpp`) — it is our own code, and it arrived on `master` in #228 on 2026-09-04, together with the `-DGGML_VECTOR_INDEX=ON` flag and the `Test vector index (undefined)` step that compile it. Because `CI (sanitize)` has never once run in this fork, nothing ever compiled it. **This PR is the first time that code has been built in CI, and it caught a four-day-old break on the first attempt.** That is the change working, not failing.

**Out of scope for this PR, by decision.** The fix is two lines (`static_cast<int>(ids.size())`, matching the ~30 other comparisons in that file), but it belongs to whoever owns vector-index, not to a CI-infrastructure change. This PR's job is to get these jobs onto our runners, and that is done and verified. `ctest (UNDEFINED)` will stay red until the code owner fixes those two lines.

Nothing is blocked by it: the only required status check on `master` is `Check Approvals` (ruleset `14278657`), which passes.

### Static checks

- All six files parse as YAML, and the resulting job config was asserted: 3 jobs repointed at fleet labels, 5 job definitions gated, `openvino-windows-2022` untouched.
- `actionlint` on all six: the only findings are two pre-existing classes, not introduced here.
  - `label "..." is unknown` — there is no `.github/actionlint.yaml` in this repo, so every custom self-hosted label warns, upstream's `Intel` / `OpenVINO` / `ubuntu-24.04-s390x` included.
  - `constant expression "false" in condition [if-cond]` — `master`'s `build-self-hosted.yml` already emits **6** identical warnings from #209's `if: false` pattern. #230's description records this same class as pre-existing and accepted.
  - The `shellcheck` SC2046/SC2086 findings are in upstream `run:` blocks this PR does not touch.

## 🛡️ Permissions changes

None. No `permissions:` block is added, removed or altered.

## ⚠️ Follow-ups

- This only fixes `master`. `pull_request` runs read workflow files from the PR's own head merged into its base, so PRs targeting other branches keep the old behaviour until this is backported. `temp-10549` and `rpc-set-tensor-2d-hash` currently have **zero** of #209's changes. #237 is based on `freetoken-moe-cache-dense-prefill` and will not pick this up.
- Upstream syncs can re-arm what's gated here. #228 re-added the `pull_request` trigger to `build-sanitize.yml` that `master` did not have. Worth a line on the sync checklist.

QVAC-24501
