### PR TITLE
ggml webgpu: link libstdc++ for prebuilt Dawn on Linux

### DIFF
--- a/ggml/src/ggml-webgpu/CMakeLists.txt
+++ b/ggml/src/ggml-webgpu/CMakeLists.txt
@@ -81,3 +81,12 @@ endif()
 
 target_include_directories(ggml-webgpu PRIVATE ${SHADER_OUTPUT_DIR})
 target_link_libraries(ggml-webgpu PRIVATE ${DawnWebGPU_TARGET})
+if(UNIX AND NOT APPLE AND NOT EMSCRIPTEN)
+    find_library(GGML_WEBGPU_LIBSTDCXX NAMES libstdc++.so.6
+                 PATHS /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /usr/lib64 /usr/lib
+                 NO_DEFAULT_PATH)
+    if(NOT GGML_WEBGPU_LIBSTDCXX)
+        set(GGML_WEBGPU_LIBSTDCXX stdc++)
+    endif()
+    target_link_libraries(ggml-webgpu PRIVATE ${GGML_WEBGPU_LIBSTDCXX})
+endif()


### PR DESCRIPTION
Draft: keeps the prebuilt-Dawn path working under clang/libc++ toolchains; building Dawn from source under the same toolchain (e.g. the vcpkg `dawn` port) is the cleaner long-term alternative — opening this for the interim and for discussion.

## Problem

The prebuilt `libwebgpu_dawn.a` from the pinned google/dawn release is GCC/libstdc++-built. When `ggml-webgpu` is built with clang and `-stdlib=libc++` (the qvac vcpkg triplet), Dawn's vague-linkage libstdc++ symbols stay undefined in the resulting `GGML_BACKEND_DL` module:

- `--as-needed` drops a library that only satisfies weak references, and
- the clang driver silently rewrites a plain `-lstdc++` into `-lc++` under `-stdlib=libc++`,

so the module links without error but fails at dlopen (`undefined symbol: _ZTVNSt7__cxx1119basic_istringstream...`), which consumers only observe as a silent CPU fallback.

## Change

Link the runtime by absolute path (`libstdc++.so.6` via `find_library`), which neither mechanism can drop. On GCC/libstdc++ builds this only makes an already-implicit NEEDED entry explicit.

## Validation (Ubuntu x64, clang/libc++ triplet)

With this change the module dlopens and `@qvac/llm-llamacpp` runs WebGPU on an RTX 5090 at 97-98% of native `llama-bench`; without it, dlopen fails and the addon falls back to CPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
