### PR TITLE
vector-index: keep the public C API exportable under hidden visibility

### DIFF
--- a/ggml/include/ggml-vector-index.h
+++ b/ggml/include/ggml-vector-index.h
@@ -38,6 +38,20 @@
 #    endif
 #endif
 
+// This library is built with CXX_VISIBILITY_PRESET hidden, unlike ggml / ggml-base.
+// In a static build GGML_API carries no visibility attribute, so the preset would
+// leave the public API hidden as well: on Mach-O those symbols become private
+// extern, and a consumer relinking the archive into a shared module cannot export
+// them even when its -exported_symbols_list names them. Annotate the API directly
+// so it stays exportable while the implementation internals remain hidden.
+#ifndef GGML_VEC_INDEX_API
+#    if defined(_WIN32) && !defined(__MINGW32__)
+#        define GGML_VEC_INDEX_API GGML_API
+#    else
+#        define GGML_VEC_INDEX_API __attribute__ ((visibility ("default"))) extern
+#    endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -68,14 +82,14 @@ enum ggml_vec_index_error {
 };
 
 // Returns a stable string for ggml_vec_index_error values.
-GGML_API const char * ggml_vec_index_error_to_string(int error);
+GGML_VEC_INDEX_API const char * ggml_vec_index_error_to_string(int error);
 
 // Lifecycle.
 //
 // `dim` must be > 0. `bit_width` must be 4, 8, or 32. `bit_width=4` and
 // `bit_width=8` store per-vector symmetric quantized codes with one f32 scale
 // per vector. `bit_width=32` stores full f32 vectors. Returns NULL on bad args.
-GGML_API ggml_vec_index_t * ggml_vec_index_create(int dim, int bit_width);
+GGML_VEC_INDEX_API ggml_vec_index_t * ggml_vec_index_create(int dim, int bit_width);
 
 // Creates a TurboQuant q2 vector index. This is distinct from the generic
 // q4/q8 modes created by `ggml_vec_index_create`: vectors are normalized,
@@ -87,7 +101,7 @@ GGML_API ggml_vec_index_t * ggml_vec_index_create(int dim, int bit_width);
 // dimensions can be loaded and rewritten, but add/search/IVF are unsupported.
 // `ggml_vec_index_prepare` is best-effort and does not report allocation status.
 // mmap loading and logged mutations are reserved for later format work.
-GGML_API ggml_vec_index_t * ggml_vec_index_create_turbovec_q2(int dim);
+GGML_VEC_INDEX_API ggml_vec_index_t * ggml_vec_index_create_turbovec_q2(int dim);
 
 // Creates a TurboQuant q4 vector index. This is distinct from the generic
 // `bit_width=4` mode created by `ggml_vec_index_create`: vectors are normalized,
@@ -99,9 +113,9 @@ GGML_API ggml_vec_index_t * ggml_vec_index_create_turbovec_q2(int dim);
 // dimensions can be loaded and rewritten, but add/search/IVF are unsupported.
 // `ggml_vec_index_prepare` is best-effort and does not report allocation status.
 // mmap loading and logged mutations are reserved for later format work.
-GGML_API ggml_vec_index_t * ggml_vec_index_create_turbovec_q4(int dim);
+GGML_VEC_INDEX_API ggml_vec_index_t * ggml_vec_index_create_turbovec_q4(int dim);
 
-GGML_API void ggml_vec_index_free(ggml_vec_index_t * idx);
+GGML_VEC_INDEX_API void ggml_vec_index_free(ggml_vec_index_t * idx);
 
 // Mutation.
 //
@@ -114,7 +128,7 @@ GGML_API void ggml_vec_index_free(ggml_vec_index_t * idx);
 // is not a valid id. `n == 0` is a no-op on handles that accept plain
 // mutations. Live index length and total allocated slots are capped at INT_MAX;
 // compact after bulk removes to reclaim tombstoned slots.
