### PR TITLE
ggml webgpu: probe webgpu in ggml_backend_load_all_from_path

### DIFF
--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -654,6 +654,7 @@ void ggml_backend_load_all_from_path(const char * dir_path) {
     ggml_backend_load_best("rpc", silent, dir_path);
     ggml_backend_load_best("sycl", silent, dir_path);
     ggml_backend_load_best("vulkan", silent, dir_path);
+    ggml_backend_load_best("webgpu", silent, dir_path);
     ggml_backend_load_best("virtgpu", silent, dir_path);
 
     bool useOpencl = true;


### PR DESCRIPTION
## Problem

`ggml_backend_load_all_from_path()` probes a hardcoded list of backend names (blas/cuda/hip/metal/vulkan/virtgpu/...) that does not include `webgpu` — upstream has it, the entry was lost in a sync. In a `GGML_BACKEND_DL` build that ships `libqvac-ggml-webgpu.so`, the module is never dlopened, so consumers silently fall back to CPU with `warning: no usable GPU found`.

## Change

One line: probe `webgpu` like the other GPU backends.

## Validation (Linux x64, RTX 5090)

Built `@qvac/llm-llamacpp` unmodified against a `qvac-fabric` overlay port with `GGML_WEBGPU=ON` (Dawn prebuilt `18eb229`) and ran it under Bare v1.31 with Qwen3.5-2B Q4_K_M, fa on, 502-token prompt / 128 generated:

| | pp t/s | tg t/s |
|---|---:|---:|
| native `llama-bench` (same tag, same GPU) | 2310 | 195.6 |
| addon under Bare, with this fix | 2267 (98%) | 189.8 (97%) |
| addon under Bare, without this fix | CPU fallback | 34 (CPU) |

The process's own `/proc/self/maps` shows the webgpu module, `libvulkan` and `/dev/nvidiactl` mapped; renaming the module away reproduces the CPU fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
