### PR TITLE
QVAC-24933 mtmd: let the caller skip the projector's audio encoder

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2624,6 +2624,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_MTMD, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_DOWNLOAD}).set_env("LLAMA_ARG_MMPROJ_AUTO"));
     add_opt(common_arg(
+        {"--mmproj-audio"},
+        {"--no-mmproj-audio"},
+        string_format("whether to load the audio encoder of the multimodal projector, if it has one (default: %s)", params.mmproj_no_audio ? "disabled" : "enabled"),
+        [](common_params & params, bool value) {
+            params.mmproj_no_audio = !value;
+        }
+    ).set_examples(mmproj_examples).set_env("LLAMA_ARG_MMPROJ_AUDIO"));
+    add_opt(common_arg(
         {"--mmproj-offload"},
         {"--no-mmproj-offload"},
         string_format("whether to enable GPU offloading for multimodal projector (default: %s)", params.mmproj_use_gpu ? "enabled" : "disabled"),

--- a/common/common.h
+++ b/common/common.h
@@ -600,6 +600,7 @@ struct common_params {
     ggml_backend_dev_t mmproj_device = nullptr; // GPU device to use for multimodal model
     std::string mmproj_backend = "";            // GPU backend for multimodal model (e.g. "CUDA", "Metal", "Vulkan")
     bool no_mmproj = false;                     // explicitly disable multimodal model
+    bool mmproj_no_audio = false;               // load the projector but skip its audio encoder
     std::vector<std::string> image;             // path to image file(s) ; TODO: change the name to "media"
     int image_min_tokens = -1;
     int image_max_tokens = -1;

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -4404,6 +4404,12 @@ struct clip_init_result clip_init(const char * fname, struct clip_context_params
             skip_audio = ctx_vision->model.proj_type == PROJECTOR_TYPE_GEMMA3NV;
         }
 
+        // The caller can drop the audio tower when it never sends audio
+        if (loader.has_audio && !skip_audio && ctx_params.skip_audio) {
+            LOG_INF("%s: skipping the audio encoder at the caller's request\n", __func__);
+            skip_audio = true;
+        }
+
         if (loader.has_audio && !skip_audio) {
             ctx_audio = new clip_ctx(ctx_params);
             loader.load_hparams(ctx_audio->model, CLIP_MODALITY_AUDIO);

--- a/tools/mtmd/clip.h
+++ b/tools/mtmd/clip.h
@@ -84,6 +84,11 @@ struct clip_context_params {
     // on a Flash-style model. Do not rely on zero-init: use mtmd_context_params_default()
     // or set this field explicitly.
     int image_no_upscale;
+    // skip the audio encoder even when the GGUF declares one. The projector still
+    // loads its vision encoder, so clip_init() returns a vision-only context and
+    // mtmd_support_audio() reports false. Lets a caller that never feeds audio
+    // avoid paying for those weights and their warmup compute buffers.
+    bool skip_audio;
 };
 
 struct clip_init_result {

--- a/tools/mtmd/mtmd-cli.cpp
+++ b/tools/mtmd/mtmd-cli.cpp
@@ -164,6 +164,7 @@ struct mtmd_cli_context {
         mparams.image_tile_mode  = (int)params.image_tile_mode;
         mparams.image_max_tiles  = params.image_max_tiles;
         mparams.image_no_upscale = params.image_no_upscale;
+        mparams.skip_audio       = params.mmproj_no_audio;
         if (std::getenv("MTMD_DEBUG_GRAPH") != nullptr) {
             mparams.cb_eval_user_data = &cb_data;
             mparams.cb_eval = common_debug_cb_eval;

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -483,6 +483,7 @@ mtmd_context_params mtmd_context_params_default() {
         /* image_tile_mode   */ 1, // 0=batched, 1=sequential (default, matches common_params), 2=disabled
         /* image_max_tiles   */ -1,
         /* image_no_upscale  */ -1, // -1=model default, 0=off, 1=on
+        /* skip_audio        */ false,
     };
     return params;
 }
@@ -601,6 +602,7 @@ struct mtmd_context {
             /* image_tile_mode   */ ctx_params.image_tile_mode,
             /* image_max_tiles   */ ctx_params.image_max_tiles,
             /* image_no_upscale  */ ctx_params.image_no_upscale,
+            /* skip_audio        */ ctx_params.skip_audio,
         };
 
         auto res = clip_init(mmproj_fname, ctx_clip_params);

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -145,6 +145,11 @@ struct mtmd_context_params {
     // than always stretched to the cap. Changes the number of output tokens, so a
     // checkpoint whose GGUF omits the key needs this set to preprocess correctly.
     int image_no_upscale;
+
+    // skip loading the audio encoder even when the mmproj declares one. The vision
+    // encoder still loads, so mtmd_support_audio() returns false and audio input is
+    // rejected. Use it when the caller never sends audio and wants the memory back.
+    bool skip_audio;
 };
 
 MTMD_API const char * mtmd_default_marker(void);


### PR DESCRIPTION
Add skip_audio to clip_context_params and mtmd_context_params, defaulting to false so existing behaviour is unchanged. Also expose it as `--mmproj-audio/--no-mmproj-audio (LLAMA_ARG_MMPROJ_AUDIO)`
and wire `common_params::mmproj_no_audio` through mtmd-cli, which copies context params field by field.