### PR TITLE
ggml webgpu: log why the backend registers no device

### DIFF
--- a/ggml/src/ggml-webgpu/ggml-webgpu.cpp
+++ b/ggml/src/ggml-webgpu/ggml-webgpu.cpp
@@ -4750,11 +4750,17 @@ ggml_backend_reg_t ggml_backend_webgpu_reg() {
     }
 
     // WebGPU backend requires f16 support and, on native, implicit device synchronization.
-    if (adapter != nullptr && adapter.HasFeature(wgpu::FeatureName::ShaderF16)
+    if (adapter == nullptr) {
+        GGML_LOG_WARN("ggml_webgpu: no adapter available, backend disabled\n");
+    } else if (!adapter.HasFeature(wgpu::FeatureName::ShaderF16)) {
+        GGML_LOG_WARN(
+            "ggml_webgpu: adapter lacks shader-f16, backend disabled (Dawn hides f16 on NVIDIA/Vulkan by "
+            "default; in Chromium-based browsers launch with --enable-dawn-features=vulkan_enable_f16_on_nvidia)\n");
 #ifndef __EMSCRIPTEN__
-        && adapter.HasFeature(wgpu::FeatureName::ImplicitDeviceSynchronization)
+    } else if (!adapter.HasFeature(wgpu::FeatureName::ImplicitDeviceSynchronization)) {
+        GGML_LOG_WARN("ggml_webgpu: adapter lacks implicit device synchronization, backend disabled\n");
 #endif
-    ) {
+    } else {
         ctx->device_count = 1;
     }
 


### PR DESCRIPTION
## Problem

`ggml_backend_webgpu_reg()` probes the adapter and silently registers zero devices when a prerequisite is missing. Consumers then fall back to CPU with no hint of why. This cost us a long hunt on the browser path: in Chromium on Linux/NVIDIA, Dawn hides `shader-f16` by default (the toggle `vulkan_enable_f16_on_nvidia` is off inside the browser), so the WASM+WebGPU build ran single-threaded CPU inference while reporting nothing.

Measured on an RTX 5090, Qwen3.5-2B Q4_K_M in Chrome 152 (pp128/tg16, fa on):

| | pp128 t/s | tg16 t/s |
|---|---:|---:|
| adapter without shader-f16 (silent CPU fallback) | 3.4 | 2.8 |
| Chrome launched with `--enable-dawn-features=vulkan_enable_f16_on_nvidia` | 1317.6 | 109.9 |
| native `llama-bench`, same GPU/workload | 1169.0 | 192.0 |

Same wasm binary — a 39-390x difference purely from the hidden f16 feature. Web apps can detect and surface this (probe `adapter.features` for `shader-f16`), but the backend should say why it disabled itself.

## Change

In the registration probe, warn once per missing prerequisite instead of staying silent:

- no adapter available;
- adapter lacks `shader-f16` (with the Chromium toggle hint for the NVIDIA/Vulkan case);
- adapter lacks implicit device synchronization (native only).

No behavioral change otherwise. clang-format clean; compiles native (Dawn prebuilt) and is exercised by the WASM path described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