-GGML_API int ggml_vec_index_add(
+GGML_VEC_INDEX_API int ggml_vec_index_add(
     ggml_vec_index_t * idx,
     const float      * vectors,
     int                n,
@@ -123,12 +137,12 @@ GGML_API int ggml_vec_index_add(
 // Removes the entry for `id` by marking its internal slot deleted. Physical
 // storage is compacted only when writing a snapshot. Returns GGML_VEC_INDEX_OK
 // if removed, GGML_VEC_INDEX_E_NOT_FOUND if not present, negative on error.
-GGML_API int ggml_vec_index_remove(ggml_vec_index_t * idx, uint64_t id);
+GGML_VEC_INDEX_API int ggml_vec_index_remove(ggml_vec_index_t * idx, uint64_t id);
 
 // Physically removes deleted slots from in-memory storage. This does not write
 // to disk. If any slots are removed, prepared filters and IVF state are
 // invalidated. Returns 0 on success, negative on error.
-GGML_API int ggml_vec_index_compact(ggml_vec_index_t * idx);
+GGML_VEC_INDEX_API int ggml_vec_index_compact(ggml_vec_index_t * idx);
 
 // Logged mutations for incremental persistence. These update `idx` and append
 // a durable v4 delta record to `delta_path`. Replay the log on top of a full
@@ -155,7 +169,7 @@ GGML_API int ggml_vec_index_compact(ggml_vec_index_t * idx);
 // return GGML_VEC_INDEX_E_INVALID_ARG.
 // New logged mutations require v4 logs; compact the snapshot+delta pair first
 // when carrying a legacy log.
-GGML_API int ggml_vec_index_add_logged(
+GGML_VEC_INDEX_API int ggml_vec_index_add_logged(
     ggml_vec_index_t * idx,
     const float      * vectors,
     int                n,
@@ -167,19 +181,19 @@ GGML_API int ggml_vec_index_add_logged(
 // `ggml_vec_index_add_logged`. Same return convention as
 // `ggml_vec_index_remove`: GGML_VEC_INDEX_OK if removed,
 // GGML_VEC_INDEX_E_NOT_FOUND if not present, negative on error.
-GGML_API int ggml_vec_index_remove_logged(
+GGML_VEC_INDEX_API int ggml_vec_index_remove_logged(
     ggml_vec_index_t * idx,
     uint64_t           id,
     const char       * delta_path);
 
 // Returns 1 if the id is in the index, 0 otherwise. NULL handles return 0.
 // Read-only.
-GGML_API int ggml_vec_index_contains(const ggml_vec_index_t * idx, uint64_t id);
+GGML_VEC_INDEX_API int ggml_vec_index_contains(const ggml_vec_index_t * idx, uint64_t id);
 
 // Optional cache warmup. TurboVec q2/q4 precompute rotation and codebook state;
 // other storage modes ignore this call. Existing callers do not need to call
 // this; use `ggml_vec_index_build_ivf` when ANN search preparation is needed.
-GGML_API void ggml_vec_index_prepare(ggml_vec_index_t * idx);
+GGML_VEC_INDEX_API void ggml_vec_index_prepare(ggml_vec_index_t * idx);
 
 // Builds an in-memory IVF-flat approximate nearest-neighbor structure for the
 // same dot-product score used by exact search. IVF assigns vectors and queries
@@ -190,7 +204,7 @@ GGML_API void ggml_vec_index_prepare(ggml_vec_index_t * idx);
 // search state. Successful add/remove calls invalidate the IVF structure.
 // `n_lists` is capped to the current index length. `n_iter` controls centroid
 // refinement; 0 uses deterministic initial centroids only.
-GGML_API int ggml_vec_index_build_ivf(
+GGML_VEC_INDEX_API int ggml_vec_index_build_ivf(
     ggml_vec_index_t * idx,
     int                n_lists,
     int                n_iter);
@@ -215,7 +229,7 @@ GGML_API int ggml_vec_index_build_ivf(
 // internally. All query components must be finite; TurboVec q2/q4 also require
 // `abs(component) < 1e16`. SIMD and scalar reduction order can produce small
 // score differences across CPU architectures.
-GGML_API int ggml_vec_index_search(
+GGML_VEC_INDEX_API int ggml_vec_index_search(
     const ggml_vec_index_t * idx,
     const float            * queries,
     int                      n_q,
@@ -227,7 +241,7 @@ GGML_API int ggml_vec_index_search(
 // considered. Missing ids are ignored; duplicate filter ids are treated once.
 // `allowed_ids` may be NULL only when `n_allowed == 0`, which produces only
 // sentinel results. The same filter is applied to every query row.
-GGML_API int ggml_vec_index_search_filtered(
+GGML_VEC_INDEX_API int ggml_vec_index_search_filtered(
     const ggml_vec_index_t * idx,
     const float            * queries,
     int                      n_q,
@@ -241,14 +255,14 @@ GGML_API int ggml_vec_index_search_filtered(
 // `allowed_ids` once, so callers can reuse it for repeated searches over the
 // same allowlist. The source index must outlive every filter created from it.
 // Stale filters return GGML_VEC_INDEX_E_INVALID_ARG.
-GGML_API ggml_vec_index_filter_t * ggml_vec_index_filter_create(
+GGML_VEC_INDEX_API ggml_vec_index_filter_t * ggml_vec_index_filter_create(
     const ggml_vec_index_t * idx,
     const uint64_t         * allowed_ids,
     int                      n_allowed);
 
-GGML_API void ggml_vec_index_filter_free(ggml_vec_index_filter_t * filter);
+GGML_VEC_INDEX_API void ggml_vec_index_filter_free(ggml_vec_index_filter_t * filter);
 
-GGML_API int ggml_vec_index_search_prepared_filtered(
+GGML_VEC_INDEX_API int ggml_vec_index_search_prepared_filtered(
     const ggml_vec_index_t        * idx,
     const ggml_vec_index_filter_t * filter,
     const float                   * queries,
@@ -262,7 +276,7 @@ GGML_API int ggml_vec_index_search_prepared_filtered(
 // searched; higher values improve recall and lower the latency win. `nprobe`
 // must be >= 1. If nprobe is greater than the number of built lists, all lists
 // are searched, so candidate coverage matches exact search.
-GGML_API int ggml_vec_index_search_ivf(
+GGML_VEC_INDEX_API int ggml_vec_index_search_ivf(
     const ggml_vec_index_t * idx,
     const float            * queries,
     int                      n_q,
@@ -277,19 +291,19 @@ GGML_API int ggml_vec_index_search_ivf(
 // Returns GGML_VEC_INDEX_E_NOT_DURABLE when the file was atomically replaced
 // but the parent-directory sync failed. Legacy v1 snapshots are limited to 4
 // GiB serialized size; larger v1 states are rejected by load.
-GGML_API int ggml_vec_index_write(
+GGML_VEC_INDEX_API int ggml_vec_index_write(
     ggml_vec_index_t * idx,
     const char       * path);
 
 // Loads v2/v3 files and migrates v1 f32 snapshots. Legacy bit_width=8 snapshots
 // are quantized to q8; all other legacy bit widths migrate to f32/32-bit.
 // Returns 0 on success and stores the loaded handle in `out`.
-GGML_API int ggml_vec_index_load_ex(
+GGML_VEC_INDEX_API int ggml_vec_index_load_ex(
     const char         * path,
     ggml_vec_index_t  ** out);
 
 // Returns NULL on failure.
-GGML_API ggml_vec_index_t * ggml_vec_index_load(const char * path);
+GGML_VEC_INDEX_API ggml_vec_index_t * ggml_vec_index_load(const char * path);
 
 // Loads a v2 .tvim snapshot with its vector section memory-mapped read-only.
 // Legacy v1 snapshots return GGML_VEC_INDEX_E_BAD_VERSION.
@@ -306,39 +320,39 @@ GGML_API ggml_vec_index_t * ggml_vec_index_load(const char * path);
 // Requires a little-endian host and, on POSIX, a filesystem that supports
 // flock(). Use `ggml_vec_index_load` on other hosts.
 // Returns 0 on success and stores the loaded handle in `out`.
-GGML_API int ggml_vec_index_load_mmap_ex(
+GGML_VEC_INDEX_API int ggml_vec_index_load_mmap_ex(
     const char         * path,
     ggml_vec_index_t  ** out);
 
 // Returns NULL on failure or unsupported file format.
-GGML_API ggml_vec_index_t * ggml_vec_index_load_mmap(const char * path);
+GGML_VEC_INDEX_API ggml_vec_index_t * ggml_vec_index_load_mmap(const char * path);
 
 // Loads a full .tvim snapshot and replays an append-only delta log. Missing
 // delta logs are treated as empty. The returned handle is bound to that delta
 // log: plain add, remove, compact, and snapshot write operations return
 // GGML_VEC_INDEX_E_INVALID_ARG.
 // Returns 0 on success and stores the loaded handle in `out`.
-GGML_API int ggml_vec_index_load_with_delta_ex(
+GGML_VEC_INDEX_API int ggml_vec_index_load_with_delta_ex(
     const char         * snapshot_path,
     const char         * delta_path,
     ggml_vec_index_t  ** out);
 
-GGML_API ggml_vec_index_t * ggml_vec_index_load_with_delta(
+GGML_VEC_INDEX_API ggml_vec_index_t * ggml_vec_index_load_with_delta(
     const char * snapshot_path,
     const char * delta_path);
 
 // Writes a fresh snapshot and resets the .tvid delta log. Returns
 // GGML_VEC_INDEX_E_PARTIAL_COMPACT if the snapshot was replaced but its
 // durability could not be confirmed, or if resetting the delta log failed.
-GGML_API int ggml_vec_index_compact_delta(
+GGML_VEC_INDEX_API int ggml_vec_index_compact_delta(
     ggml_vec_index_t * idx,
     const char       * snapshot_path,
     const char       * delta_path);
 
 // Stats. NULL handles return 0.
-GGML_API int ggml_vec_index_len(const ggml_vec_index_t * idx);
-GGML_API int ggml_vec_index_dim(const ggml_vec_index_t * idx);
-GGML_API int ggml_vec_index_bit_width(const ggml_vec_index_t * idx);
+GGML_VEC_INDEX_API int ggml_vec_index_len(const ggml_vec_index_t * idx);
+GGML_VEC_INDEX_API int ggml_vec_index_dim(const ggml_vec_index_t * idx);
+GGML_VEC_INDEX_API int ggml_vec_index_bit_width(const ggml_vec_index_t * idx);
 
 // File format (.tvim versions 2 and 3, all little-endian):
 // "TQ+" here is the TurboVec per-coordinate calibration scheme, unrelated to


### PR DESCRIPTION
## Overview

`ggml-vector-index` is the only ggml target that sets `CXX_VISIBILITY_PRESET hidden`. In a static build `GGML_API` expands to a bare `extern` with no visibility attribute, so the preset hides the public API along with the internals. On Mach-O those definitions become *private extern*, and a consumer that whole-archives the library into a shared module cannot export them even when its `-exported_symbols_list` names them — `ld64` will not promote a private extern to global.

The result: `@qvac/fabric` 0.12.0 shipped Darwin and iOS modules that contain the vector-index code but export none of the 30 `ggml_vec_index_*` entry points. Linux, Android and Windows export all 30. A fabric-based `@qvac/embed-llamacpp` therefore links against symbols the runtime never exposes, and because `cmake-bare` links Apple modules with `-Wl,-undefined,dynamic_lookup`, the miss does not surface as a link error — it surfaces as a `SIGSEGV` on the first call.

This annotates the public API with a dedicated `GGML_VEC_INDEX_API` macro carrying default visibility, so it stays exportable regardless of the preset while the implementation internals stay hidden. Windows keeps the existing `GGML_API` behaviour, where exports are driven by the consumer's generated `.def`.

## Additional information

Why a new macro rather than the alternatives:

- **Not `-DGGML_API=...`, and not editing the `GGML_API` fallback in this header.** That block is guarded by `#ifndef GGML_API`. If `ggml.h` is included first it wins, and a change here is silently ignored.
- **Not dropping `CXX_VISIBILITY_PRESET hidden` from the target.** That would un-hide every internal C++ symbol in the library. Fabric's Apple `exports.txt` matches on broad globs (`*ggml_*`, `*string_*`), so those internals would land in the module's public export table. Fabric's export check already warns that Apple prebuilds expose 1582 engine symbols at default visibility (cross-addon interposition risk); this would make that materially worse.

Annotating the 30 declarations is the surgical option: it promotes exactly the documented C API and nothing else.

This targets `temp-10297` so it can ship as a `v10297.1.3` tag — that is the line `@qvac/fabric` currently pins, and the one that needs a published port for the Darwin regression to clear. `temp-10549` carries an identical `ggml-vector-index.h` and gets the same commit via #252; `temp-10796` does not have the vector-index sources yet, so it will pick this up when they are ported over.

One loose end I could not explain from static analysis: the preset is set unconditionally, yet ELF targets (Linux, Android) export the API anyway. Something in those toolchain paths is not applying `-fvisibility=hidden` to this target, or is overriding it. Putting the visibility on the declarations makes the API exportable regardless of which platform's build happens to apply the preset, so the fix does not depend on knowing the answer.

## Validation

Built `@qvac/fabric` unmodified except for a vcpkg overlay port pointing at this exact commit, on the standard prebuild matrix. `llvm-nm --defined-only --extern-only` on the resulting `.bare` modules, compared against the published 0.12.0 binaries:

| target | `ggml_vec_index_*` exported | total exported symbols |
|---|---|---|
| darwin-arm64 | 0 → **30** | 6623 → 6653 |
| darwin-x64 | 0 → **30** | 7028 → 7058 |
| ios-arm64 | **30** | 6648 |
| ios-arm64-simulator | **30** | 6648 |
| ios-x64-simulator | **30** | 7053 |

The total moves by exactly +30 on both Darwin arches, which is the useful part: only the public API gained visibility, the internals are still hidden. The module's own `.bare.exports` sidecar lists all 30 on each of the five targets. linux-x64, linux-arm64, android-arm64 and win32-x64 built green and unchanged.

The header compiles clean under `clang -fsyntax-only` in both C and C++17 modes.

On a regression test: this is a property of how a *consumer* relinks the static archive into a shared module, so it is not observable from a ctest binary inside this repo — linking a test executable against the archive resolves private externs just fine, which is why the existing vector-index tests pass on macOS today. The guard that actually catches it is the export check in the fabric package, which sees the final Mach-O module. Happy to add a symbol-visibility assertion here instead if a reviewer prefers it in-tree.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Cursor (Claude) diagnosed the missing exports from the shipped binaries, wrote the header change, ran the prebuild validation above, and drafted this description; I directed the investigation, chose this approach over the alternatives listed above, and reviewed every line.
