### PR TITLE
ggml : bound the used-expert scan in the MoE copy path

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -2068,29 +2068,34 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                                 copy_size);
                         };
 
+                        // the ids tensor may have zero rows, in which case no expert is marked
+                        // used; bound the scan so that it cannot read past the end of the bitset
                         int id = 0;
-                        while (!ggml_bitset_get(used_ids.data(), id)) {
+                        while (id < n_expert && !ggml_bitset_get(used_ids.data(), id)) {
                             id++;
                         }
-                        int32_t first_id = id;
-                        int32_t last_id = first_id;
 
-                        for (++id; id < n_expert; ++id) {
-                            if (!ggml_bitset_get(used_ids.data(), id)) {
-                                continue;
-                            }
+                        if (id < n_expert) {
+                            int32_t first_id = id;
+                            int32_t last_id = first_id;
 
-                            if (id == last_id + 1) {
+                            for (++id; id < n_expert; ++id) {
+                                if (!ggml_bitset_get(used_ids.data(), id)) {
+                                    continue;
+                                }
+
+                                if (id == last_id + 1) {
+                                    last_id = id;
+                                    continue;
+                                }
+
+                                copy_experts(first_id, last_id);
+
+                                first_id = id;
                                 last_id = id;
-                                continue;
                             }
-
                             copy_experts(first_id, last_id);
-
-                            first_id = id;
-                            last_id = id;
                         }
-                        copy_experts(first_id, last_id);
                     }
                 } else {
                     // try async copy, but if not possible, we can still use a sync copy without synchronizing the dst backend, since we handle the synchronization here with multiple copies and events


### PR DESCRIPTION
### Problem

`ggml_backend_sched_compute_splits()` scans the `used_ids` bitset for the first set expert with an unbounded loop:

```cpp
int id = 0;
while (!ggml_bitset_get(used_ids.data(), id)) {
    id++;
}
```

The bitset is populated by a loop bounded by `ids_tensor->ne[1]`. When the ids tensor has **zero rows** the body never runs, the bitset stays all-zero, and the scan reads past its 16-word allocation into adjacent heap memory until it meets a non-zero bit. The resulting index is used as a byte offset into the destination tensor, giving an out-of-bounds write:

```
ggml/src/ggml-backend.cpp:259: GGML_ASSERT(offset <= nbytes && size <= nbytes - offset
                               && "tensor access out of bounds") failed
```

Instrumented output from the failing run:

```
ids_tensor=ffn_moe_topk-47  ids_ne=[10,0]  n_expert=512  first_id=576  cache_entry=0
name=CUDA0#blk.47.ffn_gate_exps.weight#0  nbytes=471859200  offset=530841600  size=921600
```

`530841600 / 921600 = 576`, against 512 valid experts — 65 experts past the end.

### Trigger

`moe_cache_size > 0` combined with `-c` at 65536 or above. Independent of `--fit`, of `-b`/`-ub` geometry, and of prompt length (a 60-token prompt reproduces identically). ctx=32768 passes; the threshold was not bisected further.

Both preconditions are defaults (`fit_params = true`, `moe_cache_auto = true`), but `--fit` auto-selects 40960/27648, so the crash requires an explicit large `-c`.

### Fix

Bound the scan by `n_expert` and skip the copy when no expert is referenced by the ubatch. The grouping loop below it is unchanged — only re-indented into the new guard.

Note the unbounded loop is inherited from upstream (`ggml/src/ggml-backend.cpp` in ggml-org/llama.cpp) and is latent there; it should be reported upstream too.

This makes the out-of-bounds access safe but does not explain **why** a zero-row `ffn_moe_topk` reaches `llama_decode`. That is still open and worth tracking separately.

### Testing

Hardware: 1× H100 80GB HBM3 (driver 580.105.08), CUDA 12.8, GCC 11.4, Ubuntu 22.04.5.
Model: `unsloth/Qwen3.8-Flash-Next-GGUF` UD-Q4_K_XL, 512 experts/layer.

Previously-crashing config now completes, 4 consecutive requests, zero OOB asserts:

```
llama-server -b 4096 -ub 2048 -c 262144 --fit on --moe-cache-mib auto
```

| prompt | prefill | decode |
| --- | --- | --- |
| 50 tok | 68.4 t/s | 21.3 t/s |
| 10k | 2007.9 t/s | 39.0 t/s |
| 100k | 1515.4 t/s | 28.3 t/s |
| 100k (repeat) | 1515.0 t/s | 27.3 t/s |

Output sanity (greedy): `'The capital of France is'` → `' Paris. The capital of Germany is Berlin. ...'`; `'2 + 2 = '` → `'4'`; `'def fibonacci(n):'` → correct recursive body.

No regression at ctx=16384: 2512 / 2821 t/s prefill vs 2423 t/s before the change.
