### PR TITLE
ggml webgpu: request a high-performance adapter

### DIFF
--- a/ggml/src/ggml-webgpu/ggml-webgpu.cpp
+++ b/ggml/src/ggml-webgpu/ggml-webgpu.cpp
@@ -3980,6 +3980,7 @@ static void ggml_webgpu_init_memset_pipeline(webgpu_global_context & ctx) {
 
 static void ggml_backend_webgpu_request_adapter(wgpu::Instance & instance, wgpu::Adapter & adapter) {
     wgpu::RequestAdapterOptions options = {};
+    options.powerPreference             = wgpu::PowerPreference::HighPerformance;
 
 #ifndef __EMSCRIPTEN__
     // TODO: track need for these toggles: https://issues.chromium.org/issues/42251215


### PR DESCRIPTION
## Problem

`ggml_backend_webgpu_request_adapter()` leaves `RequestAdapterOptions` at defaults, so Dawn picks its first adapter. On hybrid systems that is the integrated GPU: on a Ryzen 9950X3D + RTX 5090 desktop the backend selected the iGPU (`AMD RADV RAPHAEL_MENDOCINO`) and left the discrete GPU idle. The only workaround was pinning the Vulkan ICD via `VK_DRIVER_FILES`.

## Change

Request `PowerPreference::HighPerformance`, matching how the other ggml GPU backends prefer the discrete device. The same field maps to the browser's `requestAdapter({powerPreference})` on the Emscripten path.

## Validation (Linux x64, no ICD pinning)

- Before: `ggml_webgpu: adapter_info: ... AMD Ryzen 9 9950X3D ... (RADV RAPHAEL_MENDOCINO)`
- After: `ggml_webgpu: adapter_info: ... NVIDIA GeForce RTX 5090 | NVIDIA: 595.84`

`llama-bench` (Qwen3.5-2B Q4_K_M, fa on) on the resulting adapter: pp512 2310 t/s, tg128 195.6 t/s.

A per-device selector (env var / API) for multi-GPU setups is a possible follow-up; this fixes the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
