### PR TITLE
ggml: share native MTP compute buffers and synchronize catch-up

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2385,6 +2385,7 @@ common_speculative_init_result::common_speculative_init_result(
 
     if (spec_mtp) {
         cparams.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+        cparams.ctx_other_share_compute = true;
     }
 
     // note: for small models maybe we can set this to the maximum possible draft from all speculative types

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1523,6 +1523,8 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             if (chain_heads) {
                 llama_set_nextn_layer_offset(ctx_dft, 0); // restore default for non-draft decodes
             }
+            // Catch-up decode is async; finish before the target reuses shared compute buffers.
+            llama_synchronize(ctx_dft);
             if (!ok) {
                 return false;
             }

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -341,6 +341,11 @@ extern "C" {
     GGML_API ggml_backend_sched_t ggml_backend_sched_new(ggml_backend_t * backends, ggml_backend_buffer_type_t * bufts, int n_backends, size_t graph_size, bool parallel, bool op_offload);
     GGML_API void                 ggml_backend_sched_free(ggml_backend_sched_t sched);
 
+    // Share physical compute buffers while keeping scheduler and graph allocation state independent.
+    // The caller must ensure the schedulers do not execute concurrently while the buffers are shared.
+    // Returns false for incompatible or unsupported scheduler layouts, or if dst is already allocated.
+    GGML_API bool ggml_backend_sched_share_compute_buffers(ggml_backend_sched_t dst, ggml_backend_sched_t src);
+
     // Initialize backend buffers from a measure graph
     GGML_API bool                 ggml_backend_sched_reserve_size(ggml_backend_sched_t sched, struct ggml_cgraph * measure_graph, size_t * sizes);
     GGML_API bool                 ggml_backend_sched_reserve(ggml_backend_sched_t sched, struct ggml_cgraph * measure_graph); // returns success

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -344,6 +344,7 @@ extern "C" {
     // Share physical compute buffers while keeping scheduler and graph allocation state independent.
     // The caller must ensure the schedulers do not execute concurrently while the buffers are shared.
     // Returns false for incompatible or unsupported scheduler layouts, or if dst is already allocated.
+    // Buffers with reset callbacks are unsupported because reset can invalidate another graph's tensor extras.
     GGML_API bool ggml_backend_sched_share_compute_buffers(ggml_backend_sched_t dst, ggml_backend_sched_t src);
 
     // Initialize backend buffers from a measure graph

--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -479,8 +479,15 @@ struct node_alloc {
     struct tensor_alloc src[GGML_MAX_SRC];
 };
 
+struct ggml_gallocr_shared_buffers {
+    size_t refs;
+    int n_buffers;
+    struct vbuffer ** buffers;
+};
+
 struct ggml_gallocr {
     ggml_backend_buffer_type_t * bufts; // [n_buffers]
+    struct ggml_gallocr_shared_buffers * shared_buffers;
     struct vbuffer ** buffers; // [n_buffers]
     struct ggml_dyn_tallocr ** buf_tallocs; // [n_buffers]
     int n_buffers;
@@ -535,9 +542,37 @@ ggml_gallocr_t ggml_gallocr_new(ggml_backend_buffer_type_t buft) {
     return ggml_gallocr_new_n(&buft, 1);
 }
 
+static void ggml_gallocr_shared_buffers_unref(struct ggml_gallocr_shared_buffers * shared) {
+    GGML_ASSERT(shared != NULL && shared->refs > 0);
+    if (--shared->refs > 0) {
+        return;
+    }
+
+    for (int i = 0; i < shared->n_buffers; ++i) {
+        bool freed = false;
+        for (int j = 0; j < i; ++j) {
+            if (shared->buffers[j] == shared->buffers[i]) {
+                freed = true;
+                break;
+            }
+        }
+        if (!freed) {
+            ggml_vbuffer_free(shared->buffers[i]);
+        }
+    }
+
+    free(shared->buffers);
+    free(shared);
+}
+
 void ggml_gallocr_free(ggml_gallocr_t galloc) {
     if (galloc == NULL) {
         return;
+    }
+
+    if (galloc->shared_buffers != NULL) {
+        ggml_gallocr_shared_buffers_unref(galloc->shared_buffers);
+        galloc->buffers = NULL;
     }
 
     for (int i = 0; i < galloc->n_buffers; i++) {
@@ -577,6 +612,40 @@ void ggml_gallocr_free(ggml_gallocr_t galloc) {
     free(galloc->node_allocs);
     free(galloc->leaf_allocs);
     free(galloc);
+}
+
+bool ggml_gallocr_share_buffers(ggml_gallocr_t dst, ggml_gallocr_t src) {
+    if (dst == NULL || src == NULL || dst == src ||
+        dst->n_buffers != src->n_buffers || dst->shared_buffers != NULL) {
+        return false;
+    }
+
+    for (int i = 0; i < dst->n_buffers; ++i) {
+        if (dst->bufts[i] != src->bufts[i] || dst->buffers[i] != NULL || src->buffers[i] == NULL) {
+            return false;
+        }
+    }
+
+    struct ggml_gallocr_shared_buffers * shared = src->shared_buffers;
+    if (shared != NULL &&
+        (shared->n_buffers != src->n_buffers || shared->buffers != src->buffers)) {
+        return false;
+    }
+
+    if (shared == NULL) {
+        shared = calloc(1, sizeof(*shared));
+        GGML_ASSERT(shared != NULL);
+        shared->refs = 1;
+        shared->n_buffers = src->n_buffers;
+        shared->buffers = src->buffers;
+        src->shared_buffers = shared;
+    }
+
+    free(dst->buffers);
+    shared->refs++;
+    dst->shared_buffers = shared;
+    dst->buffers = shared->buffers;
+    return true;
 }
 
 typedef struct ggml_gallocr * ggml_gallocr_t;
@@ -822,6 +891,18 @@ static void ggml_gallocr_alloc_graph_impl(ggml_gallocr_t galloc, struct ggml_cgr
     }
 }
 
+static bool ggml_gallocr_shared_buffers_need_grow(ggml_gallocr_t galloc) {
+    for (int i = 0; i < galloc->n_buffers; ++i) {
+        for (int c = 0; c < galloc->buf_tallocs[i]->n_chunks; ++c) {
+            const size_t current = galloc->buffers[i] ? ggml_vbuffer_chunk_size(galloc->buffers[i], c) : 0;
+            if (ggml_dyn_tallocr_max_size(galloc->buf_tallocs[i], c) > current) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 static bool ggml_gallocr_reserve_n_impl(
         ggml_gallocr_t galloc, struct ggml_cgraph * graph, const int * node_buffer_ids, const int * leaf_buffer_ids, bool no_alloc) {
     size_t min_hash_size = graph->n_nodes + graph->n_leafs;
@@ -899,6 +980,18 @@ static bool ggml_gallocr_reserve_n_impl(
             galloc->leaf_allocs[i].leaf.addr = hn->addr;
             galloc->leaf_allocs[i].leaf.size_max = ggml_backend_buft_get_alloc_size(galloc->bufts[hn->buffer_id], leaf);
         }
+    }
+
+    // Never resize storage still referenced by another gallocr.
+    if (galloc->shared_buffers != NULL && ggml_gallocr_shared_buffers_need_grow(galloc)) {
+        GGML_LOG_DEBUG("%s: detaching shared compute buffers for a larger reservation\n", __func__);
+        struct vbuffer ** buffers = calloc(galloc->n_buffers, sizeof(*buffers));
+        GGML_ASSERT(buffers != NULL);
+
+        struct ggml_gallocr_shared_buffers * shared = galloc->shared_buffers;
+        galloc->shared_buffers = NULL;
+        galloc->buffers = buffers;
+        ggml_gallocr_shared_buffers_unref(shared);
     }
 
     // reallocate buffers if needed

--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -624,6 +624,14 @@ bool ggml_gallocr_share_buffers(ggml_gallocr_t dst, ggml_gallocr_t src) {
         if (dst->bufts[i] != src->bufts[i] || dst->buffers[i] != NULL || src->buffers[i] == NULL) {
             return false;
         }
+
+        // Reset callbacks can invalidate tensor extras still used by another scheduler's graph.
+        for (int c = 0; c < GGML_VBUFFER_MAX_CHUNKS; ++c) {
+            ggml_backend_buffer_t buffer = src->buffers[i]->chunks[c];
+            if (buffer != NULL && buffer->iface.reset != NULL) {
+                return false;
+            }
+        }
     }
 
     struct ggml_gallocr_shared_buffers * shared = src->shared_buffers;

--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -85,6 +85,13 @@ extern "C" {
     GGML_API ggml_backend_buffer_t ggml_backend_multi_buffer_get_buffer(ggml_backend_buffer_t buffer, const void * addr);
     GGML_API void                  ggml_backend_multi_buffer_set_usage(ggml_backend_buffer_t buffer, enum ggml_backend_buffer_usage usage);
 
+    // graph allocator internals
+    struct ggml_gallocr;
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((visibility("hidden")))
+#endif
+    bool ggml_gallocr_share_buffers(struct ggml_gallocr * dst, struct ggml_gallocr * src);
+
     //
     // Backend (meta)
     //

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -2276,6 +2276,23 @@ void ggml_backend_sched_free(ggml_backend_sched_t sched) {
     free(sched);
 }
 
+bool ggml_backend_sched_share_compute_buffers(ggml_backend_sched_t dst, ggml_backend_sched_t src) {
+    if (dst == nullptr || src == nullptr || dst == src ||
+        dst->n_copies != 1 || src->n_copies != 1 ||
+        dst->n_backends != src->n_backends || dst->is_alloc) {
+        return false;
+    }
+
+    for (int i = 0; i < dst->n_backends; ++i) {
+        if (dst->bufts[i] != src->bufts[i] ||
+            ggml_backend_get_device(dst->backends[i]) != ggml_backend_get_device(src->backends[i])) {
+            return false;
+        }
+    }
+
+    return ggml_gallocr_share_buffers(dst->galloc, src->galloc);
+}
+
 void ggml_backend_sched_reset(ggml_backend_sched_t sched) {
     GGML_ASSERT(sched);
     // reset state for the next run

--- a/include/llama.h
+++ b/include/llama.h
@@ -420,6 +420,10 @@ extern "C" {
         // a source/target/parent context
         // can be utilized in various ways, for example by sharing results or llama_memory between 2 contexts
         struct llama_context * ctx_other;
+        // Share MTP compute buffers with ctx_other when compatible (default: false).
+        // The caller must serialize all sharing contexts, including asynchronous work.
+        // Synchronize the previous context before decoding, reserving, or changing another context.
+        bool ctx_other_share_compute;
         bool training;    // if true, we're in training mode (affects LoRA K/V gradient flow)
     };
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -667,7 +667,7 @@ void llama_context::sched_reserve() {
 
     if (ctx_compute != nullptr) {
         int n_devices = 0;
-        bool is_cuda = true;
+        bool is_supported = true;
         for (ggml_backend_t backend : backend_ptrs) {
             ggml_backend_dev_t device = ggml_backend_get_device(backend);
             if (device == nullptr || ggml_backend_dev_type(device) == GGML_BACKEND_DEVICE_TYPE_CPU) {
@@ -676,10 +676,12 @@ void llama_context::sched_reserve() {
 
             n_devices++;
             ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(device);
-            is_cuda = is_cuda && reg != nullptr && strcmp(ggml_backend_reg_name(reg), "CUDA") == 0;
+            const char * name = reg != nullptr ? ggml_backend_reg_name(reg) : "";
+            is_supported = is_supported &&
+                (strcmp(name, "CUDA") == 0 || strcmp(name, "Vulkan") == 0 || strcmp(name, "MTL") == 0);
         }
 
-        if (n_devices == 1 && is_cuda &&
+        if (n_devices == 1 && is_supported &&
             ggml_backend_sched_share_compute_buffers(sched.get(), ctx_compute->get_sched())) {
             LLAMA_LOG_INFO("%s: sharing compute buffers with the target context\n", __func__);
         } else {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -667,7 +667,6 @@ void llama_context::sched_reserve() {
 
     if (ctx_compute != nullptr) {
         int n_devices = 0;
-        bool is_supported = true;
         for (ggml_backend_t backend : backend_ptrs) {
             ggml_backend_dev_t device = ggml_backend_get_device(backend);
             if (device == nullptr || ggml_backend_dev_type(device) == GGML_BACKEND_DEVICE_TYPE_CPU) {
@@ -675,13 +674,9 @@ void llama_context::sched_reserve() {
             }
 
             n_devices++;
-            ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(device);
-            const char * name = reg != nullptr ? ggml_backend_reg_name(reg) : "";
-            is_supported = is_supported &&
-                (strcmp(name, "CUDA") == 0 || strcmp(name, "Vulkan") == 0 || strcmp(name, "MTL") == 0);
         }
 
-        if (n_devices == 1 && is_supported &&
+        if (n_devices == 1 &&
             ggml_backend_sched_share_compute_buffers(sched.get(), ctx_compute->get_sched())) {
             LLAMA_LOG_INFO("%s: sharing compute buffers with the target context\n", __func__);
         } else {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -162,10 +162,11 @@ llama_context::llama_context(
         }
     }
 
-    if (params.ctx_type == LLAMA_CONTEXT_TYPE_MTP && params.ctx_other != nullptr &&
+    if (params.ctx_other_share_compute && params.ctx_type == LLAMA_CONTEXT_TYPE_MTP && params.ctx_other != nullptr &&
         &params.ctx_other->get_model() == &model &&
         cparams.n_seq_max == 1 && params.ctx_other->n_seq_max() == 1) {
-        ctx_compute = params.ctx_other;
+        ctx_compute = params.ctx_other->compute_state;
+        params.ctx_other->compute_share_source = true;
     }
 
     auto rope_scaling_type = params.rope_scaling_type;
@@ -527,6 +528,7 @@ llama_context::llama_context(
 }
 
 llama_context::~llama_context() {
+    compute_state.reset();
     // wait for any pending asynchronous copies into the output buffers before they are freed
     synchronize();
 
@@ -627,6 +629,10 @@ void llama_context::resolve_fused_ops(const llama_memory_context_i * mctx, uint3
 }
 
 void llama_context::sched_reserve() {
+    auto source = ctx_compute.lock();
+    if (source && compute_generation != source->generation) {
+        sched_need_reserve = true;
+    }
     if (!sched_need_reserve) {
         return;
     }
@@ -649,6 +655,12 @@ void llama_context::sched_reserve() {
     gf_res_prev.reset(new llm_graph_result(max_nodes));
     gf_res_reserve.reset(new llm_graph_result(max_nodes));
 
+    auto previous_sched = std::move(sched);
+    compute_state->sched = nullptr;
+    if (!compute_share_source) {
+        previous_sched.reset();
+    }
+
     auto create_sched = [&](bool parallel) {
         sched.reset(ggml_backend_sched_new(
             backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, parallel, cparams.op_offload));
@@ -665,11 +677,12 @@ void llama_context::sched_reserve() {
     };
     create_sched(cparams.pipeline_parallel);
 
-    if (ctx_compute != nullptr) {
+    if (source) {
         int n_devices = 0;
         for (ggml_backend_t backend : backend_ptrs) {
             ggml_backend_dev_t device = ggml_backend_get_device(backend);
-            if (device == nullptr || ggml_backend_dev_type(device) == GGML_BACKEND_DEVICE_TYPE_CPU) {
+            if (device == nullptr || ggml_backend_dev_type(device) == GGML_BACKEND_DEVICE_TYPE_CPU ||
+                ggml_backend_dev_type(device) == GGML_BACKEND_DEVICE_TYPE_ACCEL) {
                 continue;
             }
 
@@ -677,12 +690,16 @@ void llama_context::sched_reserve() {
         }
 
         if (n_devices == 1 &&
-            ggml_backend_sched_share_compute_buffers(sched.get(), ctx_compute->get_sched())) {
+            ggml_backend_sched_share_compute_buffers(sched.get(), source->sched)) {
             LLAMA_LOG_INFO("%s: sharing compute buffers with the target context\n", __func__);
         } else {
             LLAMA_LOG_INFO("%s: compute buffer sharing unavailable; using independent buffers\n", __func__);
         }
+        compute_generation = source->generation;
+    } else if (compute_share_source && previous_sched) {
+        ggml_backend_sched_share_compute_buffers(sched.get(), previous_sched.get());
     }
+    previous_sched.reset();
 
     llama_memory_context_ptr mctx;
     if (memory) {
@@ -776,6 +793,9 @@ void llama_context::sched_reserve() {
     } else {
         LLAMA_LOG_INFO("%s: graph splits = %d (with bs=%d), %d (with bs=1)\n", __func__, n_splits_pp, n_tokens, n_splits_tg);
     }
+
+    compute_state->sched = sched.get();
+    ++compute_state->generation;
 
     const int64_t t_end_us = ggml_time_us();
 
@@ -3838,6 +3858,7 @@ llama_context_params llama_context_default_params() {
         /*.sampler                     =*/ nullptr,
         /*.n_sampler                   =*/ 0,
         /*.ctx_other                   =*/ nullptr,
+        /*.ctx_other_share_compute     =*/ false,
         /*.training                    =*/ false,
     };
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -162,6 +162,12 @@ llama_context::llama_context(
         }
     }
 
+    if (params.ctx_type == LLAMA_CONTEXT_TYPE_MTP && params.ctx_other != nullptr &&
+        &params.ctx_other->get_model() == &model &&
+        cparams.n_seq_max == 1 && params.ctx_other->n_seq_max() == 1) {
+        ctx_compute = params.ctx_other;
+    }
+
     auto rope_scaling_type = params.rope_scaling_type;
     if (rope_scaling_type == LLAMA_ROPE_SCALING_TYPE_UNSPECIFIED) {
         rope_scaling_type = hparams.rope_scaling_type_train;
@@ -658,6 +664,28 @@ void llama_context::sched_reserve() {
         }
     };
     create_sched(cparams.pipeline_parallel);
+
+    if (ctx_compute != nullptr) {
+        int n_devices = 0;
+        bool is_cuda = true;
+        for (ggml_backend_t backend : backend_ptrs) {
+            ggml_backend_dev_t device = ggml_backend_get_device(backend);
+            if (device == nullptr || ggml_backend_dev_type(device) == GGML_BACKEND_DEVICE_TYPE_CPU) {
+                continue;
+            }
+
+            n_devices++;
+            ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(device);
+            is_cuda = is_cuda && reg != nullptr && strcmp(ggml_backend_reg_name(reg), "CUDA") == 0;
+        }
+
+        if (n_devices == 1 && is_cuda &&
+            ggml_backend_sched_share_compute_buffers(sched.get(), ctx_compute->get_sched())) {
+            LLAMA_LOG_INFO("%s: sharing compute buffers with the target context\n", __func__);
+        } else {
+            LLAMA_LOG_INFO("%s: compute buffer sharing unavailable; using independent buffers\n", __func__);
+        }
+    }
 
     llama_memory_context_ptr mctx;
     if (memory) {

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -363,6 +363,7 @@ private:
     std::vector<swap_info> output_swaps;
 
     ggml_backend_sched_ptr sched;
+    llama_context * ctx_compute = nullptr;
 
     bool sched_need_reserve = true;
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <map>
+#include <memory>
 #include <vector>
 
 struct llama_model;
@@ -40,6 +41,11 @@ struct llama_memory_buffer {
 };
 
 using llama_memory_buffers = std::map<ggml_backend_buffer_type_t, llama_memory_buffer>;
+
+struct llama_compute_state {
+    ggml_backend_sched_t sched = nullptr;
+    uint64_t generation = 0;
+};
 
 struct llama_context {
     // init scheduler and compute buffers, reserve worst-case graphs
@@ -363,7 +369,10 @@ private:
     std::vector<swap_info> output_swaps;
 
     ggml_backend_sched_ptr sched;
-    llama_context * ctx_compute = nullptr;
+    std::shared_ptr<llama_compute_state> compute_state = std::make_shared<llama_compute_state>();
+    std::weak_ptr<llama_compute_state> ctx_compute;
+    uint64_t compute_generation = 0;
+    bool compute_share_source = false;
 
     bool sched_need_reserve = true;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -226,6 +226,10 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
     # llama_build_and_test(test-double-float.cpp) # SLOW
 
     llama_build_and_test(test-llama-archs.cpp)
+    llama_test(test-llama-archs NAME test-mtp-shared-cpu ARGS --mtp-shared-cpu)
+    if (GGML_CUDA)
+        llama_test(test-llama-archs NAME test-mtp-shared ARGS --mtp-shared)
+    endif()
 
     set(MODEL_DIR "${CMAKE_CURRENT_BINARY_DIR}/test-models/")
     file(MAKE_DIRECTORY "${MODEL_DIR}")

--- a/tests/test-alloc.cpp
+++ b/tests/test-alloc.cpp
@@ -88,6 +88,8 @@ static void dummy_backend_buffer_clear(ggml_backend_buffer_t, uint8_t) {}
 struct dummy_backend {
     std::unique_ptr<dummy_backend_context> context;
     ggml_backend_buffer_type               buffer_type;
+    ggml_backend_device                    device;
+    ggml_backend                           backend;
 };
 
 static dummy_backend dummy_backend_init(size_t max_buffer_size, size_t alignment = 8) {
@@ -111,6 +113,40 @@ static dummy_backend dummy_backend_init(size_t max_buffer_size, size_t alignment
     b.buffer_type.iface.get_max_size  = dummy_backend_buffer_type_get_max_size;
     b.buffer_type.iface.is_host       = dummy_backend_buffer_type_is_host;
     return b;
+}
+
+//
+// ggml_backend / device interface
+//
+
+static const char * dummy_backend_get_name(ggml_backend_t) {
+    return "dummy_backend";
+}
+
+static enum ggml_backend_dev_type dummy_backend_device_get_type(ggml_backend_dev_t) {
+    return GGML_BACKEND_DEVICE_TYPE_CPU;
+}
+
+static bool dummy_backend_device_supports_op(ggml_backend_dev_t, const ggml_tensor *) {
+    return true;
+}
+
+static bool dummy_backend_device_supports_buft(ggml_backend_dev_t device, ggml_backend_buffer_type_t buft) {
+    return buft == device->context;
+}
+
+static ggml_backend_sched_ptr dummy_backend_sched_new(dummy_backend & b) {
+    b.device.iface.get_type      = dummy_backend_device_get_type;
+    b.device.iface.supports_op   = dummy_backend_device_supports_op;
+    b.device.iface.supports_buft = dummy_backend_device_supports_buft;
+    b.device.context             = &b.buffer_type;
+
+    b.backend.iface.get_name = dummy_backend_get_name;
+    b.backend.device         = &b.device;
+
+    ggml_backend_t             backends[] = { &b.backend };
+    ggml_backend_buffer_type_t bufts[]    = { &b.buffer_type };
+    return ggml_backend_sched_ptr(ggml_backend_sched_new(backends, bufts, 1, 64, false, false));
 }
 
 //
@@ -142,6 +178,13 @@ static ggml_tensor * make_input_1d(ggml_context * ctx, int64_t n_elements) {
 static ggml_tensor * make_input_with_size(ggml_context * ctx, size_t size_bytes) {
     GGML_ASSERT(size_bytes % 4 == 0);
     return make_input_1d(ctx, size_bytes / 4);
+}
+
+static ggml_tensor * make_scale_graph(ggml_context * ctx, ggml_cgraph * graph, size_t size_bytes) {
+    ggml_tensor * out = ggml_scale(ctx, make_input_with_size(ctx, size_bytes), 2.0f);
+    ggml_set_output(out);
+    ggml_build_forward_expand(graph, out);
+    return out;
 }
 
 static void assign_names(ggml_context * ctx, const char * prefix = "x") {
@@ -583,6 +626,55 @@ static void test_reallocation() {
     }
 }
 
+static void test_shared_buffers() {
+    dummy_backend backend = dummy_backend_init(SIZE_MAX);
+
+    auto [ctx_src, graph_src, ctx_src_ptr] = make_context();
+    ggml_tensor * src_out = make_scale_graph(ctx_src, graph_src, 16);
+
+    ggml_backend_sched_ptr src = dummy_backend_sched_new(backend);
+    GGML_ASSERT(ggml_backend_sched_reserve(src.get(), graph_src));
+    GGML_ASSERT(ggml_backend_sched_alloc_graph(src.get(), graph_src));
+    const size_t shared_size = backend.context->allocated_total();
+    GGML_ASSERT(shared_size > 0);
+
+    auto [ctx_dst, graph_dst, ctx_dst_ptr] = make_context();
+    ggml_tensor * dst_out = make_scale_graph(ctx_dst, graph_dst, 8);
+
+    ggml_backend_sched_ptr dst = dummy_backend_sched_new(backend);
+    GGML_ASSERT(ggml_backend_sched_share_compute_buffers(dst.get(), src.get()));
+    GGML_ASSERT(ggml_backend_sched_reserve(dst.get(), graph_dst));
+    GGML_ASSERT(ggml_backend_sched_alloc_graph(dst.get(), graph_dst));
+    GGML_ASSERT(backend.context->allocated_total() == shared_size);
+    GGML_ASSERT(src_out->buffer == dst_out->buffer);
+
+    // Schedulers keep independent allocation plans.
+    ggml_backend_sched_reset(src.get());
+    GGML_ASSERT(ggml_backend_sched_alloc_graph(src.get(), graph_src));
+
+    auto [ctx_big, graph_big, ctx_big_ptr] = make_context();
+    ggml_tensor * big_out = make_scale_graph(ctx_big, graph_big, 64);
+
+    // A larger reservation detaches from shared buffers.
+    ggml_backend_sched_ptr big = dummy_backend_sched_new(backend);
+    GGML_ASSERT(ggml_backend_sched_share_compute_buffers(big.get(), src.get()));
+    GGML_ASSERT(ggml_backend_sched_reserve(big.get(), graph_big));
+    GGML_ASSERT(ggml_backend_sched_alloc_graph(big.get(), graph_big));
+    GGML_ASSERT(big_out->buffer != src_out->buffer);
+    GGML_ASSERT(backend.context->allocated_total() > shared_size);
+
+    big.reset();
+    GGML_ASSERT(backend.context->allocated_total() == shared_size);
+    // Freeing the source does not invalidate the destination.
+    src.reset();
+    GGML_ASSERT(backend.context->allocated_total() == shared_size);
+    ggml_backend_sched_reset(dst.get());
+    GGML_ASSERT(ggml_backend_sched_alloc_graph(dst.get(), graph_dst));
+    GGML_ASSERT(backend.context->allocated_total() == shared_size);
+    dst.reset();
+    GGML_ASSERT(backend.context->allocated_total() == 0);
+}
+
 static void run(const char * name, void (*f)()) {
     printf("%s ", name);
     fflush(stdout);
@@ -604,5 +696,6 @@ int main() {
     run("test_multiple_buffer_types", test_multiple_buffer_types);
     run("test_buffer_size_zero", test_buffer_size_zero);
     run("test_reallocation", test_reallocation);
+    run("test_shared_buffers", test_shared_buffers);
     return 0;
 }

--- a/tests/test-alloc.cpp
+++ b/tests/test-alloc.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <exception>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 //
@@ -14,12 +15,23 @@
 
 uint8_t * const alloc_base = (uint8_t *) 16;
 
+struct dummy_tensor_extra {
+    size_t offset;
+    size_t size;
+};
+
+struct dummy_tensor_extra_pool {
+    std::vector<std::unique_ptr<dummy_tensor_extra>> entries;
+    size_t next = 0;
+};
+
 struct dummy_backend_context {
     size_t max_buffer_size = 64;
     size_t alignment       = 8;
 
     ggml_backend_buffer_i              buffer_interface;
     std::vector<ggml_backend_buffer_t> buffers;
+    std::unordered_map<ggml_backend_buffer_t, dummy_tensor_extra_pool> tensor_extras;
 
     size_t allocated_total() const {
         size_t n = 0;
@@ -65,6 +77,7 @@ static void dummy_backend_buffer_free_buffer(ggml_backend_buffer_t buffer) {
     auto i = std::find(ctx->buffers.begin(), ctx->buffers.end(), buffer);
     GGML_ASSERT(i != ctx->buffers.end());
     ctx->buffers.erase(i);
+    ctx->tensor_extras.erase(buffer);
 }
 
 static void * dummy_backend_buffer_get_base(ggml_backend_buffer_t) {
@@ -73,6 +86,30 @@ static void * dummy_backend_buffer_get_base(ggml_backend_buffer_t) {
 
 static ggml_status dummy_backend_buffer_init_tensor(ggml_backend_buffer_t, ggml_tensor *) {
     return GGML_STATUS_SUCCESS;
+}
+
+static ggml_status dummy_backend_buffer_init_tensor_extra(ggml_backend_buffer_t buffer, ggml_tensor * tensor) {
+    if (tensor->view_src != nullptr) {
+        tensor->extra = tensor->view_src->extra;
+        return GGML_STATUS_SUCCESS;
+    }
+
+    auto * ctx = (dummy_backend_context *) buffer->context;
+    auto & pool = ctx->tensor_extras[buffer];
+    if (pool.next == pool.entries.size()) {
+        pool.entries.emplace_back(new dummy_tensor_extra{});
+    }
+
+    auto * extra = pool.entries[pool.next++].get();
+    extra->offset = (uintptr_t) tensor->data - (uintptr_t) alloc_base;
+    extra->size = ggml_nbytes(tensor);
+    tensor->extra = extra;
+    return GGML_STATUS_SUCCESS;
+}
+
+static void dummy_backend_buffer_reset_extras(ggml_backend_buffer_t buffer) {
+    auto * ctx = (dummy_backend_context *) buffer->context;
+    ctx->tensor_extras[buffer].next = 0;
 }
 
 static void dummy_backend_buffer_memset_tensor(ggml_backend_buffer_t, ggml_tensor *, uint8_t, size_t, size_t) {}
@@ -675,6 +712,53 @@ static void test_shared_buffers() {
     GGML_ASSERT(backend.context->allocated_total() == 0);
 }
 
+static void test_shared_buffers_tensor_extras(size_t max_buffer_size) {
+    dummy_backend backend = dummy_backend_init(max_buffer_size);
+    backend.context->buffer_interface.init_tensor = dummy_backend_buffer_init_tensor_extra;
+    backend.context->buffer_interface.reset = dummy_backend_buffer_reset_extras;
+
+    auto [ctx_src, graph_src, ctx_src_ptr] = make_context();
+    ggml_tensor * src_a = make_input_with_size(ctx_src, 16);
+    ggml_tensor * src_b = make_input_with_size(ctx_src, 16);
+    ggml_tensor * src_out = ggml_add(ctx_src, src_a, src_b);
+    ggml_set_output(src_out);
+    ggml_build_forward_expand(graph_src, src_out);
+
+    auto src = dummy_backend_sched_new(backend);
+    GGML_ASSERT(ggml_backend_sched_reserve(src.get(), graph_src));
+    // Put the reset callback on the last chunk to check every backing buffer.
+    for (size_t i = 0; i + 1 < backend.context->buffers.size(); ++i) {
+        backend.context->buffers[i]->iface.reset = nullptr;
+    }
+    GGML_ASSERT(ggml_backend_sched_alloc_graph(src.get(), graph_src));
+    const size_t src_size = backend.context->allocated_total();
+
+    auto [ctx_dst, graph_dst, ctx_dst_ptr] = make_context();
+    ggml_tensor * dst_out = ggml_add(ctx_dst, make_input_with_size(ctx_dst, 8), make_input_with_size(ctx_dst, 8));
+    ggml_set_output(dst_out);
+    ggml_build_forward_expand(graph_dst, dst_out);
+
+    auto dst = dummy_backend_sched_new(backend);
+    const bool shared = ggml_backend_sched_share_compute_buffers(dst.get(), src.get());
+    GGML_ASSERT(ggml_backend_sched_reserve(dst.get(), graph_dst));
+    GGML_ASSERT(ggml_backend_sched_alloc_graph(dst.get(), graph_dst));
+
+    // The target can reuse its graph without initializing its tensor extras again.
+    for (ggml_tensor * tensor : { src_a, src_b, src_out }) {
+        auto * extra = (dummy_tensor_extra *) tensor->extra;
+        GGML_ASSERT(extra->offset == (uintptr_t) tensor->data - (uintptr_t) alloc_base);
+        GGML_ASSERT(extra->size == ggml_nbytes(tensor));
+    }
+    GGML_ASSERT(!shared);
+    GGML_ASSERT(dst_out->buffer != src_out->buffer);
+
+    dst.reset();
+    GGML_ASSERT(backend.context->allocated_total() == src_size);
+    src.reset();
+    GGML_ASSERT(backend.context->allocated_total() == 0);
+    GGML_ASSERT(backend.context->tensor_extras.empty());
+}
+
 static void run(const char * name, void (*f)()) {
     printf("%s ", name);
     fflush(stdout);
@@ -697,5 +781,7 @@ int main() {
     run("test_buffer_size_zero", test_buffer_size_zero);
     run("test_reallocation", test_reallocation);
     run("test_shared_buffers", test_shared_buffers);
+    run("test_shared_buffers_tensor_extras(SIZE_MAX)", []() { test_shared_buffers_tensor_extras(SIZE_MAX); });
+    run("test_shared_buffers_tensor_extras(16)", []() { test_shared_buffers_tensor_extras(16); });
     return 0;
 }

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -1,4 +1,8 @@
 #include "common.h"
+#include "speculative.h"
+#include "../src/llama-context.h"
+#include "../ggml/src/ggml-backend-impl.h"
+#include <set>
 #include "log.h"
 #include "ggml-backend.h"
 #include "ggml.h"
@@ -65,7 +69,7 @@ static void set_tensor_data(struct ggml_tensor * tensor, void * userdata) {
 }
 
 static void usage(char ** argv) {
-    printf("Usage: %s [-a/--arch arch] [-s/--seed seed] [-v/--verbose]\n", argv[0]);
+    printf("Usage: %s [-a/--arch arch] [-s/--seed seed] [-v/--verbose] [--mtp-shared|--mtp-shared-cpu]\n", argv[0]);
 }
 
 static std::vector<llama_token> get_tokens(const uint32_t n_tokens, const uint32_t n_vocab, const size_t seed){
@@ -731,9 +735,183 @@ static int test_backends(const llm_arch target_arch, const size_t seed, const gg
     return all_ok ? 0 : 1;
 }
 
+struct mtp_backend_probe {
+    ggml_backend_i iface;
+    bool pending = false;
+    bool fail = false;
+    std::set<ggml_backend_buffer_t> buffers;
+};
+
+static std::map<ggml_backend_t, mtp_backend_probe> mtp_probes;
+
+static ggml_status mtp_graph_compute(ggml_backend_t backend, ggml_cgraph * graph) {
+    auto & probe = mtp_probes.at(backend);
+    for (int i = 0; i < ggml_graph_n_nodes(graph); ++i) {
+        auto * tensor = ggml_graph_node(graph, i);
+        if (tensor->buffer && ggml_backend_buffer_get_usage(tensor->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE) {
+            probe.buffers.insert(tensor->buffer);
+        }
+    }
+    auto status = probe.iface.graph_compute(backend, graph);
+    probe.pending = true;
+    if (probe.fail) {
+        probe.fail = false;
+        return GGML_STATUS_FAILED; // Fail after submitting work to exercise error-path synchronization.
+    }
+    return status;
+}
+
+static void mtp_synchronize(ggml_backend_t backend) {
+    auto & probe = mtp_probes.at(backend);
+    if (probe.iface.synchronize) {
+        probe.iface.synchronize(backend);
+    }
+    probe.pending = false;
+}
+
+static int test_mtp_shared(bool cpu) {
+    // A CPU helper with ACCEL classification exercises the same device gate as BLAS/Accelerate.
+    static ggml_backend_device helper = *ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+    helper.iface.get_type = [](ggml_backend_dev_t) { return GGML_BACKEND_DEVICE_TYPE_ACCEL; };
+    helper.iface.init_backend = [](ggml_backend_dev_t dev, const char * params) {
+        auto cpu = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+        auto backend = cpu->iface.init_backend(cpu, params);
+        backend->device = dev;
+        return backend;
+    };
+    helper.iface.supports_op = [](ggml_backend_dev_t, const ggml_tensor *) { return false; };
+    ggml_backend_device_register(&helper);
+    auto metadata = get_gguf_ctx(LLM_ARCH_QWEN35, false);
+    gguf_set_val_u32(metadata.get(), "qwen35.block_count", 3);
+    gguf_set_val_u32(metadata.get(), "qwen35.nextn_predict_layers", 1);
+    auto mp = llama_model_default_params();
+    static ggml_backend_device compute = *ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+    compute.iface.get_type = [](ggml_backend_dev_t) { return GGML_BACKEND_DEVICE_TYPE_GPU; };
+    compute.iface.init_backend = helper.iface.init_backend;
+    ggml_backend_dev_t devices[] = {&compute, nullptr};
+    if (cpu) {
+        mp.devices = devices; // Exercise sharing and source destruction under CPU sanitizers too.
+    }
+    mp.n_gpu_layers = 999;
+    mp.load_mtp = true;
+    size_t seed = 1234;
+    llama_model_ptr model(llama_model_init_from_user(metadata.get(), set_tensor_data, &seed, mp));
+    GGML_ASSERT(model);
+    std::vector<float> reference;
+    for (bool share : {false, true}) {
+        auto cp = llama_context_default_params();
+        GGML_ASSERT(!cp.ctx_other_share_compute);
+        cp.n_ctx = 512;
+        cp.n_batch = cp.n_ubatch = 32;
+        cp.n_outputs_max = cp.n_outputs_max_per_seq = 32;
+        cp.n_seq_max = 1;
+        cp.n_threads = cp.n_threads_batch = 2;
+        cp.no_perf = false;
+        cp.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED;
+        llama_context_ptr target(llama_init_from_model(model.get(), cp));
+        GGML_ASSERT(target);
+        cp.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+        cp.ctx_other = target.get();
+        cp.ctx_other_share_compute = share;
+        llama_context_ptr draft(llama_init_from_model(model.get(), cp));
+        GGML_ASSERT(draft);
+        common_params_speculative params;
+        params.types = {COMMON_SPECULATIVE_TYPE_DRAFT_MTP};
+        params.draft.ctx_tgt = target.get();
+        params.draft.ctx_dft = draft.get();
+        params.draft.backend_sampling = false;
+        common_speculative_ptr spec(common_speculative_init(params, 1));
+        GGML_ASSERT(spec);
+        auto install = [](llama_context * ctx) {
+            auto sched = ctx->get_sched();
+            for (int i = 0; i < ggml_backend_sched_get_n_backends(sched); ++i) {
+                auto backend = ggml_backend_sched_get_backend(sched, i);
+                mtp_probes[backend].iface = backend->iface;
+                backend->iface.graph_compute = mtp_graph_compute;
+                backend->iface.synchronize = mtp_synchronize;
+            }
+        };
+        install(target.get());
+        install(draft.get());
+        auto finished = [](llama_context * ctx) {
+            auto sched = ctx->get_sched();
+            for (int i = 0; i < ggml_backend_sched_get_n_backends(sched); ++i) {
+                GGML_ASSERT(!mtp_probes.at(ggml_backend_sched_get_backend(sched, i)).pending);
+            }
+        };
+        auto buffers = [](llama_context * ctx) {
+            std::set<ggml_backend_buffer_t> result;
+            auto sched = ctx->get_sched();
+            for (int i = 0; i < ggml_backend_sched_get_n_backends(sched); ++i) {
+                const auto & probe = mtp_probes.at(ggml_backend_sched_get_backend(sched, i));
+                result.insert(probe.buffers.begin(), probe.buffers.end());
+            }
+            return result;
+        };
+        llama_batch batch = llama_batch_init(32, 0, 1);
+        std::vector<float> logits;
+        llama_sampler_ptr sampler(llama_sampler_chain_init(llama_sampler_chain_default_params()));
+        llama_sampler_chain_add(sampler.get(), llama_sampler_init_greedy());
+        common_speculative_begin(spec.get(), 0, {});
+        for (int pass = 0; pass < 8; ++pass) {
+            if (pass == 3 || pass == 5) {
+                GGML_ASSERT(llama_set_sampler(target.get(), 0, pass == 3 ? sampler.get() : nullptr));
+                for (auto & entry : mtp_probes) {
+                    entry.second.buffers.clear();
+                }
+            }
+            common_batch_clear(batch);
+            for (int i = 0; i < 32; ++i) {
+                common_batch_add(batch, (i + pass) % 128, pass * 32 + i, {0}, true);
+            }
+            GGML_ASSERT(llama_decode(target.get(), batch) == 0);
+            const auto * output = llama_get_logits(target.get());
+            logits.insert(logits.end(), output, output + 128 * 32);
+            if (pass == 6) {
+                auto backend = ggml_backend_sched_get_backend(draft->get_sched(), 0);
+                mtp_probes.at(backend).fail = true;
+            }
+            GGML_ASSERT(common_speculative_process(spec.get(), batch) == (pass != 6));
+            finished(draft.get());
+            if (pass == 2 || pass == 4 || pass == 5) {
+                auto tgt = buffers(target.get());
+                auto dft = buffers(draft.get());
+                bool aliases = false;
+                for (auto buffer : tgt) {
+                    aliases |= dft.count(buffer) != 0;
+                }
+                auto backend = ggml_backend_sched_get_backend(target->get_sched(), 0);
+                const auto type = ggml_backend_dev_type(ggml_backend_get_device(backend));
+                if (type == GGML_BACKEND_DEVICE_TYPE_GPU || type == GGML_BACKEND_DEVICE_TYPE_IGPU) {
+                    GGML_ASSERT(aliases == share);
+                }
+            }
+        }
+        GGML_ASSERT(llama_perf_context(target.get()).n_reused > 0);
+        GGML_ASSERT(llama_perf_context(draft.get()).n_reused > 0);
+        if (share) {
+            GGML_ASSERT(nmse(reference, logits) < 1e-8);
+        } else {
+            reference = logits;
+        }
+        llama_batch_free(batch);
+        spec.reset();
+        target.reset();
+        llama_set_embeddings(draft.get(), true);
+        draft->sched_reserve(); // The source is gone; the draft must reserve independently.
+        draft.reset();
+        mtp_probes.clear();
+    }
+    printf("MTP shared compute: passed\n");
+    return 0;
+}
+
 int main(int argc, char ** argv) {
     // FIXME these tests are disabled in the CI for macOS-latest-cmake-arm64 because they are segfaulting
     common_init();
+    if (argc == 2 && (strcmp(argv[1], "--mtp-shared") == 0 || strcmp(argv[1], "--mtp-shared-cpu") == 0)) {
+        return test_mtp_shared(strcmp(argv[1], "--mtp-shared-cpu") == 0);
+    }
     std::random_device rd;
 
     llm_arch arch = LLM_ARCH_UNKNOWN;


### PR DESCRIPTION
## Overview

Native MTP currently reserves a second compute workspace even when the target and draft run sequentially. Port https://github.com/ggml-org/llama.cpp/pull/27489 onto `temp-10549`, preserving this fork's scheduler configuration and the original author attribution. Schedulers retain independent allocation plans while sharing reference-counted backing buffers; larger reservations detach.

Also synchronize the MTP catch-up decode before `process()` returns. `llama_decode(ctx_dft, ...)` is asynchronous, so without this barrier the next target batch can overwrite shared workspace while draft kernels are still running. The barrier also runs on the catch-up error path.

Compute sharing now requires the explicit `ctx_other_share_compute` opt-in (default false); the serialized common MTP path opts in. Sharing remains limited to the same model object, one sequence, one compute device (CPU/ACCEL helpers excluded), and compatible scheduler layouts. A separately loaded MTP head retains independent buffers.

## Additional information

Validated on NVIDIA GB10 with CUDA 13.0.88 against base `57ef02cb4`, using `Qwen3.8-27B-UD-Q8_K_L.gguf`. The separate-head comparison uses the same model's extracted MTP block and required global tensors; all 18 tensor payloads were verified byte-for-byte by SHA-256.

Peak live GGML CUDA backing-buffer allocations (MiB):

| Context / KV | MTP head | Base | Patch | Saved |
|---|---|---:|---:|---:|
| 8192 / f16 | Embedded | 26700.60 | 26570.59 | 130.02 |
| 8192 / f16 | Separate | 28323.65 | 28323.65 | 0.00 |
| 196608 / q4_0 | Embedded | 31624.60 | 30596.59 | 1028.02 |
| 196608 / q4_0 | Separate | 33247.65 | 33247.65 | 0.00 |

Measured with an external allocation/free tracer that counts each physical GGML CUDA buffer once. Includes model, KV, and compute buffers; excludes pinned host memory, backend-internal pools, and driver allocations. These figures are not total GPU memory usage.

Validation:

- CUDA Release build and `test-alloc` pass, including the ported shared-buffer lifecycle test.
- One slot, all layers offloaded, batch/microbatch 512, Flash Attention on, maximum draft length 2, eight CPU threads.
- Each base/patched configuration generated 128 tokens from a 16-token prompt and 128 from a 1536-token prompt spanning three prefill batches, with temperature 0 and seed 1234. All 16 completions succeeded; output hashes and accepted/generated draft counts matched in every base/patch pair.
- All runs exited cleanly and released every traced CUDA buffer.
- For the 1536-token prompt with the embedded head, generation was 13.39 -> 13.03 tok/s at 8K/f16 and 13.95 -> 13.61 tok/s at 196608/q4_0. These are single-run observations, not a statistically controlled performance result.

The large context setting tests reservation size; the prompt itself contains 1536 tokens.

### Vulkan and Metal validation

Sharing is backend-independent: there is no backend-name allowlist. Eligibility requires the explicit context opt-in, matching model identity, one sequence, one compute device (CPU/ACCEL helpers excluded), matching scheduler devices and buffer types, and a single scheduler copy. Target/MTP execution must be serialized.

Tested on `qvac-dev-strix-1` (Radeon 8060S / RADV Mesa 25.2.8) with cached `Qwen3.6-27B-MTP-Q4_K_M.gguf`, and `qvac-dev-mac-arm64` (M3 Ultra) with cached `Qwen_Qwen3.5-35B-A3B-Q4_0.gguf`. These backend tests use different models from the Qwen3.8-27B CUDA tests above.

Peak GPU compute backing allocations, MiB (excludes model/KV/host buffers and backend-private or driver allocations):

| Backend | Context / KV | Independent | Shared | Saved |
|---|---|---:|---:|---:|
| metal | 8192/f16 | 167.03 | 84.57 | 82.46 |
| metal | 196608/q4_0 | 1271.14 | 636.63 | 634.52 |
| vulkan | 8192/f16 | 272.15 | 142.13 | 130.02 |
| vulkan | 196608/q4_0 | 590.15 | 326.13 | 264.02 |

Both settings used one sequence, batch/microbatch 512, Flash Attention, and draft maximum 2. Baseline was the CUDA-only version of this PR, including its synchronization fix. All 16 additional completions (short and 1536-token multi-batch prompts, 128 generated tokens each) succeeded, with identical output hashes and accepted/generated draft counts in every within-backend comparison. All tracked compute buffers were freed. Allocator tests passed on both backends, and the extended gate also builds and passes `test-alloc` with CUDA.

Memory was measured with identical temporary allocation instrumentation in both remote builds; that instrumentation is not included in this PR. The large context setting tests reservation capacity, not a full-length prompt.

### Review fixes and current GB10 validation (3908bbeba)

Sharing is now explicit at the context API. A weak scheduler-state reference removes the target-context lifetime dependency. Scheduler generations reattach the draft after target sampler changes; compatible target rebuilds retain their workspace. CPU and ACCEL helpers do not count as additional compute devices.

Added synthetic target/MTP execution regressions covering asynchronous completion (including an error injected after backend submission), multiple prefill batches, graph reuse, sampler attach/remove, ACCEL helpers, and freeing the target before draft reservation. CUDA CTest passes all three selected tests. The CPU-backed sharing variant and allocator tests pass AddressSanitizer with leak detection. Removing the catch-up barrier makes the regression fail. The CUDA regression is registered in the `main` CTest suite used by GPU CI.

Retested on this NVIDIA GB10 with `Qwen3.8-27B-UD-Q8_K_L.gguf`. Each of eight configurations generated 128 tokens from a short prompt, 128 from a 1536-token prompt spanning three prefill batches, then repeated the long request. One sequence, all layers offloaded, batch/microbatch 512, Flash Attention on, MTP maximum 2, eight CPU threads, temperature 0 and seed 1234. All 24 completions succeeded, paired output hashes and draft counts matched, and all traced buffers were released.

Physical GGML CUDA backing allocations, MiB (same scope as the original CUDA table):

| Context / KV | Backend sampling | Independent after requests | Shared after requests | Saved | Independent peak | Shared peak |
|---|---|---:|---:|---:|---:|---:|
| 8192 / f16 | off | 26700.60 | 26570.59 | 130.02 | 26700.60 | 26570.59 |
| 196608 / q4_0 | off | 31624.60 | 30596.59 | 1028.02 | 31624.60 | 30596.59 |
| 8192 / f16 | on | 26700.60 | 26570.59 | 130.02 | 26700.60 | 26700.60 |
| 196608 / q4_0 | on | 31624.60 | 30596.59 | 1028.02 | 31624.60 | 31624.60 |

After-request memory stayed stable across all three requests, including backend sampling. With backend sampling, the first sampler grows the workspace slightly; safe detachment temporarily keeps both workspaces alive before the draft reattaches. Therefore the sampling-on savings apply after requests, while sampling-off savings also reduce whole-run peak allocations. The independent comparison uses the same binary and external tracing, with an API interceptor clearing the sharing opt-in. No tracing instrumentation is included in the PR. These figures are not total GPU memory usage.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/tetherto/qvac-fabric-llm.cpp/blob/temp-10549/CONTRIBUTING.md).
- AI usage disclosure: YES - Codex assisted with porting the upstream change, adding synchronization, extracting the comparison head, running measurements, and preparing this PR.
