### PR TITLE
rpc: add asynchronous butterfly all-reduce dispatch

### DIFF
--- a/ggml/include/ggml-rpc.h
+++ b/ggml/include/ggml-rpc.h
@@ -9,10 +9,12 @@ extern "C" {
 // qvac fork: downstream ggml_op insertions shift the serialized op ids
 // relative to upstream, so the wire format is incompatible with stock
 // llama.cpp peers even though the message framing is unchanged. Keep the
-// major version offset (+100) from upstream's so mismatched peers are
-// rejected at the HELLO handshake instead of misdecoding graphs. The
+// major version in the downstream namespace (>= 100), bumping it for
+// incompatible changes, so mismatched peers are rejected at the HELLO
+// handshake instead of misdecoding graphs. The
 // HELLO fields are uint8_t on the wire, so the value must stay <= 255.
-#define RPC_PROTO_MAJOR_VERSION    107
+// 108 adds butterfly communicator rounds and round-tagged peer frames.
+#define RPC_PROTO_MAJOR_VERSION    108
 #define RPC_PROTO_MINOR_VERSION    0
 #define RPC_PROTO_PATCH_VERSION    0
 

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -252,8 +252,9 @@ struct rpc_msg_comm_init_req {
     uint32_t device;
     uint32_t rank;
     uint32_t world;
-    uint32_t port;      // rank 0: port to listen on; rank > 0: rank 0's comm port
-    char     host[64];  // rank > 0: rank 0's host
+    uint32_t round;
+    uint32_t port;      // lower rank listens; higher rank connects
+    char     host[64];  // lower rank's host
     uint8_t  session_id[RPC_COMM_SESSION_ID_SIZE];
     uint8_t  wire_bf16;
 };
@@ -274,6 +275,11 @@ struct rpc_msg_comm_allreduce_req {
     uint32_t   device;
     uint64_t   op_id;
     rpc_tensor tensor;
+};
+
+struct rpc_comm_frame_header {
+    uint64_t op_id;
+    uint32_t round;
 };
 
 struct rpc_msg_comm_free_req {
@@ -1744,9 +1750,9 @@ private:
                               std::unordered_map<uint64_t, struct ggml_tensor*> & tensor_map);
 
 
-    // pairwise allreduce over a direct connection to the peer server
+    // One direct peer connection per recursive-doubling round.
     struct comm_state {
-        socket_ptr              peer;
+        std::vector<socket_ptr>  peers;
         uint32_t                rank = 0;
         uint32_t                world = 0;
         bool                    wire_bf16 = true;
@@ -1759,6 +1765,8 @@ private:
         std::vector<uint8_t>    send_buf;
         std::vector<uint8_t>    recv_buf;
     };
+
+    bool comm_allreduce_round(const rpc_msg_comm_allreduce_req & request, comm_state & state, uint32_t round);
 
     std::vector<ggml_backend_t> backends;
     std::string bind_host;
@@ -2546,18 +2554,24 @@ void rpc_server::sync_all_backends() {
 // as the client HELLO, so it gets the same transport upgrades (e.g. RDMA).
 bool rpc_server::comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_init_rsp & response) {
     response.ok = 0;
-    if (request.device >= backends.size() || request.world != 2 || request.rank >= request.world ||
+    if (request.device >= backends.size() || request.world < 2 ||
+            (request.world & (request.world - 1)) != 0 || request.rank >= request.world ||
+            request.round >= 31 || (uint32_t(1) << request.round) >= request.world ||
             request.port == 0 || request.port > UINT16_MAX || request.wire_bf16 > 1) {
         return true;
     }
     comm_state & state = comm_states[request.device];
-    if (state.peer != nullptr) {
-        GGML_LOG_WARN("[%s] communicator already initialized for device %u\n", __func__, request.device);
+    if (request.round != state.peers.size() ||
+            (request.round > 0 && (state.rank != request.rank || state.world != request.world ||
+                                  state.wire_bf16 != (request.wire_bf16 != 0)))) {
+        GGML_LOG_WARN("[%s] inconsistent communicator round for device %u\n", __func__, request.device);
         return true;
     }
+    socket_ptr connection;
+    const uint32_t peer_rank = request.rank ^ (uint32_t(1) << request.round);
     uint8_t local_caps[RPC_CONN_CAPS_SIZE] = {};
     uint8_t remote_caps[RPC_CONN_CAPS_SIZE] = {};
-    if (request.rank == 0) {
+    if (request.rank < peer_rank) {
         socket_ptr srv = socket_t::create_server(bind_host.c_str(), request.port);
         if (srv == nullptr) {
             GGML_LOG_ERROR("[%s] failed to listen on comm port %u\n", __func__, request.port);
@@ -2565,7 +2579,7 @@ bool rpc_server::comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_i
         }
         const auto deadline = std::chrono::steady_clock::now() +
                 std::chrono::milliseconds(RPC_COMM_ACCEPT_TIMEOUT_MS);
-        while (state.peer == nullptr) {
+        while (connection == nullptr) {
             const int remaining_ms = (int) std::chrono::duration_cast<std::chrono::milliseconds>(
                     deadline - std::chrono::steady_clock::now()).count();
             if (remaining_ms <= 0) {
@@ -2587,27 +2601,25 @@ bool rpc_server::comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_i
                     !peer->set_timeout(RPC_COMM_IO_TIMEOUT_MS)) {
                 continue;
             }
-            state.peer = std::move(peer);
+            connection = std::move(peer);
         }
-        if (state.peer == nullptr) {
-            GGML_LOG_ERROR("[%s] timed out waiting for rank 1 on comm port %u\n", __func__, request.port);
+        if (connection == nullptr) {
+            GGML_LOG_ERROR("[%s] timed out waiting for rank %u on comm port %u\n", __func__, peer_rank, request.port);
             return true;
         }
-        if (!state.peer->recv_data(remote_caps, sizeof(remote_caps))) {
-            state.peer = nullptr;
+        if (!connection->recv_data(remote_caps, sizeof(remote_caps))) {
             return true;
         }
-        state.peer->get_caps(local_caps);
-        if (!state.peer->send_data(local_caps, sizeof(local_caps))) {
-            state.peer = nullptr;
+        connection->get_caps(local_caps);
+        if (!connection->send_data(local_caps, sizeof(local_caps))) {
             return true;
         }
-        state.peer->update_caps(remote_caps);
+        connection->update_caps(remote_caps);
     } else {
         const std::string host(request.host, strnlen(request.host, sizeof(request.host)));
         const auto deadline = std::chrono::steady_clock::now() +
                 std::chrono::milliseconds(RPC_COMM_CONNECT_TIMEOUT_MS);
-        while (state.peer == nullptr) {
+        while (connection == nullptr) {
             const auto now = std::chrono::steady_clock::now();
             if (now >= deadline) {
                 break;
@@ -2624,10 +2636,10 @@ bool rpc_server::comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_i
                         peer->recv_data(&remote_hello, sizeof(remote_hello)) &&
                         validate_comm_peer_hello(remote_hello, request.session_id) &&
                         peer->set_timeout(RPC_COMM_IO_TIMEOUT_MS)) {
-                    state.peer = std::move(peer);
+                    connection = std::move(peer);
                 }
             }
-            if (state.peer == nullptr) {
+            if (connection == nullptr) {
                 const int retry_ms = std::min(RPC_COMM_CONNECT_RETRY_MS, (int)
                         std::chrono::duration_cast<std::chrono::milliseconds>(
                             deadline - std::chrono::steady_clock::now()).count());
@@ -2636,22 +2648,23 @@ bool rpc_server::comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_i
                 }
             }
         }
-        if (state.peer == nullptr) {
+        if (connection == nullptr) {
             GGML_LOG_ERROR("[%s] failed to connect to peer %s:%u\n", __func__, host.c_str(), request.port);
             return true;
         }
-        state.peer->get_caps(local_caps);
-        if (!state.peer->send_data(local_caps, sizeof(local_caps)) ||
-            !state.peer->recv_data(remote_caps, sizeof(remote_caps))) {
-            state.peer = nullptr;
+        connection->get_caps(local_caps);
+        if (!connection->send_data(local_caps, sizeof(local_caps)) ||
+            !connection->recv_data(remote_caps, sizeof(remote_caps))) {
             return true;
         }
-        state.peer->update_caps(remote_caps);
+        connection->update_caps(remote_caps);
     }
+    state.peers.push_back(std::move(connection));
     state.rank        = request.rank;
     state.world       = request.world;
     state.wire_bf16   = request.wire_bf16 != 0;
-    GGML_LOG_INFO("[%s] device %u joined pairwise comm as rank %u\n", __func__, request.device, request.rank);
+    GGML_LOG_INFO("[%s] device %u rank %u connected to rank %u in round %u\n",
+                  __func__, request.device, request.rank, peer_rank, request.round);
     response.ok = 1;
     return true;
 }
@@ -2661,7 +2674,7 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
         return false;
     }
     comm_state & state = comm_states[request.device];
-    if (state.peer == nullptr) {
+    if (state.world < 2 || (uint64_t(1) << state.peers.size()) != state.world) {
         GGML_LOG_ERROR("[%s] no communicator for device %u\n", __func__, request.device);
         return false;
     }
@@ -2670,6 +2683,17 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
                        __func__, request.op_id, state.next_op_id);
         return false;
     }
+    for (uint32_t round = 0; round < state.peers.size(); round++) {
+        if (!comm_allreduce_round(request, state, round)) {
+            return false;
+        }
+    }
+    state.next_op_id++;
+    return true;
+}
+
+bool rpc_server::comm_allreduce_round(const rpc_msg_comm_allreduce_req & request, comm_state & state, uint32_t round) {
+    const socket_ptr & peer = state.peers[round];
     ggml_backend_t backend = backends[request.device];
 
     size_t ctx_size = 16*ggml_tensor_overhead() + 2*ggml_graph_overhead_custom(8, false);
@@ -2689,10 +2713,9 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
     const size_t  nbytes = ggml_nbytes(t_dst);
     const int64_t ne     = ggml_nelements(t_dst);
     if (nbytes == 0) {
-        state.next_op_id++;
         return true;
     }
-    if (t_dst->type != GGML_TYPE_F32 || !ggml_is_contiguous(t_dst) || ne <= 0 ||
+    if (t_dst->type != GGML_TYPE_F32 || !ggml_is_contiguous(t_dst) || t_dst->nb[0] != sizeof(float) || ne <= 0 ||
             (uint64_t) ne > SIZE_MAX / sizeof(float) || nbytes != (size_t) ne * sizeof(float)) {
         GGML_LOG_ERROR("[%s] all-reduce tensor must be contiguous F32\n", __func__);
         return false;
@@ -2719,7 +2742,7 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
         }
     }
     size_t frame_bytes;
-    if (!checked_add_size(sizeof(request.op_id), wire_bytes, frame_bytes)) {
+    if (!checked_add_size(sizeof(rpc_comm_frame_header), wire_bytes, frame_bytes)) {
         GGML_LOG_ERROR("[%s] all-reduce frame size overflows\n", __func__);
         return false;
     }
@@ -2761,9 +2784,10 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
         send_frame = state.send_buf.data();
         recv_frame = state.recv_buf.data();
     }
-    memcpy(send_frame, &request.op_id, sizeof(request.op_id));
-    uint8_t * send_data = send_frame + sizeof(request.op_id);
-    uint8_t * recv_data = recv_frame + sizeof(request.op_id);
+    const rpc_comm_frame_header header = {request.op_id, round};
+    memcpy(send_frame, &header, sizeof(header));
+    uint8_t * send_data = send_frame + sizeof(header);
+    uint8_t * recv_data = recv_frame + sizeof(header);
 
     auto new_scratch_tensor = [&](ggml_type type, size_t offset) {
         ggml_tensor * t = ggml_new_tensor_4d(ctx, type, t_dst->ne[0], t_dst->ne[1], t_dst->ne[2], t_dst->ne[3]);
@@ -2808,24 +2832,24 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
 
     bool exchange_ok;
     if (wire_bytes >= RPC_COMM_FULL_DUPLEX_THRESHOLD) {
-        exchange_ok = state.peer->exchange_data(send_frame, recv_frame, frame_bytes);
-    } else if (state.rank == 0) {
-        exchange_ok = state.peer->send_data(send_frame, frame_bytes) &&
-                      state.peer->recv_data(recv_frame, frame_bytes);
+        exchange_ok = peer->exchange_data(send_frame, recv_frame, frame_bytes);
+    } else if ((state.rank & (uint32_t(1) << round)) == 0) {
+        exchange_ok = peer->send_data(send_frame, frame_bytes) &&
+                      peer->recv_data(recv_frame, frame_bytes);
     } else {
-        exchange_ok = state.peer->recv_data(recv_frame, frame_bytes) &&
-                      state.peer->send_data(send_frame, frame_bytes);
+        exchange_ok = peer->recv_data(recv_frame, frame_bytes) &&
+                      peer->send_data(send_frame, frame_bytes);
     }
     if (!exchange_ok) {
-        GGML_LOG_ERROR("[%s] peer exchange failed for operation %" PRIu64 "\n", __func__, request.op_id);
+        GGML_LOG_ERROR("[%s] peer exchange failed for operation %" PRIu64 " round %u\n", __func__, request.op_id, round);
         return false;
     }
 
-    uint64_t peer_op_id;
-    memcpy(&peer_op_id, recv_frame, sizeof(peer_op_id));
-    if (peer_op_id != request.op_id) {
-        GGML_LOG_ERROR("[%s] peer operation id %" PRIu64 " does not match %" PRIu64 "\n",
-                       __func__, peer_op_id, request.op_id);
+    rpc_comm_frame_header peer_header;
+    memcpy(&peer_header, recv_frame, sizeof(peer_header));
+    if (peer_header.op_id != request.op_id || peer_header.round != round) {
+        GGML_LOG_ERROR("[%s] unexpected peer operation %" PRIu64 " round %u, expected %" PRIu64 " round %u\n",
+                       __func__, peer_header.op_id, peer_header.round, request.op_id, round);
         return false;
     }
 
@@ -2851,7 +2875,6 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
     } else {
         compute_nodes(t_red, nullptr);
     }
-    state.next_op_id++;
     return true;
 }
 
@@ -3454,7 +3477,7 @@ static ggml_backend_dev_t ggml_backend_rpc_reg_get_device(ggml_backend_reg_t reg
     }
 }
 
-// Pairwise allreduce between two RPC servers over a direct server-to-server connection.
+// Recursive-doubling allreduce over direct server-to-server connections.
 // The client only sends fire-and-forget COMM_ALLREDUCE commands; the tensor data is
 // exchanged between the servers and never passes through the client.
 struct ggml_backend_rpc_comm_shared_context {
@@ -3488,9 +3511,10 @@ static void ggml_backend_rpc_comm_free(void * comm_ctx_v) {
 }
 
 static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_backends) {
-    if (n_backends != 2 || std::getenv("GGML_RPC_NO_COMM") != nullptr) {
-        if (n_backends != 2) {
-            GGML_LOG_WARN("RPC all-reduce currently only supports 2 ranks, falling back to slow all-reduce\n");
+    if (n_backends < 2 || n_backends > UINT32_MAX || (n_backends & (n_backends - 1)) != 0 ||
+            std::getenv("GGML_RPC_NO_COMM") != nullptr) {
+        if (n_backends > 1 && (n_backends & (n_backends - 1)) != 0) {
+            GGML_LOG_WARN("RPC all-reduce requires a power-of-two rank count, falling back to slow all-reduce\n");
         }
         return nullptr;
     }
@@ -3530,94 +3554,99 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
     auto it = registry.find(key);
     if (it != registry.end()) {
         if (auto shared = it->second.lock()) {
-            GGML_LOG_INFO("%s: reusing pairwise communicator (%s <-> %s)\n", __func__,
-                          ranks[0].endpoint.c_str(), ranks[1].endpoint.c_str());
+            GGML_LOG_INFO("%s: reusing butterfly communicator (%zu ranks)\n", __func__, n_backends);
             return new ggml_backend_rpc_comm_context{std::move(shared)};
         }
     }
 
-    // rank 1 connects to rank 0 on its serving host; endpoints must be mutually reachable
-    // (e.g. do not bind the servers to 127.0.0.1 when they run on different machines)
-    std::string host0;
-    int port0;
-    if (!parse_endpoint(ranks[0].endpoint, host0, port0)) {
-        return nullptr;
-    }
-    if (host0.size() >= 64) {
-        return nullptr;
-    }
-
-    uint32_t comm_port = 0;
+    // Each lower rank listens on its own communication port. Reuse that port
+    // across rounds; only the accepted peer sockets remain open between rounds.
+    uint32_t port_base = 0;
     if (const char * env = std::getenv("GGML_RPC_COMM_PORT")) {
         char * end = nullptr;
         const unsigned long parsed = std::strtoul(env, &end, 10);
-        if (end == env || *end != '\0' || parsed == 0 || parsed > 65535) {
-            GGML_LOG_WARN("%s: invalid GGML_RPC_COMM_PORT '%s'\n", __func__, env);
+        if (end == env || *end != '\0' || parsed == 0 || parsed > 65535 ||
+                n_backends - 2 > 65535 - parsed) {
+            GGML_LOG_WARN("%s: invalid GGML_RPC_COMM_PORT '%s' for %zu ranks\n", __func__, env, n_backends);
             return nullptr;
         }
-        comm_port = (uint32_t) parsed;
-    } else if (port0 <= 0 || port0 > 65535 - 1000) {
-        GGML_LOG_WARN("%s: RPC port %d + 1000 is out of range; set GGML_RPC_COMM_PORT\n", __func__, port0);
-        return nullptr;
-    } else {
-        comm_port = (uint32_t) port0 + 1000;
+        port_base = (uint32_t) parsed;
+    }
+    std::vector<std::string> hosts(n_backends);
+    std::vector<uint32_t> ports(n_backends);
+    // The highest rank always connects; no peer needs its host or listener port.
+    for (size_t i = 0; i + 1 < n_backends; i++) {
+        int rpc_port;
+        if (!parse_endpoint(ranks[i].endpoint, hosts[i], rpc_port) || hosts[i].size() >= 64) {
+            return nullptr;
+        }
+        if (port_base == 0 && (rpc_port <= 0 || rpc_port > 65535 - 1000)) {
+            GGML_LOG_WARN("%s: RPC port %d + 1000 is out of range; set GGML_RPC_COMM_PORT\n", __func__, rpc_port);
+            return nullptr;
+        }
+        ports[i] = port_base != 0 ? port_base + (uint32_t) i : (uint32_t) rpc_port + 1000;
     }
 
-    std::array<uint8_t, RPC_COMM_SESSION_ID_SIZE> session_id;
-    if (!fill_secure_random(session_id.data(), session_id.size())) {
-        GGML_LOG_WARN("%s: failed to generate communicator session id\n", __func__);
-        return nullptr;
-    }
-
-    // Submit all init requests before waiting for any response: rank 0 blocks in accept
-    // until rank 1 has connected.
-    std::vector<std::shared_ptr<rpc_completion>> completions;
-    completions.reserve(n_backends);
-    for (size_t i = 0; i < n_backends; i++) {
-        rpc_msg_comm_init_req request = {};
-        request.device    = ranks[i].device;
-        request.rank      = (uint32_t) i;
-        request.world     = (uint32_t) n_backends;
-        request.port      = comm_port;
-        request.wire_bf16 = wire_bf16;
-        memcpy(request.session_id, session_id.data(), session_id.size());
-        if (i > 0) {
-            memcpy(request.host, host0.c_str(), host0.size());
-        }
-        completions.push_back(ranks[i].cmd_queue->submit_rpc_deferred_owned(
-            RPC_CMD_COMM_INIT, &request, sizeof(request), sizeof(rpc_msg_comm_init_rsp)));
-    }
-    auto completion_ok = [](const std::shared_ptr<rpc_completion> & completion) {
-        if (!completion->wait() || completion->response.size() != sizeof(rpc_msg_comm_init_rsp)) {
-            return false;
-        }
-        rpc_msg_comm_init_rsp response;
-        memcpy(&response, completion->response.data(), sizeof(response));
-        return response.ok != 0;
-    };
-
-    bool ok = true;
-    std::array<bool, 2> initialized = {};
-    // wait on rank 1 first: rank 0 only replies once rank 1 has connected to it
-    for (size_t i = n_backends; i-- > 0;) {
-        initialized[i] = completion_ok(completions[i]);
-        if (!initialized[i]) {
-            GGML_LOG_WARN("%s: rank %zu (%s) failed to initialize\n", __func__, i, ranks[i].endpoint.c_str());
-            ok = false;
-        }
-    }
-    if (!ok) {
+    std::vector<bool> initialized(n_backends, false);
+    auto cleanup = [&]() {
         for (size_t i = 0; i < n_backends; i++) {
-            if (!initialized[i]) {
-                continue;
+            if (initialized[i]) {
+                rpc_msg_comm_free_req request = {ranks[i].device};
+                ranks[i].cmd_queue->submit_rpc(RPC_CMD_COMM_FREE, &request, sizeof(request));
             }
-            rpc_msg_comm_free_req request = {ranks[i].device};
-            ranks[i].cmd_queue->submit_rpc(RPC_CMD_COMM_FREE, &request, sizeof(request));
         }
-        return nullptr;
+    };
+    uint32_t round = 0;
+    for (size_t mask = 1; mask < n_backends; mask <<= 1, round++) {
+        // A separate secret per edge and round rejects stale or misrouted peers.
+        std::vector<std::array<uint8_t, RPC_COMM_SESSION_ID_SIZE>> sessions(n_backends);
+        for (size_t i = 0; i < n_backends; i++) {
+            if ((i & mask) == 0 && !fill_secure_random(sessions[i].data(), sessions[i].size())) {
+                GGML_LOG_WARN("%s: failed to generate communicator session id\n", __func__);
+                cleanup();
+                return nullptr;
+            }
+        }
+
+        // Submit the entire round before waiting: lower ranks block in accept.
+        std::vector<std::shared_ptr<rpc_completion>> completions;
+        completions.reserve(n_backends);
+        for (size_t i = 0; i < n_backends; i++) {
+            const size_t listener = i & ~mask;
+            rpc_msg_comm_init_req request = {};
+            request.device    = ranks[i].device;
+            request.rank      = (uint32_t) i;
+            request.world     = (uint32_t) n_backends;
+            request.round     = round;
+            request.port      = ports[listener];
+            request.wire_bf16 = wire_bf16;
+            memcpy(request.session_id, sessions[listener].data(), sessions[listener].size());
+            memcpy(request.host, hosts[listener].c_str(), hosts[listener].size());
+            completions.push_back(ranks[i].cmd_queue->submit_rpc_deferred_owned(
+                RPC_CMD_COMM_INIT, &request, sizeof(request), sizeof(rpc_msg_comm_init_rsp)));
+        }
+        bool ok = true;
+        for (size_t i = n_backends; i-- > 0;) {
+            const auto & completion = completions[i];
+            rpc_msg_comm_init_rsp response = {};
+            if (completion->wait() && completion->response.size() == sizeof(response)) {
+                memcpy(&response, completion->response.data(), sizeof(response));
+            }
+            if (response.ok) {
+                initialized[i] = true;
+            } else {
+                GGML_LOG_WARN("%s: rank %zu (%s) failed to initialize round %u\n",
+                              __func__, i, ranks[i].endpoint.c_str(), round);
+                ok = false;
+            }
+        }
+        if (!ok) {
+            cleanup();
+            return nullptr;
+        }
     }
-    GGML_LOG_INFO("%s: pairwise communicator initialized (%s <-> %s)\n", __func__,
-                  ranks[0].endpoint.c_str(), ranks[1].endpoint.c_str());
+    GGML_LOG_INFO("%s: butterfly communicator initialized (%zu ranks, %u rounds)\n",
+                  __func__, n_backends, round);
     auto shared = std::make_shared<ggml_backend_rpc_comm_shared_context>();
     shared->ranks = std::move(ranks);
     registry[key] = shared;
@@ -3632,13 +3661,13 @@ static bool ggml_backend_rpc_comm_allreduce_tensor(void * comm_ctx_v, ggml_tenso
     auto shared = comm_ctx->shared;
     std::lock_guard<std::mutex> lock(shared->mutex);
     const size_t n_ranks = shared->ranks.size();
-    const int64_t ne = ggml_nelements(tensors[0]);
-    if (ne == 0) {
-        return true;
+    if (tensors == nullptr || tensors[0] == nullptr) {
+        return false;
     }
+    const int64_t ne = ggml_nelements(tensors[0]);
     for (size_t i = 0; i < n_ranks; i++) {
         if (tensors[i] == nullptr || tensors[i]->type != GGML_TYPE_F32 || ggml_nelements(tensors[i]) != ne ||
-                !ggml_is_contiguous(tensors[i]) ||
+                !ggml_is_contiguous(tensors[i]) || tensors[i]->nb[0] != sizeof(float) ||
                 tensors[i]->buffer == nullptr || !ggml_backend_buffer_is_rpc(tensors[i]->buffer)) {
             return false;
         }
@@ -3647,6 +3676,9 @@ static bool ggml_backend_rpc_comm_allreduce_tensor(void * comm_ctx_v, ggml_tenso
         if ((tensors[i]->flags & GGML_TENSOR_FLAG_COMPUTE) == 0) {
             return false;
         }
+    }
+    if (ne == 0) {
+        return true;
     }
     const uint64_t op_id = shared->next_op_id;
     for (size_t i = 0; i < n_ranks; i++) {

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1616,14 +1616,19 @@ static ggml_backend_i ggml_backend_rpc_interface = {
 };
 
 ggml_backend_buffer_type_t ggml_backend_rpc_buffer_type(const char * endpoint, uint32_t device) {
+    struct buffer_type_owner {
+        ggml_backend_rpc_buffer_type_context context;
+        ggml_backend_buffer_type             buffer_type;
+    };
     static std::mutex mutex;
     std::lock_guard<std::mutex> lock(mutex);
     std::string buft_name = "RPC" + std::to_string(device) + "[" + std::string(endpoint) + "]";
-    // NOTE: buffer types are allocated and never freed; this is by design
-    static std::unordered_map<std::string, ggml_backend_buffer_type_t> buft_map;
+    // Callers borrow stable pointers for the cache's lifetime. Reclaim the
+    // metadata at shutdown without touching devices or making RPC calls.
+    static std::unordered_map<std::string, std::unique_ptr<buffer_type_owner>> buft_map;
     auto it = buft_map.find(buft_name);
     if (it != buft_map.end()) {
-        return it->second;
+        return &it->second->buffer_type;
     }
     auto cmd_queue = get_command_queue(endpoint);
     if (cmd_queue == nullptr) {
@@ -1632,7 +1637,8 @@ ggml_backend_buffer_type_t ggml_backend_rpc_buffer_type(const char * endpoint, u
     }
     size_t                                 alignment = get_alignment(cmd_queue, device);
     size_t                                 max_size  = get_max_size(cmd_queue, device);
-    ggml_backend_rpc_buffer_type_context * buft_ctx = new ggml_backend_rpc_buffer_type_context {
+    auto owner = std::make_unique<buffer_type_owner>();
+    owner->context = {
         /* .endpoint  = */ endpoint,
         /* .device    = */ device,
         /* .name      = */ buft_name,
@@ -1640,12 +1646,13 @@ ggml_backend_buffer_type_t ggml_backend_rpc_buffer_type(const char * endpoint, u
         /* .max_size  = */ max_size
     };
     auto reg = ggml_backend_rpc_add_server(endpoint);
-    ggml_backend_buffer_type_t buft = new ggml_backend_buffer_type {
+    owner->buffer_type = {
         /* .iface   = */ ggml_backend_rpc_buffer_type_interface,
         /* .device  = */ ggml_backend_reg_dev_get(reg, device),
-        /* .context = */ buft_ctx
+        /* .context = */ &owner->context
     };
-    buft_map[buft_name] = buft;
+    ggml_backend_buffer_type_t buft = &owner->buffer_type;
+    buft_map.emplace(buft_name, std::move(owner));
     return buft;
 }
 
@@ -3764,24 +3771,38 @@ bool ggml_backend_rpc_prefetch_connection(const char * endpoint) {
 }
 
 ggml_backend_reg_t ggml_backend_rpc_add_server(const char * endpoint) {
-    static std::unordered_map<std::string, ggml_backend_reg_t> reg_map;
+    struct device_owner {
+        ggml_backend_rpc_device_context context;
+        ggml_backend_device             device;
+    };
+    struct reg_owner {
+        ggml_backend_rpc_reg_context                context;
+        std::vector<std::unique_ptr<device_owner>> devices;
+        ggml_backend_reg                           reg;
+    };
+    // The API exposes borrowed registry/device pointers. Keep their addresses
+    // stable while cached, and destroy all owned metadata at shutdown. These
+    // destructors do not depend on the buffer-type or connection caches.
+    static std::unordered_map<std::string, std::unique_ptr<reg_owner>> reg_map;
     static std::mutex mutex;
     static uint32_t dev_id = 0;
     std::lock_guard<std::mutex> lock(mutex);
-    if (reg_map.find(endpoint) != reg_map.end()) {
+    auto it = reg_map.find(endpoint);
+    if (it != reg_map.end()) {
         release_prefetched_command_queue(endpoint);
-        return reg_map[endpoint];
+        return &it->second->reg;
     }
     uint32_t dev_count = ggml_backend_rpc_get_device_count(endpoint);
     if (dev_count == 0) {
         return nullptr;
     }
-    ggml_backend_rpc_reg_context * ctx = new ggml_backend_rpc_reg_context;
-    ctx->name = "RPC[" + std::string(endpoint) + "]";
+    auto owner = std::make_unique<reg_owner>();
+    owner->context.name = "RPC[" + std::string(endpoint) + "]";
     for (uint32_t ind = 0; ind < dev_count; ind++) {
         std::string dev_name = "RPC" + std::to_string(dev_id);
         std::string dev_desc = std::string(endpoint);
-        ggml_backend_rpc_device_context * dev_ctx = new ggml_backend_rpc_device_context {
+        auto device = std::make_unique<device_owner>();
+        device->context = {
             /* .endpoint    = */    endpoint,
             /* .device      = */    ind,
             /* .name        = */    dev_name,
@@ -3789,20 +3810,22 @@ ggml_backend_reg_t ggml_backend_rpc_add_server(const char * endpoint) {
             /* .graph_uids  = */    {},
         };
 
-        ggml_backend_dev_t dev = new ggml_backend_device {
+        device->device = {
             /* .iface   = */ ggml_backend_rpc_device_i,
             /* .reg     = */ ggml_backend_rpc_reg(),
-            /* .context = */ dev_ctx,
+            /* .context = */ &device->context,
         };
-        ctx->devices.push_back(dev);
+        owner->context.devices.push_back(&device->device);
+        owner->devices.push_back(std::move(device));
         dev_id++;
     }
-    ggml_backend_reg_t reg = new ggml_backend_reg {
+    owner->reg = {
         /* .api_version = */ GGML_BACKEND_API_VERSION,
         /* .iface       = */ ggml_backend_rpc_reg_interface,
-        /* .context     = */ ctx
+        /* .context     = */ &owner->context
     };
-    reg_map[endpoint] = reg;
+    ggml_backend_reg_t reg = &owner->reg;
+    reg_map.emplace(endpoint, std::move(owner));
     return reg;
 }
 

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -664,6 +664,8 @@ class rpc_command_queue {
     }
 
     bool submit_rpc(rpc_cmd command, const void * input, size_t input_size) {
+        // Own the payload before returning. Transport failures poison the queue
+        // and are reported by the next synchronization, readback, or submission.
         rpc_queue_cmd queue_cmd;
         queue_cmd.command = command;
         if (input_size > 0) {
@@ -673,17 +675,18 @@ class rpc_command_queue {
         return enqueue(std::move(queue_cmd));
     }
 
-    bool submit_rpc_checked(rpc_cmd command, const void * input, size_t input_size) {
-        auto          completion = std::make_shared<rpc_completion>();
-        rpc_queue_cmd queue_cmd;
-        queue_cmd.command    = command;
-        queue_cmd.completion = completion;
-        if (input_size > 0) {
-            queue_cmd.data.resize(input_size);
-            memcpy(queue_cmd.data.data(), input, input_size);
+    void busy_spin_acquire() {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            busy_spin_users++;
         }
-        enqueue(std::move(queue_cmd));
-        return completion->wait();
+        cv.notify_one();
+    }
+
+    void busy_spin_release() {
+        std::lock_guard<std::mutex> lock(mutex);
+        GGML_ASSERT(busy_spin_users > 0);
+        busy_spin_users--;
     }
 
     std::shared_ptr<rpc_completion> submit_rpc_deferred(rpc_cmd      command,
@@ -887,9 +890,22 @@ class rpc_command_queue {
             rpc_queue_cmd cmd;
             {
                 std::unique_lock<std::mutex> lock(mutex);
-                cv.wait(lock, [this] { return shutdown || !commands.empty(); });
+                if (busy_spin_users == 0) {
+                    cv.wait(lock, [this] { return shutdown || !commands.empty() || busy_spin_users != 0; });
+                }
                 if (shutdown && commands.empty()) {
                     return;
+                }
+                if (commands.empty()) {
+                    lock.unlock();
+#if defined(__aarch64__) && (defined(__clang__) || defined(__GNUC__))
+                    __asm__ volatile("yield" ::: "memory");
+#elif (defined(__x86_64__) || defined(__i386__)) && (defined(__clang__) || defined(__GNUC__))
+                    __asm__ volatile("pause" ::: "memory");
+#else
+                    std::this_thread::yield();
+#endif
+                    continue;
                 }
                 cmd = std::move(commands.front());
                 commands.pop_front();
@@ -921,6 +937,7 @@ class rpc_command_queue {
     std::deque<rpc_queue_cmd>                 commands;
     bool                                      shutdown = false;
     bool                                      failed   = false;
+    unsigned                                  busy_spin_users = 0; // protected by mutex
     std::mutex                                submit_mutex;
     std::mutex                                alloc_cache_mutex;
     std::unordered_map<std::string, uint64_t> alloc_cache;
@@ -1473,20 +1490,20 @@ static enum ggml_status ggml_backend_rpc_graph_compute(ggml_backend_t backend, g
         rpc_msg_graph_recompute_req request;
         request.device = rpc_ctx->device;
         request.uid    = cgraph->uid;
-        if (!rpc_ctx->cmd_queue->submit_rpc_checked(RPC_CMD_GRAPH_RECOMPUTE, &request, sizeof(request))) {
+        if (!rpc_ctx->cmd_queue->submit_rpc(RPC_CMD_GRAPH_RECOMPUTE, &request, sizeof(request))) {
             return GGML_STATUS_FAILED;
         }
     } else {
+        std::vector<uint8_t> input;
+        serialize_graph(rpc_ctx->device, cgraph, rpc_ctx->cmd_queue, input);
+        if (!rpc_ctx->cmd_queue->submit_rpc(RPC_CMD_GRAPH_COMPUTE, input.data(), input.size())) {
+            return GGML_STATUS_FAILED;
+        }
         if (cgraph->uid != 0) {
             if (graph_uids.size() >= GRAPH_CACHE_MAX) {
                 graph_uids.clear();
             }
             graph_uids.insert(cgraph->uid);
-        }
-        std::vector<uint8_t> input;
-        serialize_graph(rpc_ctx->device, cgraph, rpc_ctx->cmd_queue, input);
-        if (!rpc_ctx->cmd_queue->submit_rpc_checked(RPC_CMD_GRAPH_COMPUTE, input.data(), input.size())) {
-            return GGML_STATUS_FAILED;
         }
     }
     return GGML_STATUS_SUCCESS;
@@ -3496,11 +3513,15 @@ struct ggml_backend_rpc_comm_shared_context {
     std::vector<rank_info> ranks;
     std::mutex mutex;
     uint64_t next_op_id = 0;
+    bool busy_spin = false;
 
     ~ggml_backend_rpc_comm_shared_context() {
         for (const auto & rank : ranks) {
             rpc_msg_comm_free_req request = {rank.device};
             rank.cmd_queue->submit_rpc(RPC_CMD_COMM_FREE, &request, sizeof(request));
+            if (busy_spin) {
+                rank.cmd_queue->busy_spin_release();
+            }
         }
     }
 };
@@ -3656,6 +3677,14 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
                   __func__, n_backends, round);
     auto shared = std::make_shared<ggml_backend_rpc_comm_shared_context>();
     shared->ranks = std::move(ranks);
+    // Acquire only after successful initialization, once per shared communicator.
+    // Reused handles keep polling alive until the final handle is released.
+    shared->busy_spin = std::getenv("GGML_RPC_NO_BUSY_SPIN") == nullptr;
+    if (shared->busy_spin) {
+        for (const auto & rank : shared->ranks) {
+            rank.cmd_queue->busy_spin_acquire();
+        }
+    }
     registry[key] = shared;
     return new ggml_backend_rpc_comm_context{std::move(shared)};
 }
@@ -3693,7 +3722,7 @@ static bool ggml_backend_rpc_comm_allreduce_tensor(void * comm_ctx_v, ggml_tenso
         request.device = shared->ranks[i].device;
         request.op_id   = op_id;
         request.tensor = serialize_tensor(tensors[i]);
-        if (!shared->ranks[i].cmd_queue->submit_rpc_checked(RPC_CMD_COMM_ALLREDUCE, &request, sizeof(request))) {
+        if (!shared->ranks[i].cmd_queue->submit_rpc(RPC_CMD_COMM_ALLREDUCE, &request, sizeof(request))) {
             if (i == 0) {
                 return false;
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -345,10 +345,6 @@ if (GGML_RPC)
                 ${CMAKE_CURRENT_SOURCE_DIR}/test_rpc_allreduce.py
                 --server $<TARGET_FILE:ggml-rpc-server> ${ARGN})
             set_tests_properties(${name} PROPERTIES TIMEOUT 150 LABELS "rpc")
-            if (LLAMA_SANITIZE_ADDRESS OR GGML_SANITIZE_ADDRESS)
-                set_tests_properties(${name} PROPERTIES ENVIRONMENT
-                    "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/test-rpc-lsan.supp")
-            endif()
         endfunction()
         foreach(ranks 2 4 8)
             foreach(wire f32 bf16)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -334,6 +334,37 @@ endif()
 if (GGML_RPC)
     llama_build_and_test(test-rpc.cpp)
     set_tests_properties(test-rpc PROPERTIES SKIP_RETURN_CODE 77 TIMEOUT 120)
+
+    add_executable(test-rpc-allreduce test-rpc-allreduce.cpp)
+    target_link_libraries(test-rpc-allreduce PRIVATE ggml)
+    target_compile_features(test-rpc-allreduce PRIVATE cxx_std_17)
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+    if (Python3_Interpreter_FOUND AND LLAMA_BUILD_TOOLS AND GGML_CPU AND NOT EMSCRIPTEN)
+        function(rpc_allreduce_test name)
+            add_test(NAME ${name} COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/test_rpc_allreduce.py
+                --server $<TARGET_FILE:ggml-rpc-server> ${ARGN})
+            set_tests_properties(${name} PROPERTIES TIMEOUT 150 LABELS "rpc")
+            if (LLAMA_SANITIZE_ADDRESS OR GGML_SANITIZE_ADDRESS)
+                set_tests_properties(${name} PROPERTIES ENVIRONMENT
+                    "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/test-rpc-lsan.supp")
+            endif()
+        endfunction()
+        foreach(ranks 2 4 8)
+            foreach(wire f32 bf16)
+                rpc_allreduce_test(test-rpc-allreduce-${ranks}-${wire}
+                    --client $<TARGET_FILE:test-rpc-allreduce> --ranks ${ranks} --wire ${wire})
+            endforeach()
+        endforeach()
+        rpc_allreduce_test(test-rpc-allreduce-port-base
+            --client $<TARGET_FILE:test-rpc-allreduce> --ranks 4 --port-base)
+        rpc_allreduce_test(test-rpc-allreduce-init-failure
+            --client $<TARGET_FILE:test-rpc-allreduce> --ranks 4 --init-failure)
+        rpc_allreduce_test(test-rpc-allreduce-disabled
+            --client $<TARGET_FILE:test-rpc-allreduce> --ranks 4 --disabled)
+        rpc_allreduce_test(test-rpc-local
+            --client $<TARGET_FILE:test-rpc> --ranks 2 --wire bf16 --legacy)
+    endif()
 endif()
 
 # Vulkan TBQ/PQ copy-to-quant subgroup-size sweep. Spawns itself with different

--- a/tests/test-rpc-allreduce.cpp
+++ b/tests/test-rpc-allreduce.cpp
@@ -1,0 +1,213 @@
+#include "ggml-backend.h"
+#include "ggml-cpp.h"
+#include "ggml.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <random>
+#include <vector>
+
+// Invoke the communicator directly: these tests must never pass through fallback.
+static bool reduce_and_check(ggml_backend_comm_allreduce_tensor_t allreduce, void * comm,
+                             const std::vector<ggml_backend_t> & backends, size_t count, bool random_input) {
+    const size_t world = backends.size();
+    std::vector<ggml_context_ptr> contexts;
+    std::vector<ggml_backend_buffer_ptr> buffers;
+    std::vector<ggml_tensor *> tensors;
+    std::vector<double> expected(count, 0.0), magnitude(count, 0.0);
+    std::vector<float> data(count);
+    std::mt19937 rng(1234);
+    std::uniform_real_distribution<float> distribution(-1.0f, 1.0f);
+    for (size_t rank = 0; rank < world; rank++) {
+        ggml_init_params params = {ggml_tensor_overhead(), nullptr, true};
+        contexts.emplace_back(ggml_init(params));
+        if (!contexts.back()) {
+            return false;
+        }
+        tensors.push_back(ggml_new_tensor_1d(contexts.back().get(), GGML_TYPE_F32, count));
+        buffers.emplace_back(ggml_backend_alloc_ctx_tensors(contexts.back().get(), backends[rank]));
+        if (!buffers.back()) {
+            return false;
+        }
+        tensors.back()->flags |= GGML_TENSOR_FLAG_COMPUTE;
+        for (size_t j = 0; j < count; j++) {
+            data[j] = random_input ? distribution(rng) : float(rank + 1);
+            expected[j] += data[j];
+            magnitude[j] += std::fabs(data[j]);
+        }
+        ggml_backend_tensor_set(tensors.back(), data.data(), 0, count * sizeof(float));
+    }
+
+    // Rejection must happen before dispatch and must not advance the operation ID.
+    if (allreduce(comm, nullptr)) {
+        return false;
+    }
+    ggml_tensor * first = tensors[0];
+    tensors[0] = nullptr;
+    if (allreduce(comm, tensors.data())) {
+        return false;
+    }
+    tensors[0] = first;
+    tensors.back()->flags &= ~GGML_TENSOR_FLAG_COMPUTE;
+    if (allreduce(comm, tensors.data())) {
+        return false;
+    }
+    tensors.back()->flags |= GGML_TENSOR_FLAG_COMPUTE;
+    tensors.back()->type = GGML_TYPE_F16;
+    if (allreduce(comm, tensors.data())) {
+        return false;
+    }
+    tensors.back()->type = GGML_TYPE_F32;
+    tensors.back()->ne[0]++;
+    if (allreduce(comm, tensors.data())) {
+        return false;
+    }
+    tensors.back()->ne[0]--;
+    tensors.back()->nb[0] *= 2;
+    if (allreduce(comm, tensors.data())) {
+        return false;
+    }
+    tensors.back()->nb[0] /= 2;
+    for (auto * tensor : tensors) {
+        tensor->ne[0] = 0;
+    }
+    if (!allreduce(comm, tensors.data())) {
+        return false;
+    }
+    for (auto * tensor : tensors) {
+        tensor->ne[0] = count;
+    }
+
+    if (!allreduce(comm, tensors.data())) {
+        fprintf(stderr, "direct all-reduce rejected %zu ranks / %zu elements\n", world, count);
+        return false;
+    }
+    // Queue a second reduction without a client-side barrier to check ordering.
+    const int repeats = random_input ? 1 : 2;
+    if (repeats == 2 && !allreduce(comm, tensors.data())) {
+        return false;
+    }
+    const bool bf16 = std::getenv("GGML_RPC_NO_WIRE_BF16") == nullptr && count >= 32768;
+    const double tolerance = bf16 ? 0.004 * std::log2(double(world)) : 1e-6;
+    std::vector<float> rank_zero;
+    for (size_t rank = 0; rank < world; rank++) {
+        ggml_backend_synchronize(backends[rank]);
+        ggml_backend_tensor_get(tensors[rank], data.data(), 0, count * sizeof(float));
+        for (size_t j = 0; j < count; j++) {
+            const double target = expected[j] * (repeats == 2 ? world : 1);
+            const double bound = random_input ? tolerance * magnitude[j] + 1e-6 : 0.0;
+            if (!std::isfinite(data[j]) || std::fabs(data[j] - target) > bound ||
+                    (rank > 0 && data[j] != rank_zero[j])) {
+                fprintf(stderr, "rank %zu element %zu/%zu: got %.9g, expected %.9g (bound %.9g)\n",
+                        rank, j, count, data[j], target, bound);
+                return false;
+            }
+        }
+        if (rank == 0) {
+            rank_zero = data;
+        }
+    }
+    return true;
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s HOST:PORT HOST:PORT [HOST:PORT ...]\n", argv[0]);
+        return 1;
+    }
+    ggml_backend_load_all();
+    ggml_backend_reg_t reg = ggml_backend_reg_by_name("RPC");
+    if (!reg) {
+        return 1;
+    }
+    auto add_server = (ggml_backend_reg_t (*)(const char *)) ggml_backend_reg_get_proc_address(
+        reg, "ggml_backend_rpc_add_server");
+    auto init = (ggml_backend_comm_init_t) ggml_backend_reg_get_proc_address(reg, "ggml_backend_comm_init");
+    auto free = (ggml_backend_comm_free_t) ggml_backend_reg_get_proc_address(reg, "ggml_backend_comm_free");
+    auto allreduce = (ggml_backend_comm_allreduce_tensor_t) ggml_backend_reg_get_proc_address(
+        reg, "ggml_backend_comm_allreduce_tensor");
+    if (!add_server || !init || !free || !allreduce) {
+        return 1;
+    }
+    std::vector<ggml_backend_ptr> owners;
+    std::vector<ggml_backend_t> backends;
+    for (int i = 1; i < argc; i++) {
+        ggml_backend_reg_t server = add_server(argv[i]);
+        if (!server || ggml_backend_reg_dev_count(server) == 0) {
+            return 1;
+        }
+        owners.emplace_back(ggml_backend_dev_init(ggml_backend_reg_dev_get(server, 0), nullptr));
+        if (!owners.back()) {
+            return 1;
+        }
+        backends.push_back(owners.back().get());
+    }
+    const size_t world = backends.size();
+    if (std::getenv("GGML_RPC_NO_COMM")) {
+        if (init(backends.data(), world) != nullptr) {
+            return 1;
+        }
+        printf("RPC communicator disabled as requested\n");
+        return 0;
+    }
+    if (std::getenv("GGML_RPC_TEST_INIT_FAILURE")) {
+        // The runner blocks rank 1's listener, which is first used in round 1.
+        // Repeat on the same client connections to check partial-init cleanup.
+        for (int attempt = 0; attempt < 2; attempt++) {
+            if (init(backends.data(), world) != nullptr) {
+                fprintf(stderr, "expected communicator initialization failure\n");
+                return 1;
+            }
+        }
+        backends.resize(2);
+        void * comm = init(backends.data(), backends.size());
+        if (!comm || !reduce_and_check(allreduce, comm, backends, 7, false)) {
+            fprintf(stderr, "communicator did not recover after partial initialization\n");
+            return 1;
+        }
+        free(comm);
+        printf("RPC partial initialization cleanup passed\n");
+        return 0;
+    }
+    if (init(backends.data(), 0) || init(backends.data(), 1)) {
+        return 1;
+    }
+    if (world >= 4 && init(backends.data(), 3)) {
+        return 1;
+    }
+    ggml_backend_t duplicate[2] = {backends[0], backends[0]};
+    if (init(duplicate, 2)) {
+        return 1;
+    }
+
+    void * comm = init(backends.data(), world);
+    void * reused = init(backends.data(), world);
+    if (!comm || !reused) {
+        fprintf(stderr, "failed to initialize/reuse %zu-rank communicator\n", world);
+        return 1;
+    }
+    for (size_t count : {size_t(1), size_t(7), size_t(16383), size_t(16384), size_t(32767),
+                         size_t(32768), size_t(32769), size_t(262145)}) {
+        if (!reduce_and_check(allreduce, comm, backends, count, false) ||
+                !reduce_and_check(allreduce, reused, backends, count, true)) {
+            return 1;
+        }
+    }
+    free(comm);
+    if (!reduce_and_check(allreduce, reused, backends, 32769, true)) {
+        return 1;
+    }
+    free(reused);
+    comm = init(backends.data(), world);
+    if (!comm || !reduce_and_check(allreduce, comm, backends, 7, false)) {
+        return 1;
+    }
+    free(comm);
+    for (auto backend : backends) {
+        ggml_backend_synchronize(backend);
+    }
+    printf("RPC butterfly all-reduce passed (%zu ranks)\n", world);
+    return 0;
+}

--- a/tests/test-rpc-allreduce.cpp
+++ b/tests/test-rpc-allreduce.cpp
@@ -205,6 +205,36 @@ int main(int argc, char ** argv) {
         return 1;
     }
     free(comm);
+    // Cached device and buffer-type pointers outlive individual backends and
+    // communicators. Reconnect using those borrowed pointers after releasing
+    // every backend, then let LeakSanitizer check cache destruction at exit.
+    std::vector<ggml_backend_dev_t> devices;
+    std::vector<ggml_backend_buffer_type_t> buffer_types;
+    for (auto backend : backends) {
+        ggml_backend_synchronize(backend);
+        devices.push_back(ggml_backend_get_device(backend));
+        buffer_types.push_back(ggml_backend_get_default_buffer_type(backend));
+    }
+    backends.clear();
+    owners.clear();
+    for (size_t rank = 0; rank < world; rank++) {
+        ggml_backend_reg_t server = add_server(argv[rank + 1]);
+        if (!server || ggml_backend_reg_dev_get(server, 0) != devices[rank] ||
+                ggml_backend_dev_buffer_type(devices[rank]) != buffer_types[rank]) {
+            fprintf(stderr, "cached RPC metadata changed after releasing backends\n");
+            return 1;
+        }
+        owners.emplace_back(ggml_backend_dev_init(devices[rank], nullptr));
+        if (!owners.back()) {
+            return 1;
+        }
+        backends.push_back(owners.back().get());
+    }
+    comm = init(backends.data(), world);
+    if (!comm || !reduce_and_check(allreduce, comm, backends, 7, false)) {
+        return 1;
+    }
+    free(comm);
     for (auto backend : backends) {
         ggml_backend_synchronize(backend);
     }

--- a/tests/test-rpc-lsan.supp
+++ b/tests/test-rpc-lsan.supp
@@ -1,4 +1,0 @@
-# RPC intentionally retains buffer types and endpoint registrations for the
-# process lifetime. Suppress only those factories, not communicator allocations.
-leak:ggml_backend_rpc_buffer_type
-leak:ggml_backend_rpc_add_server

--- a/tests/test-rpc-lsan.supp
+++ b/tests/test-rpc-lsan.supp
@@ -1,0 +1,4 @@
+# RPC intentionally retains buffer types and endpoint registrations for the
+# process lifetime. Suppress only those factories, not communicator allocations.
+leak:ggml_backend_rpc_buffer_type
+leak:ggml_backend_rpc_add_server

--- a/tests/test-rpc.cpp
+++ b/tests/test-rpc.cpp
@@ -1,6 +1,7 @@
 #include "ggml-backend.h"
 #include "ggml-cpp.h"
 #include "ggml.h"
+#include "../ggml/src/ggml-impl.h"
 
 #include <algorithm>
 #include <chrono>
@@ -195,6 +196,7 @@ int main() {
     ggml_tensor * result_a = ggml_scale(ctx_a.get(), tensor_a, 2.0f);
     ggml_cgraph * graph    = ggml_new_graph_custom(ctx_a.get(), 16, false);
     ggml_build_forward_expand(graph, result_a);
+    graph->uid = ggml_graph_next_uid(); // exercise queued GRAPH_COMPUTE followed by GRAPH_RECOMPUTE
     ggml_cgraph * foreign_graph = ggml_new_graph_custom(ctx_a.get(), 1, false);
     ggml_graph_add_node(foreign_graph, tensor_a);
 
@@ -249,6 +251,7 @@ int main() {
     }
 
     std::vector<float> input(ggml_nelements(tensor_a));
+    std::vector<std::vector<float>> queued_results(8, std::vector<float>(ggml_nelements(result_a)));
     for (int iteration = 0; iteration < 8; iteration++) {
         ggml_backend_event_t event = events[iteration % 4];
         ggml_backend_event_synchronize(event);
@@ -257,9 +260,18 @@ int main() {
         if (ggml_backend_graph_compute_async(backend_a.get(), graph) != GGML_STATUS_SUCCESS) {
             return 1;
         }
+        ggml_backend_tensor_get_async(backend_a.get(), result_a, queued_results[iteration].data(), 0,
+                                      ggml_nbytes(result_a));
         ggml_backend_event_record(event, backend_a.get());
     }
     ggml_backend_synchronize(backend_a.get());
+
+    for (size_t iteration = 0; iteration < queued_results.size(); iteration++) {
+        if (!check_values(queued_results[iteration], 2.0f*iteration)) {
+            fprintf(stderr, "queued RPC graph/readback ordering failed at iteration %zu\n", iteration);
+            return 1;
+        }
+    }
 
     std::vector<float> result(ggml_nelements(result_a));
     ggml_backend_tensor_get(result_a, result.data(), 0, ggml_nbytes(result_a));

--- a/tests/test-rpc.cpp
+++ b/tests/test-rpc.cpp
@@ -196,7 +196,7 @@ int main() {
     ggml_tensor * result_a = ggml_scale(ctx_a.get(), tensor_a, 2.0f);
     ggml_cgraph * graph    = ggml_new_graph_custom(ctx_a.get(), 16, false);
     ggml_build_forward_expand(graph, result_a);
-    graph->uid = ggml_graph_next_uid(); // exercise queued GRAPH_COMPUTE followed by GRAPH_RECOMPUTE
+    graph->uid = 1; // nonzero uid: RPC client caches the graph so queued re-dispatches exercise GRAPH_RECOMPUTE
     ggml_cgraph * foreign_graph = ggml_new_graph_custom(ctx_a.get(), 1, false);
     ggml_graph_add_node(foreign_graph, tensor_a);
 

--- a/tests/test_rpc_allreduce.py
+++ b/tests/test_rpc_allreduce.py
@@ -3,6 +3,7 @@
 
 import argparse
 import contextlib
+import logging
 import os
 from pathlib import Path
 import socket
@@ -131,7 +132,7 @@ def main():
                 for rank, (_, log) in enumerate(servers):
                     log.flush()
                     log.seek(0)
-                    print(f"--- RPC rank {rank} ---\n{log.read()}", flush=True)
+                    logging.error("--- RPC rank %d ---\n%s", rank, log.read())
                 raise
             finally:
                 for process, _ in servers:

--- a/tests/test_rpc_allreduce.py
+++ b/tests/test_rpc_allreduce.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Run RPC collective tests against isolated local servers (CPU by default)."""
+
+import argparse
+import contextlib
+import os
+from pathlib import Path
+import socket
+import subprocess
+import tempfile
+import time
+
+
+def reserve_port(port=0):
+    sock = socket.socket()
+    try:
+        if os.name == "nt":
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+        sock.bind(("127.0.0.1", port))
+    except OSError:
+        sock.close()
+        raise
+    return sock
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--server", required=True)
+    parser.add_argument("--client", required=True)
+    parser.add_argument("--ranks", type=int, default=4)
+    parser.add_argument("--device", default="CPU", help="device exposed by each local server, e.g. CPU or CUDA0")
+    parser.add_argument("--wire", choices=("f32", "bf16"), default="f32")
+    parser.add_argument("--port-base", action="store_true")
+    parser.add_argument("--init-failure", action="store_true")
+    parser.add_argument("--disabled", action="store_true")
+    parser.add_argument("--legacy", action="store_true")
+    args = parser.parse_args()
+    if args.ranks < 2 or args.ranks & (args.ranks - 1):
+        parser.error("--ranks must be a power of two >= 2")
+    if args.init_failure and args.ranks < 4:
+        parser.error("--init-failure needs at least four ranks")
+
+    env = os.environ.copy()
+    for key in ("GGML_RPC_COMM_PORT", "GGML_RPC_NO_COMM", "GGML_RPC_NO_WIRE_BF16",
+                "GGML_RPC_TEST_INIT_FAILURE", "GGML_RPC_TEST_UNREACHABLE_ENDPOINTS"):
+        env.pop(key, None)
+    if args.wire == "f32":
+        env["GGML_RPC_NO_WIRE_BF16"] = "1"
+    if args.disabled:
+        env["GGML_RPC_NO_COMM"] = "1"
+    if args.init_failure:
+        env["GGML_RPC_TEST_INIT_FAILURE"] = "1"
+
+    with contextlib.ExitStack() as stack:
+        ports = []
+        listeners = []
+        comm_listeners = []
+        for _ in range(args.ranks):
+            for attempt in range(100):
+                rpc = reserve_port()
+                port = rpc.getsockname()[1]
+                try:
+                    if port > 64535:
+                        raise OSError("RPC port leaves no room for comm port")
+                    comm = reserve_port(port + 1000)
+                except OSError:
+                    rpc.close()
+                    continue
+                listeners.append(stack.enter_context(rpc))
+                comm_listeners.append(stack.enter_context(comm))
+                ports.append(port)
+                break
+            else:
+                raise RuntimeError("could not reserve RPC ports")
+
+        if args.port_base or args.init_failure:
+            for attempt in range(100):
+                reserved = []
+                try:
+                    reserved.append(reserve_port())
+                    base = reserved[0].getsockname()[1]
+                    if base + args.ranks > 65535:
+                        raise OSError("port range overflow")
+                    for rank in range(1, args.ranks):
+                        reserved.append(reserve_port(base + rank))
+                except OSError:
+                    for sock in reserved:
+                        sock.close()
+                    continue
+                for sock in comm_listeners:
+                    sock.close()
+                comm_listeners = [stack.enter_context(sock) for sock in reserved]
+                env["GGML_RPC_COMM_PORT"] = str(base)
+                break
+            else:
+                raise RuntimeError("could not reserve communication port range")
+
+        for rank, sock in enumerate(comm_listeners):
+            if not (args.init_failure and rank == 1):
+                sock.close()
+
+        with tempfile.TemporaryDirectory(prefix="rpc-allreduce-") as directory, contextlib.ExitStack() as logs:
+            servers = []
+            try:
+                for rank, port in enumerate(ports):
+                    log = logs.enter_context(open(Path(directory) / f"rank-{rank}.log", "w+"))
+                    listeners[rank].close()
+                    process = subprocess.Popen(
+                        [args.server, "--device", args.device, "--host", "127.0.0.1", "--port", str(port),
+                         "--threads", "1"], stdout=log, stderr=subprocess.STDOUT, env=env)
+                    servers.append((process, log))
+                deadline = time.monotonic() + 30
+                for port, (process, _) in zip(ports, servers):
+                    while True:
+                        if process.poll() is not None:
+                            raise RuntimeError("RPC server exited during startup")
+                        try:
+                            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                                break
+                        except OSError:
+                            if time.monotonic() >= deadline:
+                                raise RuntimeError("RPC server startup timed out")
+                            time.sleep(0.05)
+                endpoints = [f"127.0.0.1:{port}" for port in ports]
+                command = [args.client, *endpoints]
+                if args.legacy:
+                    env["GGML_RPC_TEST_ENDPOINTS"] = ",".join(endpoints)
+                    command = [args.client]
+                subprocess.run(command, env=env, check=True, timeout=120)
+            except BaseException:
+                for rank, (_, log) in enumerate(servers):
+                    log.flush()
+                    log.seek(0)
+                    print(f"--- RPC rank {rank} ---\n{log.read()}", flush=True)
+                raise
+            finally:
+                for process, _ in servers:
+                    process.terminate()
+                for process, _ in servers:
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/rpc/README.md
+++ b/tools/rpc/README.md
@@ -134,9 +134,39 @@ RDMA is enabled by default when `libibverbs` is found at build time.
 
 ### Direct all-reduce
 
-Tensor split with exactly two RPC devices uses a direct server-to-server connection for all-reduce. The first server listens on its RPC port plus 1000, and the second server connects to it. Set `GGML_RPC_COMM_PORT` on the main host to use a different port.
+Tensor split with a power-of-two number of RPC devices (2, 4, 8, 16, ...) uses recursive-doubling (butterfly) all-reduce. In round `k`, rank `r` exchanges its accumulated tensor with rank `r XOR (1 << k)` and adds the received sum. After `log2(N)` rounds, every rank has the full sum. Tensor data travels directly between servers, without passing through the main host. Each rank sends a full tensor per round; this is not a bandwidth-optimal reduce-scatter/all-gather algorithm for large tensors.
+
+Use one RPC endpoint per rank. In each pair, the lower rank listens on its RPC port plus 1000 and the higher rank connects to it. Each listener reuses its port across rounds. Set `GGML_RPC_COMM_PORT` on the main host to override this with a base port: rank `r` listens on `base + r`. Reserve that range when running multiple endpoints on the same host.
+
+The client and all servers must use RPC protocol **108**. The communicator initialization and peer frames changed, so protocol 107 builds cannot participate. Other rank counts, mixed local/RPC backends, and unsupported tensors continue to use fallback. Direct reduction requires contiguous F32 tensors with active compute flags on every rank; a single rank needs no collective.
 
 Allow the communication port through the firewall and ensure that the servers can connect to each other. Use this only on a trusted private network because the connection does not provide transport authentication or encryption. Set `GGML_RPC_NO_COMM=1` on the main host to disable direct all-reduce.
+
+#### Testing direct all-reduce
+
+The local test runner starts isolated CPU RPC servers; it needs Python 3 but no GPU or model:
+
+```bash
+cmake -S . -B build-rpc-test -DGGML_RPC=ON -DLLAMA_BUILD_TESTS=ON -DLLAMA_BUILD_TOOLS=ON
+cmake --build build-rpc-test --target ggml-rpc-server test-rpc-allreduce test-rpc -j
+ctest --test-dir build-rpc-test -R '^test-rpc-(allreduce-|local$)' --output-on-failure
+```
+
+This covers 2, 4, and 8 ranks with F32 and BF16 wire transfers, small/large and odd tensor lengths, random reference sums, queued reductions, communicator reuse/reinitialization, unsupported inputs, port overrides, and recovery after partial initialization failure. The tests call the communicator directly and fail if it cannot initialize or reduce, so fallback cannot hide a failure.
+
+To test more local ranks, or existing servers on separate machines:
+
+```bash
+python3 tests/test_rpc_allreduce.py --server build-rpc-test/bin/ggml-rpc-server \
+    --client build-rpc-test/bin/test-rpc-allreduce --ranks 16 --wire f32
+
+GGML_RPC_NO_WIRE_BF16=1 build-rpc-test/bin/test-rpc-allreduce \
+    node0:50052 node1:50052 node2:50052 node3:50052
+```
+
+With a CUDA-enabled server build, add `--device CUDA0` to the local runner to exercise GPU transfers and reductions. All local ranks then share that GPU; this checks correctness, not multi-machine performance.
+
+For an inference comparison, use the same model, devices, tensor split, prompt and generation lengths with `--split-mode tensor`. Compare the default direct path against a run with `GGML_RPC_NO_COMM=1`, measuring prompt processing and generation separately. The initialization log reports `butterfly communicator initialized (N ranks, K rounds)`; individual unsupported reductions may still fall back. Start correctness comparisons with `GGML_RPC_NO_WIRE_BF16=1`, then evaluate BF16 separately because its rounding accumulates across rounds.
 
 ### Troubleshooting
 
@@ -146,4 +176,3 @@ $ GGML_RPC_DEBUG=1 bin/ggml-rpc-server
 ```
 
 Set `GGML_RPC_NO_WIRE_BF16=1` on the main host to keep direct all-reduce transfers in F32. By default, large F32 all-reduce tensors use BF16 on the wire to reduce peer traffic.
-

--- a/tools/rpc/README.md
+++ b/tools/rpc/README.md
@@ -144,6 +144,8 @@ Allow the communication port through the firewall and ensure that the servers ca
 
 #### Testing direct all-reduce
 
+Graph and collective commands are queued asynchronously; synchronization and readback report deferred transport failures. While a direct communicator is active, its client dispatchers busy-poll to reduce command latency. This trades CPU time for lower dispatch latency. Set `GGML_RPC_NO_BUSY_SPIN=1` on the main host to use sleeping dispatchers for an A/B comparison. Polling stops when the last shared communicator handle is released.
+
 The local test runner starts isolated CPU RPC servers; it needs Python 3 but no GPU or model:
 
 ```bash


### PR DESCRIPTION
## Overview

Enable direct butterfly all-reduce for power-of-two RPC device counts and queue graph and collective commands asynchronously. Active communicators keep client dispatchers polling to reduce dispatch latency; `GGML_RPC_NO_BUSY_SPIN=1` restores sleeping dispatchers. Cached graph metadata owns its storage, and graph/readback tests cover queued ordering.

This PR targets `temp-10549` and includes the two commits from #244 plus the asynchronous dispatch changes. Protocol 108 is required on the client and all servers. Busy-polling trades CPU time for lower dispatch latency.

## Additional information

Validation: built `ggml-rpc-server`, `test-rpc-allreduce`, and `test-rpc`. All 10 local RPC tests passed with default settings and all 10 passed with `GGML_RPC_NO_BUSY_SPIN=1`. `git diff --check` passed. GPU, multi-machine performance, and full CI were not run.

## Requirements

- Contribution guidelines reviewed by Codex; submitter remains responsible for reviewing and agreeing with them.
- AI usage disclosure: YES — Codex inspected the existing changes, ran validation, committed and pushed the three modified files, and prepared this PR. No source changes were authored by Codex during this task; earlier AI involvement is not established here.
