### PR TITLE
metal: use packed buffers for model weights

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal.cpp
+++ b/ggml/src/ggml-metal/ggml-metal.cpp
@@ -702,7 +702,7 @@ static void ggml_backend_metal_device_get_props(ggml_backend_dev_t dev, ggml_bac
     props->caps = {
         /* .async                = */ true,
         /* .host_buffer          = */ false,
-        /* .buffer_from_host_ptr = */ true,
+        /* .buffer_from_host_ptr = */ false,
         /* .events               = */ true,
         /* .mmap_support         = */ true,
         /* .copy_stream          = */ false,


### PR DESCRIPTION
Disable Metal’s `buffer_from_host_ptr` capability so model weights use packed GPU buffers while CPU weights retain mmap. This prevents oversized mapped spans from causing decode OOMs.

Validated on M3 Ultra: the failing fixture now generates, the original model still works, and larger fit margins reduce Metal allocations. Tradeoff: Metal loses zero-copy model loading.

AI disclosure: Codex prepared and tested this change.
